### PR TITLE
Fixed typo in SearchPropertyValue interface (Intval -> IntVal)

### DIFF
--- a/packages/sp/src/search.ts
+++ b/packages/sp/src/search.ts
@@ -662,7 +662,7 @@ export interface SearchProperty {
 export interface SearchPropertyValue {
     StrVal?: string;
     BoolVal?: boolean;
-    Intval?: number;
+    IntVal?: number;
     StrArray?: string[];
     QueryPropertyValueTypeIndex: QueryPropertyValueType;
 }


### PR DESCRIPTION
#### Category
- [X] Bug fix?

#### What's in this Pull Request?

Just fixed a minor type in SearchPropertyValue interface. This caused an issue when you want to use that property in a Search query, as this generated JSON is not OK to SharePoint search service, as is Case sensitive, so it fails with Intval, but works with IntVal (capital V)

```json
 {
   "Name": "ListItemId",
   "Value": {
     "QueryPropertyValueTypeIndex": 2,
     "Intval": 16
    }
}
```

Thanks,

Luis.