### PR TITLE
Added IRefiner interface over ResultTable.Refiners.

### DIFF
--- a/packages/sp/src/search.ts
+++ b/packages/sp/src/search.ts
@@ -619,12 +619,16 @@ export interface ResultTableCollection {
     SpecialTermResults?: ResultTable;
 }
 
+export interface IRefiner {
+    Name: string;
+    Entries: { RefinementCount: string; RefinementName: string; RefinementToken: string; RefinementValue: string; };
+}
 export interface ResultTable {
     GroupTemplateId?: string;
     ItemTemplateId?: string;
     Properties?: { Key: string, Value: any, ValueType: string }[];
     Table?: { Rows: { Cells: { Key: string, Value: any, ValueType: string }[] }[] };
-    Refiners?: { Name: string; Entries: { RefinementCount: string; RefinementName: string; RefinementToken: string; RefinementValue: string; }[]; }[];
+    Refiners?: IRefiner[];
     ResultTitle?: string;
     ResultTitleUrl?: string;
     RowCount?: number;


### PR DESCRIPTION
Should make them easier to return to results

#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

You cannot easily return the Refiners from the SearchResults, without having to an entire ResultsTable. Which is a little wasteful.
This is a simple interface, that allows you to return only the refiners array explicitly.

#### What's in this Pull Request?

sp/Search.ts added interface `IRefiner` and altered the `ResultTable` interface changing ResultTable.Refiners to be `IRefiner`

