### PR TITLE
Added 'groups' endpoint to 'currentUser'

### DIFF
--- a/packages/sp/src/siteusers.ts
+++ b/packages/sp/src/siteusers.ts
@@ -83,10 +83,10 @@ export class SiteUsers extends SharePointQueryableCollection {
 
 
 /**
- * Describes a single user
- *
+ * Base class for a user
+ * 
  */
-export class SiteUser extends SharePointQueryableInstance {
+export class UserBase extends SharePointQueryableInstance {
 
     /**
      * Gets the groups for this user
@@ -95,6 +95,13 @@ export class SiteUser extends SharePointQueryableInstance {
     public get groups() {
         return new SiteGroups(this, "groups");
     }
+}
+
+/**
+ * Describes a single user
+ *
+ */
+export class SiteUser extends UserBase {
 
     /**
     * Updates this user instance with the supplied properties
@@ -114,7 +121,7 @@ export class SiteUser extends SharePointQueryableInstance {
  * Represents the current user
  */
 @defaultPath("currentuser")
-export class CurrentUser extends SharePointQueryableInstance { }
+export class CurrentUser extends UserBase { }
 
 export interface SiteUserProps {
     Email: string;


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

This PR adds the `groups` property to the `web.currentUser` just like was already available for `web.siteUsers.getById(id)`.

I have done basic refactoring by creating a base `UserBase` class inheriting from `SharePointQueryableInstance` which is now extended by both existing user classes `SiteUser` and `CurrentUser`. `UserBase` contains the `get groups()` property that existed in the `SiteUser` class. 
