### PR TITLE
Fix for error parsing ClientSideText webpart #126

### DIFF
--- a/packages/sp/src/clientsidepages.ts
+++ b/packages/sp/src/clientsidepages.ts
@@ -717,9 +717,15 @@ export class ClientSideText extends ClientSidePart {
 
         super.fromHtml(html);
 
-        const match = /<div[^>]*data-sp-rte[^>]*>(.*?)<\/div>$/i.exec(html);
+        this.text = "";
 
-        this.text = match.length > 1 ? match[1] : "";
+        getBoundedDivMarkup(html, /<div[^>]*data-sp-rte[^>]*>/i, (s: string) => {
+
+            // now we need to grab the inner text between the divs
+            const match = /<div[^>]*data-sp-rte[^>]*>(.*?)<\/div>$/i.exec(s);
+
+            this.text = match.length > 1 ? match[1] : "";
+        });
     }
 }
 


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #126

#### What's in this Pull Request?

Fixes a bug where parsing the text of the ClientSideText webpart when loading from an existing page included an extra "</div>" on the end. This may have caused other problems when saving and is resolved with this PR.