### PR TITLE
ie-polyfills: fixed a typo in the homepage url

### DIFF
--- a/tools/polyfill-ie11/package.json
+++ b/tools/polyfill-ie11/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/pnp/pnpjs/issues"
   },
-  "homepage": "https:github.com/pnp/pnpjs",
+  "homepage": "https://github.com/pnp/pnpjs",
   "repository": {
     "type": "git",
     "url": "git:github.com/pnp/pnpjs"


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues
none

#### What's in this Pull Request?
Fixed the package json homepage url which was missing slashes for the polyfills package.