### PR TITLE
Updated Getting Started and Transition Guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ PnPJS is a fluent JavaScript API for consuming SharePoint and Office 365 REST AP
 
 Please use [http://aka.ms/sppnp](http://aka.ms/sppnp) for the latest updates around the whole *SharePoint Patterns and Practices (PnP) initiative*.
 
-**If you are moving from sp-pnp-js please review the [transition guide](https://pnp.github.io/pnpjs/transition-guide.html)**
+**If you are moving from sp-pnp-js please review the [transition guide](https://pnp.github.io/pnpjs/documentation/transition-guide/)**
 
 ## Getting Started
 
-Please see the [Getting Started guide](https://pnp.github.io/pnpjs/getting-started.html) in the main documentation.
+Please see the [Getting Started guide](https://pnp.github.io/pnpjs/documentation/getting-started/) in the main documentation.
 
 ## Documentation
 


### PR DESCRIPTION
I've updated the links to the Getting Started and Transition Guide as they were redirecting to the wrong location and showing a 404 page.

#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### Related Issues

None

#### What's in this Pull Request?

*Please describe the changes in this PR. Simple description or details around bugs which are being fixed.*



