### PR TITLE
SearchResult interface's ViewsLifetime property casing fix

### DIFF
--- a/packages/sp/src/search.ts
+++ b/packages/sp/src/search.ts
@@ -632,7 +632,7 @@ export interface SearchResult {
     FileExtension?: string;
     ContentTypeId?: string;
     ParentLink?: string;
-    ViewsLifeTime?: number;
+    ViewsLifetime?: number;
     ViewsRecent?: number;
     SectionNames?: string;
     SectionIndexes?: string;


### PR DESCRIPTION
#### Category

- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #191

#### What's in this Pull Request?

Fixes `SearchResult` interface `ViewsLifetime` property casing (was `ViewsLifeTime` but should be `ViewsLifetime` - this is checked in SPO and in legacy SP 2013).