### PR TITLE
Added "1.0"  as default value to dataVersion in the "import" function.

### DIFF
--- a/packages/sp/src/clientsidepages.ts
+++ b/packages/sp/src/clientsidepages.ts
@@ -759,7 +759,7 @@ export class ClientSideWebpart extends ClientSidePart {
         const manifest: ClientSidePageComponentManifest = JSON.parse(component.Manifest);
         this.title = manifest.preconfiguredEntries[0].title.default;
         this.description = manifest.preconfiguredEntries[0].description.default;
-        this.dataVersion = "";
+        this.dataVersion = "1.0";
         this.propertieJson = this.parseJsonProperties(manifest.preconfiguredEntries[0].properties);
     }
 


### PR DESCRIPTION
Without dataVersion the imported OOTB Web Part doesn't work on the page.

#### Category
- [ X ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

When importing a Web Part and trying to add it you get errors without supplying a "dataVersion".
So it's better to have 1.0 as a default value.

![image](https://user-images.githubusercontent.com/16558321/45556851-8c86e780-b83c-11e8-8731-3bfa7b220085.png)

After adding a dataVersion:

![image](https://user-images.githubusercontent.com/16558321/45557284-87766800-b83d-11e8-990c-01427faf36a8.png)

#### What's in this Pull Request?

![image](https://user-images.githubusercontent.com/16558321/45556720-3ade5d00-b83c-11e8-8f79-4df1f4b13072.png)

Changed the default value in the import function to be 1.0.
