### PR TITLE
clientPeoplePickerSearchUser fixed for verbose OData mode result payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - @pnp/nodejs: Fixed incorrect import for Request shims due to version change [[PR](https://github.com/pnp/pnpjs/pull/67)]
 - @pnp/sp: Fixed docs for web example code [[PR](https://github.com/pnp/pnpjs/pull/72)]
 - @pnp/config-store: Fixed docs and a bug in loading configuration [[PR](https://github.com/pnp/pnpjs/pull/73)]
+- @pnp/sp: Fixed clientPeoplePickerSearchUser and clientPeoplePickerResolveUser methods running error with verbose OData mode [[PR](https://github.com/pnp/pnpjs/pull/79)]
 
 ## 1.0.4 - 2018-04-06
 

--- a/packages/sp/src/userprofiles.ts
+++ b/packages/sp/src/userprofiles.ts
@@ -357,9 +357,16 @@ class ClientPeoplePickerQuery extends SharePointQueryable {
     public clientPeoplePickerResolveUser(queryParams: ClientPeoplePickerQueryParameters): Promise<PeoplePickerEntity> {
         const q = this.clone(ClientPeoplePickerQuery, null);
         q.concat(".clientpeoplepickerresolveuser");
-        return q.postCore<string>({
+        return q.postCore<string | { ClientPeoplePickerResolveUser: string }>({
             body: this.createClientPeoplePickerQueryParametersRequestBody(queryParams),
-        }).then((json) => JSON.parse(json));
+        })
+            .then(res => {
+                if (typeof res === "object") {
+                    return res.ClientPeoplePickerResolveUser;
+                }
+                return res;
+            })
+            .then(JSON.parse);
     }
 
     /**
@@ -370,9 +377,16 @@ class ClientPeoplePickerQuery extends SharePointQueryable {
     public clientPeoplePickerSearchUser(queryParams: ClientPeoplePickerQueryParameters): Promise<PeoplePickerEntity[]> {
         const q = this.clone(ClientPeoplePickerQuery, null);
         q.concat(".clientpeoplepickersearchuser");
-        return q.postCore<string>({
+        return q.postCore<string | { ClientPeoplePickerSearchUser: string }>({
             body: this.createClientPeoplePickerQueryParametersRequestBody(queryParams),
-        }).then((json) => JSON.parse(json));
+        })
+            .then(res => {
+                if (typeof res === "object") {
+                    return res.ClientPeoplePickerSearchUser;
+                }
+                return res;
+            })
+            .then(JSON.parse);
     }
 
     /**


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #78

#### What's in this Pull Request?

The PR fixes `clientPeoplePickerSearchUser` and `clientPeoplePickerResolveUser` methods running error with verbose OData mode.

With `accept: 'application/json;odata=verbose'` header the methods failed because result payloads have a different shape in comparison to `nomatadata` and `minimalmetadata`.

