### PR TITLE
Tagging availability, default value

### DIFF
--- a/packages/sp-taxonomy/src/termsets.ts
+++ b/packages/sp-taxonomy/src/termsets.ts
@@ -142,10 +142,10 @@ export class TermSet extends ClientSvcQueryable implements ITermSet {
      * 
      * @param name Name for the term
      * @param lcid Language code
-     * @param isAvailableForTagging set tagging availability (default: false)
+     * @param isAvailableForTagging set tagging availability (default: true)
      * @param id GUID id for the term (optional)
      */
-    public addTerm(name: string, lcid: number, isAvailableForTagging = false, id = getGUID()): Promise<ITerm & ITermData> {
+    public addTerm(name: string, lcid: number, isAvailableForTagging = true, id = getGUID()): Promise<ITerm & ITermData> {
 
         const params = MethodParams.build()
             .string(name)


### PR DESCRIPTION
#### Category
- [ ]  Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?
- [x]  Suggestion?


#### Related Issues

None

#### What's in this Pull Request?

I suggest a change for the default parameter isAvailableForTagging to true for the below method:

```javascript
public addTerm(name: string, lcid: number, isAvailableForTagging = true, id = getGUID()): Promise<ITerm & ITermData>
```
My thinking behind it and the reason is to align with the behavior in the UI or CSOM where the same parameter defaults to true.

Really excited about the taxonomy coming in to this initiative, well done!! Thanks!