### PR TITLE
Fixed "v1" graph docs

### DIFF
--- a/packages/graph/docs/index.md
+++ b/packages/graph/docs/index.md
@@ -18,7 +18,7 @@ import { graph } from "@pnp/graph";
 (function main() {
 
     // here we will load the current web's properties
-    graph.v1.groups.get().then(g => {
+    graph.groups.get().then(g => {
 
         console.log(`Groups: ${JSON.stringify(g, null, 4)}`);
     });
@@ -58,7 +58,7 @@ public render(): void {
     this.domElement.innerHTML = `Loading...`;
 
     // here we will load the current web's properties
-    graph.v1.groups.get().then(groups => {
+    graph.groups.get().then(groups => {
 
         this.domElement.innerHTML = `Groups: <ul>${groups.map(g => `<li>${g.displayName}</li>`).join("")}</ul>`;
     });
@@ -87,7 +87,7 @@ graph.setup({
 });
 
 // here we will load the groups information
-graph.v1.groups.get().then(g => {
+graph.groups.get().then(g => {
 
     console.log(`Groups: ${JSON.stringify(g, null, 4)}`);
 });


### PR DESCRIPTION

#### Category
- [x] Documentation update

#### What's in this Pull Request?

In the latest version pnpjs doesn't use `v1` prefix for graph access. Documentation was fixed to reflect it.



