### PR TITLE
Fix for spExtractODataId

### DIFF
--- a/packages/sp/src/odata.ts
+++ b/packages/sp/src/odata.ts
@@ -1,15 +1,22 @@
 import { SharePointQueryableConstructor } from "./sharepointqueryable";
-import { extend } from "@pnp/common";
+import { extend, combinePaths } from "@pnp/common";
 import { Logger, LogLevel } from "@pnp/logging";
 import { ODataParser, ODataParserBase } from "@pnp/odata";
+import { extractWebUrl } from "./utils/extractweburl";
 
 export function spExtractODataId(candidate: any): string {
 
-    if (candidate.hasOwnProperty("odata.id")) {
-        return candidate["odata.id"];
-    } else if (candidate.hasOwnProperty("__metadata") && candidate.__metadata.hasOwnProperty("id")) {
-        return candidate.__metadata.id;
+    if (candidate.hasOwnProperty("odata.metadata") && candidate.hasOwnProperty("odata.editLink")) {
+        // we are dealign with minimal metadata (default)
+        return combinePaths(extractWebUrl(candidate["odata.metadata"]), "_api", candidate["odata.editLink"]);
+    } else if (candidate.hasOwnProperty("odata.editLink")) {
+        return combinePaths("_api", candidate["odata.editLink"]);
+    } else if (candidate.hasOwnProperty("__metadata")) {
+        // we are dealing with verbose, which has an absolute uri
+        return candidate.__metadata.uri;
     } else {
+        // we are likely dealing with nometadata, so don't error but we won't be able to
+        // chain off these objects
         Logger.write("No uri information found in ODataEntity parsing, chaining will fail for this object.", LogLevel.Warning);
         return "";
     }

--- a/packages/sp/src/utils/extractweburl.ts
+++ b/packages/sp/src/utils/extractweburl.ts
@@ -1,6 +1,8 @@
+import { stringIsNullOrEmpty } from "@pnp/common";
+
 export function extractWebUrl(candidateUrl: string) {
 
-    if (candidateUrl === null) {
+    if (stringIsNullOrEmpty(candidateUrl)) {
         return "";
     }
 


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #190

#### What's in this Pull Request?

spExtractODataId began returning incorrect values as the data sent in that property seems to have changed. Method is updated to use the editLink field to calculate the url id of the entity.