### PR TITLE
Feature - added support for Hub site APIs

### DIFF
--- a/packages/sp/src/site.ts
+++ b/packages/sp/src/site.ts
@@ -115,6 +115,31 @@ export class Site extends SharePointQueryableInstance {
             web: Web.fromUrl(d["odata.id"] || d.__metadata.uri),
         }));
     }
+
+    /**
+     * Associates a site collection to a hub site.
+     * 
+     * @param siteId Id of the hub site collection you want to join.
+     * If you want to disassociate the site collection from hub site, then
+     * pass the siteId as 00000000-0000-0000-0000-000000000000
+     */
+    public joinHubSite(siteId: string): Promise<void> {
+        return this.clone(Site, `joinHubSite('${siteId}')`).postCore();
+    }
+
+    /**
+     * Registers the current site collection as hub site collection
+     */
+    public registerHubSite(): Promise<void> {
+        return this.clone(Site, `registerHubSite`).postCore();
+    }
+
+    /**
+     * Unregisters the current site collection as hub site collection.
+     */
+    public unRegisterHubSite(): Promise<void> {
+        return this.clone(Site, `unRegisterHubSite`).postCore();
+    }
 }
 
 /**

--- a/packages/sp/src/webs.ts
+++ b/packages/sp/src/webs.ts
@@ -77,7 +77,7 @@ export class Webs extends SharePointQueryableCollection {
  *
  */
 @defaultPath("webinfos")
-export class WebInfos extends SharePointQueryableCollection {}
+export class WebInfos extends SharePointQueryableCollection { }
 
 /**
  * Describes a web
@@ -589,6 +589,24 @@ export class Web extends SharePointQueryableShareableWeb {
         q.query.set("@v", `'${encodeURIComponent(siteOwner2 || "")}'`);
         q.query.set("@s", `'${encodeURIComponent(groupNameSeed || "")}'`);
         return q.postCore();
+    }
+
+    /**
+     * Gets hub site data for the current web.
+     * 
+     * @param forceRefresh Default value is false. When false, the data is returned from the server's cache. 
+     * When true, the cache is refreshed with the latest updates and then returned. 
+     * Use this if you just made changes and need to see those changes right away.
+     */
+    public hubSiteData(forceRefresh = false): Promise<void> {
+        return this.clone(Web, `hubSiteData(${forceRefresh})`).get();
+    }
+
+    /**
+     * Applies theme updates from the parent hub site collection.
+     */
+    public syncHubSiteTheme(): Promise<void> {
+        return this.clone(Web, `syncHubSiteTheme`).postCore();
     }
 }
 


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

NA

#### What's in this Pull Request?

Added support for Hub Sites API.
1) Added support to join a hub site and register/unregister a site collection as hub
2) Added support to get hub site's data and sync the hub site themes.

Based on [Hub sites REST API docs](https://docs.microsoft.com/en-us/sharepoint/dev/features/hub-site/hub-site-rest-api). Please let me know your thoughts on this implementation.