### PR TITLE
Fix build issues in macOS by using / separator instead of \\ in gulp tasks

### DIFF
--- a/pnp-build.js
+++ b/pnp-build.js
@@ -15,8 +15,8 @@ const defaultBuildPipeline = [
  */
 const config = {
 
-    // root location, relative 
-    packageRoot: path.resolve(".\\packages\\"),
+    // root location, relative
+    packageRoot: path.resolve("./packages/"),
 
     // the list of packages to be built, in order
     // can be a string name or a plain object with additional settings
@@ -27,7 +27,7 @@ const config = {
      *      "assets": string[], // optional, default is config.assets
      *      "buildChain": (ctx) => Promise<void>[], // optional, default is config.buildChain
      * }
-     * 
+     *
      */
     packages: [
         "logging",
@@ -54,10 +54,10 @@ const config = {
 
     // relative to the package folder
     assets: [
-        "..\\..\\LICENSE",
-        "..\\readme.md",
+        "../../LICENSE",
+        "../readme.md",
         "rollup.*.config.js",
-        "**\\*.md"
+        "**/*.md"
     ],
 
     // the set of tasks run on each project during a build

--- a/pnp-debug.js
+++ b/pnp-debug.js
@@ -7,8 +7,8 @@ const tasks = require("./build/tools/buildsystem").Tasks.Build,
 */
 const config = {
 
-    // root location, relative 
-    packageRoot: path.resolve(".\\debug"),
+    // root location, relative
+    packageRoot: path.resolve("./debug"),
 
     // the list of packages to be built, in order
     // can be a string name or a plain object with additional settings

--- a/pnp-package.js
+++ b/pnp-package.js
@@ -21,10 +21,10 @@ const config = {
     /**
      * The directory to which packages will be written
      */
-    outDir: path.resolve(".\\dist\\packages\\"),
+    outDir: path.resolve("./dist/packages/"),
 
-    // root location, relative 
-    packageRoot: path.resolve(".\\build\\packages\\"),
+    // root location, relative
+    packageRoot: path.resolve("./build/packages/"),
 
     // the list of packages to be packaged, in order
     // can be a string name or a plain object with additional settings
@@ -35,7 +35,7 @@ const config = {
      *      "assets": string[], // optional, default is config.assets
      *      "buildChain": (ctx) => Promise<void>[], // optional, default is config.buildChain
      * }
-     * 
+     *
      */
     packages: [
         "logging",

--- a/pnp-publish.js
+++ b/pnp-publish.js
@@ -12,8 +12,8 @@ const defaultPublishPipeline = [
 */
 const config = {
 
-    // root location, relative 
-    packageRoot: path.resolve(".\\dist\\packages\\"),
+    // root location, relative
+    packageRoot: path.resolve("./dist/packages/"),
 
     // the list of packages to be built, in order
     // can be a string name or a plain object with additional settings
@@ -24,7 +24,7 @@ const config = {
      *      "assets": string[], // optional, default is config.assets
      *      "buildChain": (ctx) => Promise<void>[], // optional, default is config.buildChain
      * }
-     * 
+     *
      */
     packages: [
         "logging",

--- a/tools/buildsystem/src/tasks/build/build-project.ts
+++ b/tools/buildsystem/src/tasks/build/build-project.ts
@@ -5,11 +5,11 @@ const log = require("fancy-log");
 import { exec } from "child_process";
 import { BuildContext } from "./context";
 
-const tscPath = ".\\node_modules\\.bin\\tsc";
+const tscPath = "./node_modules/.bin/tsc";
 
 /**
  * Builds the project based on the supplied tsconfig.json file
- * 
+ *
  * @param ctx The build context
  */
 export function buildProject(ctx: BuildContext) {
@@ -31,7 +31,7 @@ export function buildProject(ctx: BuildContext) {
 
 /**
  * Builds the project based on the supplied tsconfig.json file, overriding the build to produce es5
- * 
+ *
  * @param ctx The build context
  */
 export function buildProjectES5(ctx: BuildContext) {

--- a/tools/buildsystem/src/tasks/build/build-project.ts
+++ b/tools/buildsystem/src/tasks/build/build-project.ts
@@ -5,7 +5,7 @@ const log = require("fancy-log");
 import { exec } from "child_process";
 import { BuildContext } from "./context";
 
-const tscPath = "./node_modules/.bin/tsc";
+const tscPath = path.join("./node_modules/.bin/tsc");
 
 /**
  * Builds the project based on the supplied tsconfig.json file

--- a/tools/buildsystem/src/tasks/package/package-project.ts
+++ b/tools/buildsystem/src/tasks/package/package-project.ts
@@ -3,7 +3,7 @@ import { PackageContext } from "./context";
 import { exec } from "child_process";
 const path = require("path");
 
-const rollupPath = "./node_modules/.bin/rollup";
+const rollupPath = path.join("./node_modules/.bin/rollup");
 
 /**
  * Builds the project based on the supplied tsconfig.json file

--- a/tools/buildsystem/src/tasks/package/package-project.ts
+++ b/tools/buildsystem/src/tasks/package/package-project.ts
@@ -3,11 +3,11 @@ import { PackageContext } from "./context";
 import { exec } from "child_process";
 const path = require("path");
 
-const rollupPath = ".\\node_modules\\.bin\\rollup";
+const rollupPath = "./node_modules/.bin/rollup";
 
 /**
  * Builds the project based on the supplied tsconfig.json file
- * 
+ *
  * @param ctx The build context
  */
 export function packageProject(ctx: PackageContext) {

--- a/tools/buildsystem/src/tasks/package/uglify.ts
+++ b/tools/buildsystem/src/tasks/package/uglify.ts
@@ -3,12 +3,12 @@ import { PackageContext } from "./context";
 import { exec } from "child_process";
 const path = require("path");
 
-const uglifyPath = path.resolve(".\\node_modules\\.bin\\uglifyjs");
+const uglifyPath = path.resolve("./node_modules/.bin/uglifyjs");
 
 /**
  * Minifies the files created in es5 format into the target dist folder
- * 
- * @param ctx The build context 
+ *
+ * @param ctx The build context
  */
 export function uglify(ctx: PackageContext) {
 

--- a/tools/gulptasks/build.js
+++ b/tools/gulptasks/build.js
@@ -14,7 +14,7 @@ const gulp = require("gulp"),
     fs = require("fs"),
     cmdLine = require("./args").processConfigCmdLine;
 
-const tscPath = "./node_modules/.bin/tsc";
+const tscPath = path.join("./node_modules/.bin/tsc");
 
 // give outselves a single reference to the projectRoot
 const projectRoot = path.resolve(__dirname, "../..");

--- a/tools/gulptasks/build.js
+++ b/tools/gulptasks/build.js
@@ -1,6 +1,6 @@
 //******************************************************************************
 //* build.js
-//* 
+//*
 //* Defines a custom gulp task for compiling TypeScript source code into
 //* js files.  It outputs the details as to what it generated to the console.
 //******************************************************************************
@@ -14,7 +14,7 @@ const gulp = require("gulp"),
     fs = require("fs"),
     cmdLine = require("./args").processConfigCmdLine;
 
-const tscPath = ".\\node_modules\\.bin\\tsc";
+const tscPath = "./node_modules/.bin/tsc";
 
 // give outselves a single reference to the projectRoot
 const projectRoot = path.resolve(__dirname, "../..");


### PR DESCRIPTION
#### Category
- [*] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #115 

#### What's in this Pull Request?

When using / separator in gulp tasks, tasks also work in macOS (should also work in windows, not tested).

