### PR TITLE
Adding support for different auth urls such as China, Germany, and US…

### DIFF
--- a/debug/launch/sp.ts
+++ b/debug/launch/sp.ts
@@ -1,6 +1,6 @@
 import { Logger, LogLevel } from "@pnp/logging";
 import { sp } from "@pnp/sp";
-import { SPFetchClient } from "@pnp/nodejs";
+import { SPFetchClient, SPOAuthEnv } from "@pnp/nodejs";
 
 declare var process: { exit(code?: number): void };
 
@@ -10,7 +10,7 @@ export function Example(settings: any) {
     sp.setup({
         sp: {
             fetchClientFactory: () => {
-                return new SPFetchClient(settings.testing.sp.url, settings.testing.sp.id, settings.testing.sp.secret);
+                return new SPFetchClient(settings.testing.sp.url, settings.testing.sp.id, settings.testing.sp.secret, SPOAuthEnv.SPO);
             },
         },
     });

--- a/packages/nodejs/docs/sp-fetch-client.md
+++ b/packages/nodejs/docs/sp-fetch-client.md
@@ -25,15 +25,46 @@ sp.web.get().then(w => {
 });
 ```
 
+## Set Authentication Environment
+
+_Added in 1.1.2_
+
+For some areas such as Germany, China, and US Gov clouds you need to specifiy a different authentication url to the service. This is done by specifying the correct SPOAuthEnv enumeration to the SPFetchClient constructor. The options are listed below. If you are not sure which option to specify the default is likely OK.
+
+- SPO : (default) for all *.sharepoint.com urls
+- China: for China hosted cloud
+- Germany: for Germany local cloud
+- USDef: USA Defense cloud
+- USGov: USA Government cloud
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import { SPFetchClient, SPOAuthEnv } from "@pnp/nodejs";
+
+sp.setup({
+    sp: {
+        fetchClientFactory: () => {
+            return new SPFetchClient("{site url}", "{client id}", "{client secret}", SPOAuthEnv.China);
+        },
+    },
+});
+```
+
+
 ## Set Realm
 
 In some cases automatically resolving the realm may not work. In this case you can set the realm parameter in the SPFetchClient constructor. You can determine the correct value for the realm by navigating to "https://{site name}-admin.sharepoint.com/_layouts/15/TA_AllAppPrincipals.aspx" and copying the GUID value that appears after the "@" - this is the realm id.
 
+**As of version 1.1.2 the realm parameter is now the 5th parameter in the constructor.**
+
 ```TypeScript
+import { sp } from "@pnp/sp";
+import { SPFetchClient, SPOAuthEnv } from "@pnp/nodejs";
+
 sp.setup({
     sp: {
         fetchClientFactory: () => {
-            return new SPFetchClient("{site url}", "{client id}", "{client secret}", "{realm}");
+            return new SPFetchClient("{site url}", "{client id}", "{client secret}", SPOAuthEnv.SPO, "{realm}");
         },
     },
 });

--- a/packages/nodejs/src/nodejs.ts
+++ b/packages/nodejs/src/nodejs.ts
@@ -18,5 +18,5 @@ const NodeFetch = require("node-fetch");
 })(global);
 
 
-export { SPFetchClient } from "./net/spfetchclient";
+export { SPFetchClient, SPOAuthEnv } from "./net/spfetchclient";
 export { AdalFetchClient, AADToken } from "./net/adalfetchclient";


### PR DESCRIPTION
… Gov

#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #152 

#### What's in this Pull Request?

Adds support for different authentication urls for @pnp/nodejs -> SPFetchClient for local clouds such as China, Germany, and US Gov.