### PR TITLE
listItemAllFields object type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - tooling: Fixed bug in gulp task test when using the --p flag .inactive.js test files were run [[PR](https://github.com/pnp/pnpjs/pull/85)]
 - docs: Fixed import references ([@tarjeieo](https://github.com/tarjeieo)) [[PR](https://github.com/pnp/pnpjs/pull/87)]
 - @pnp/odata: Updated all parsers to use same error handling code path [[PR](https://github.com/pnp/pnpjs/pull/90)]
+- @pnp/sp: listItemAllFields object type fix [[PR](https://github.com/pnp/pnpjs/pull/98)]
 
 ### Changed
 

--- a/packages/sp/src/files.ts
+++ b/packages/sp/src/files.ts
@@ -114,8 +114,8 @@ export class File extends SharePointQueryableShareableFile {
      * Gets a value that specifies the list item field values for the list item corresponding to the file.
      *
      */
-    public get listItemAllFields(): SharePointQueryableCollection {
-        return new SharePointQueryableCollection(this, "listItemAllFields");
+    public get listItemAllFields(): SharePointQueryableInstance {
+        return new SharePointQueryableInstance(this, "listItemAllFields");
     }
 
     /**

--- a/packages/sp/src/folders.ts
+++ b/packages/sp/src/folders.ts
@@ -81,8 +81,8 @@ export class Folder extends SharePointQueryableShareableFolder {
      * Gets this folder's list item field values
      *
      */
-    public get listItemAllFields(): SharePointQueryableCollection {
-        return new SharePointQueryableCollection(this, "listItemAllFields");
+    public get listItemAllFields(): SharePointQueryableInstance {
+        return new SharePointQueryableInstance(this, "listItemAllFields");
     }
 
     /**


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #97

#### What's in this Pull Request?

Amends result object for listItemAllFields. Should be `SharePointQueryableInstance` but not `SharePointQueryableCollection`.

