### PR TITLE
Adding addClientSidePageByPath method to Web

### DIFF
--- a/packages/sp/docs/client-side-pages.md
+++ b/packages/sp/docs/client-side-pages.md
@@ -13,6 +13,14 @@ import { sp } from "@pnp/sp";
 const page = await sp.web.addClientSidePage(`MyFirstPage.aspx`);
 ```
 
+Added in 1.0.5 you can also add a client side page using the list path. This gets around potential language issues with list title. You must specify the list path when calling this method in addition to the new page's filename.
+
+```TypeScript
+import { sp } from "@pnp/sp";
+
+const page = await sp.web.addClientSidePageByPath(`MyFirstPage.aspx`, "/sites/dev/SitePages");
+```
+
 ## Load Client-side page
 
 You can also load an existing page based on the file representing that page. Note that the static fromFile returns a promise which 

--- a/packages/sp/src/webs.ts
+++ b/packages/sp/src/webs.ts
@@ -580,6 +580,17 @@ export class Web extends SharePointQueryableShareableWeb {
     public addClientSidePage(pageName: string, title = pageName.replace(/\.[^/.]+$/, ""), libraryTitle = "Site Pages"): Promise<ClientSidePage> {
         return ClientSidePage.create(this.lists.getByTitle(libraryTitle), pageName, title);
     }
+
+    /**
+     * Creates a new client side page using the library path
+     *
+     * @param pageName Name of the new page
+     * @param listRelativePath The server relative path to the list's root folder (including /sites/ if applicable)
+     * @param title Display title of the new page
+     */
+    public addClientSidePageByPath(pageName: string, listRelativePath: string, title = pageName.replace(/\.[^/.]+$/, "")): Promise<ClientSidePage> {
+        return ClientSidePage.create(this.getList(listRelativePath), pageName, title);
+    }
 }
 
 /**


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [X] Documentation update?

#### Related Issues

none

#### What's in this Pull Request?

Adds the addClientSidePageByPath method to the Web class allowing you to create a new client side page using the relative path to a list.