### PR TITLE
Implement Fields.addDependentLookupField

### DIFF
--- a/packages/sp/docs/fields.md
+++ b/packages/sp/docs/fields.md
@@ -132,6 +132,16 @@ web.lists.getByTitle("MyList").fields.addText("MyField5", 100).then(f => {
 
     console.log(f);
 });
+
+// Create a lookup field, and a dependent lookup field
+web.lists.getByTitle("MyList").fields.addLookup("MyLookup", "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx", "MyLookupTargetField").then(f => {
+    console.log(f);
+    
+    // Create the dependent lookup field
+    return web.lists.getByTitle("MyList").fields.addDependentLookupField("MyLookup_ID", f.Id, "ID");
+}).then(fDep => {
+    console.log(fDep);
+});
 ```
 
 ## Update a Field

--- a/packages/sp/src/fields.ts
+++ b/packages/sp/src/fields.ts
@@ -413,7 +413,7 @@ export class Fields extends SharePointQueryableCollection {
         showField: string,
     ): Promise<FieldAddResult> {
         return this.clone(
-            FieldsExtension,
+            Fields,
             `adddependentlookupfield(displayName='${displayName}', primarylookupfieldid='${primaryLookupFieldId}', showfield='${showField}')`,
         )
             .postCore<{ Id: string }>({})

--- a/packages/sp/src/fields.ts
+++ b/packages/sp/src/fields.ts
@@ -399,6 +399,31 @@ export class Fields extends SharePointQueryableCollection {
 
         return this.add(title, "SP.Field", extend(props, properties));
     }
+    
+   /**
+   * Creates a secondary (dependent) lookup field, based on the Id of the primary lookup field.
+   * 
+   * @param displayName The display name of the new field.
+   * @param primaryLookupFieldId The guid of the primary Lookup Field.
+   * @param showField Which field to show from the lookup list.
+   */
+    addDependentLookupField(
+        displayName: string,
+        primaryLookupFieldId: string,
+        showField: string,
+    ): Promise<FieldAddResult> {
+        return this.clone(
+            FieldsExtension,
+            `adddependentlookupfield(displayName='${displayName}', primarylookupfieldid='${primaryLookupFieldId}', showfield='${showField}')`,
+        )
+            .postCore<{ Id: string }>({})
+            .then(data => {
+                return {
+                    data,
+                    field: this.getById(data.Id),
+                };
+            });
+    }
 }
 
 /**


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [X] Documentation update?

#### Related Issues

n/a

#### What's in this Pull Request?

Noticed the [FieldCollection.addDependentLookupField](https://msdn.microsoft.com/en-us/library/office/dn600182.aspx#bk_FieldCollectionAddDependentLookupField) method was not implemented, so I implemented it. Tested against SP2013 on-prem.

