### PR TITLE
Update issue AppPermissionRequest XML debugging.md

### DIFF
--- a/packages/documentation/debugging.md
+++ b/packages/documentation/debugging.md
@@ -146,7 +146,7 @@ Now that we have created an add-in registration we need to tell SharePoint what 
 
 ```XML
   <AppPermissionRequests AllowAppOnlyPolicy="true">
-    <AppPermissionRequest Scope="http://sharepoint/content/sitecollection" Right="FullControl" />
+    <AppPermissionRequest Scope="http://sharepoint/content/tenant" Right="FullControl" />
     <AppPermissionRequest Scope="http://sharepoint/social/tenant" Right="FullControl" />
     <AppPermissionRequest Scope="http://sharepoint/search" Right="QueryAsUserIgnoreAppPrincipal" />
   </AppPermissionRequests>


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### What's in this Pull Request?

Had an issue where the permissions would not be applied. In code I would always get a HTTP/1.1 403 Forbidden error. First I thought there was an issue in the code, but I could reproduce the same error using the GetAppOnlyAuthenticatedContext method in PnPCore C#.

I found that changing the http://sharepoint/content/sitecollection to http://sharepoint/content/tenant worked fine. They both result in the same permission:

* Let it have full control of this site collection.
* Let it share its permissions with other users.
* Let it access basic information about the users of this site.
* Allow this app to execute search queries on your behalf, ignoring the app's permissions on result items.
* Allow application access to user profiles: Full Control
