### PR TITLE
Added Teams, Channels, Tabs support. No more Beta + documentation

### DIFF
--- a/packages/graph/docs/teams.md
+++ b/packages/graph/docs/teams.md
@@ -1,0 +1,166 @@
+# @pnp/graph/teams
+
+The ability to manage Team is a capability introduced in the 1.2.7 of @pnp/graph. Through the methods described
+you can add, update and delete items in Teams.
+
+## Teams the user is a member of
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const joinedTeams = await graph.users.getById('99dc1039-eb80-43b1-a09e-250d50a80b26').joinedTeams.get();
+
+const myJoinedTeams = await graph.me.joinedTeams.get();
+
+```
+
+## Get Teams by Id
+
+Using the planner.plans.getById() you can get a specific Plan.
+Planner.plans is not an available endpoint, you need to get a specific Plan.
+
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const team = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').get();
+
+```
+
+## Create new Group and Team
+When you create a new group and add a Team, the group needs to have an Owner. Or else we get an error.
+So the owner Id is important, and you could just get the users Ids from
+
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const users = await graph.users.get();
+```
+Then create
+```TypeSCript
+import { graph } from "@pnp/graph";
+
+const createdGroupTeam = await graph.teams.create('Groupname', 'description', 'OwnerId',{ 
+"memberSettings": {
+    "allowCreateUpdateChannels": true
+},
+"messagingSettings": {
+        "allowUserEditMessages": true,
+"allowUserDeleteMessages": true
+},
+"funSettings": {
+    "allowGiphy": true,
+    "giphyContentRating": "strict"
+}});
+```
+
+## Create a Team via a specific group
+Here we get the group via id and use `createTeam`
+
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const createdTeam = await graph.groups.getById('679c8ff4-f07d-40de-b02b-60ec332472dd').createTeam({ 
+"memberSettings": {
+    "allowCreateUpdateChannels": true
+},
+"messagingSettings": {
+        "allowUserEditMessages": true,
+"allowUserDeleteMessages": true
+},
+"funSettings": {
+    "allowGiphy": true,
+    "giphyContentRating": "strict"
+}});
+```
+
+## Archive a Team
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const archived = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').archive();
+
+```
+## Unarchive a Team
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const archived = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').unarchive();
+
+```
+
+## Clone a Team
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const clonedTeam = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').cloneTeam(
+'Cloned','description','apps,tabs,settings,channels,members','public');
+
+```
+## Get all channels of a Team
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const channels = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').channels.get();
+
+```
+## Get channel by Id
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const channel = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').channels.getById('19:65723d632b384ca89c81115c281428a3@thread.skype').get();
+
+```
+
+## Create a new Channel
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const newChannel = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').channels.create('New Channel', 'Description');
+
+```
+## Get installed Apps
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const installedApps = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').installedApps.get();
+
+```
+## Add an App
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const addedApp = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').installedApps.add('https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a');
+
+```
+## Remove an App
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const removedApp = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').installedApps.remove();
+
+```
+## Get Tabs from a Channel
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const tabs = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').
+channels.getById('19:65723d632b384ca89c81115c281428a3@thread.skype').tabs
+.get();
+
+```
+## Get Tab by Id
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const tab = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').
+channels.getById('19:65723d632b384ca89c81115c281428a3@thread.skype').tabs
+.getById('Id');
+
+```
+## Add a new Tab
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const newTab = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').
+channels.getById('19:65723d632b384ca89c81115c281428a3@thread.skype').tabs.add('Tab','https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a',<TabsConfiguration>{});
+
+```

--- a/packages/graph/src/groups.ts
+++ b/packages/graph/src/groups.ts
@@ -7,7 +7,7 @@ import { Event as IEvent } from "@microsoft/microsoft-graph-types";
 import { Plans } from "./planner";
 import { Photo } from "./photos";
 import { Team } from "./teams";
-import { GraphEndpoints, TeamProperties } from "./types";
+import { TeamProperties } from "./types";
 
 export enum GroupType {
     /**
@@ -165,7 +165,7 @@ export class Group extends GraphQueryableInstance {
      */
     public createTeam(properties: TeamProperties): Promise<any> {
 
-        return this.clone(Group, "team").setEndpoint(GraphEndpoints.Beta).putCore({
+        return this.clone(Group, "team").putCore({
             body: jsS(properties),
         });
     }

--- a/packages/graph/src/rest.ts
+++ b/packages/graph/src/rest.ts
@@ -21,7 +21,7 @@ export class GraphRest extends GraphQueryable {
     }
 
     public get teams(): Teams {
-        return new Teams();
+        return new Teams(this);
     }
 
     public get me(): User {

--- a/packages/graph/src/teams.ts
+++ b/packages/graph/src/teams.ts
@@ -1,18 +1,27 @@
 import { graph } from "./rest";
 import { Group, GroupType, GroupAddResult } from "./groups";
-import { GraphQueryableInstance, defaultPath } from "./graphqueryable";
-import { GraphEndpoints, TeamProperties } from "./types";
+import { GraphQueryableInstance, defaultPath, GraphQueryableCollection } from "./graphqueryable";
+import { TeamProperties, TabsConfiguration } from "./types";
 import { ODataParser, ODataDefaultParser } from "@pnp/odata";
-import { FetchOptions, jsS } from "@pnp/common";
+import { FetchOptions, jsS, extend, TypedHash } from "@pnp/common";
 
-export class Teams {
+@defaultPath("teams")
+export class Teams extends GraphQueryableCollection {
 
     /**
      * Creates a new team and associated Group with the given information
+     * @param name The name of the new Group
+     * @param description Optional description of the group
+     * @param ownerId Add an owner with a user id from the graph
      */
-    public create(name: string, description = "", teamProperties: TeamProperties = {}): Promise<TeamCreateResult> {
+    public create(name: string, description = "", ownerId: string, teamProperties: TeamProperties = {}): Promise<TeamCreateResult> {
 
-        const groupProps = description && description.length > 0 ? { description: description } : {};
+        const groupProps = {
+            "description": description && description.length > 0 ? description : "",
+            "owners@odata.bind": [
+                `https://graph.microsoft.com/v1.0/users/${ownerId}`,
+            ],
+        };
 
         return graph.groups.add(name, name, GroupType.Office365, groupProps).then((gar: GroupAddResult) => {
             return gar.group.createTeam(teamProperties).then(data => {
@@ -24,6 +33,11 @@ export class Teams {
             });
         });
     }
+
+    public getById(id: string): Team {
+        return new Team(this, id);
+    }
+
 }
 
 /**
@@ -31,6 +45,15 @@ export class Teams {
  */
 @defaultPath("team")
 export class Team extends GraphQueryableInstance<TeamProperties> {
+
+    public get channels(): Channels {
+        return new Channels(this);
+    }
+
+    public get installedApps(): Apps {
+        return new Apps(this);
+    }
+
     /**
      * Updates this team instance's properties
      * 
@@ -39,7 +62,7 @@ export class Team extends GraphQueryableInstance<TeamProperties> {
     // TODO:: update properties to be typed once type is available in graph-types
     public update(properties: TeamProperties): Promise<TeamUpdateResult> {
 
-        return this.clone(Team, "").setEndpoint(GraphEndpoints.Beta).patchCore({
+        return this.clone(Team, "").patchCore({
             body: jsS(properties),
         }).then(data => {
             return {
@@ -50,13 +73,218 @@ export class Team extends GraphQueryableInstance<TeamProperties> {
     }
 
     /**
+     * Archives this Team
+     * 
+     * @param shouldSetSpoSiteReadOnlyForMembers Should members have Read-only in associated Team Site
+     */
+    // TODO:: update properties to be typed once type is available in graph-types
+    public archive(shouldSetSpoSiteReadOnlyForMembers?: boolean): Promise<TeamUpdateResult> {
+
+        let postBody;
+
+        if (shouldSetSpoSiteReadOnlyForMembers != null) {
+            postBody = extend(postBody, {
+                shouldSetSpoSiteReadOnlyForMembers: shouldSetSpoSiteReadOnlyForMembers,
+            });
+        }
+        return this.clone(Team, "archive").postCore({
+            body: jsS(postBody),
+        }).then(data => {
+            return {
+                data: data,
+                team: this,
+            };
+        });
+    }
+
+    /**
+    * Unarchives this Team
+    * 
+    */
+    // TODO:: update properties to be typed once type is available in graph-types
+    public unarchive(): Promise<TeamUpdateResult> {
+
+        return this.clone(Team, "unarchive").postCore({
+        }).then(data => {
+            return {
+                data: data,
+                team: this,
+            };
+        });
+    }
+
+    /**
+     * Clones this Team
+     * @param name The name of the new Group
+     * @param description Optional description of the group
+     * @param partsToClone Parts to clone ex: apps,tabs,settings,channels,members
+     * @param visibility Set visibility to public or private 
+     */
+    // TODO:: update properties to be typed once type is available in graph-types
+    public cloneTeam(name: string, description = "", partsToClone: string, visibility: string): Promise<TeamUpdateResult> {
+
+        const postBody = {
+            description: description ? description : "",
+            displayName: name,
+            mailNickname: name,
+            partsToClone: partsToClone,
+            visibility: visibility,
+        };
+
+
+        return this.clone(Team, "clone").postCore({
+            body: jsS(postBody),
+        }).then(data => {
+            return {
+                data: data,
+                team: this,
+            };
+        });
+    }
+
+
+    /**
      * Executes the currently built request
      *
      * @param parser Allows you to specify a parser to handle the result
      * @param getOptions The options used for this request
      */
     public get<T = TeamProperties>(parser: ODataParser<T> = new ODataDefaultParser(), options: FetchOptions = {}): Promise<T> {
-        return this.clone(Team, "").setEndpoint(GraphEndpoints.Beta).getCore(parser, options);
+        return this.clone(Team, "").getCore(parser, options);
+    }
+}
+
+@defaultPath("channels")
+export class Channels extends GraphQueryableCollection {
+
+    /**
+     * Creates a new Channel in the Team
+     * @param name The display name of the new channel
+     * @param description Optional description of the channel
+     * 
+     */
+    public create(name: string, description = ""): Promise<ChannelCreateResult> {
+
+        const postBody = {
+            description: description && description.length > 0 ? description : "",
+            displayName: name,
+        };
+
+        return this.postCore({
+            body: jsS(postBody),
+        }).then(r => {
+            return {
+                channel: this.getById(r.id),
+                data: r,
+            };
+        });
+    }
+
+    public getById(id: string): Channel {
+        return new Channel(this, id);
+    }
+
+}
+
+export class Channel extends GraphQueryableInstance {
+    public get tabs(): Tabs {
+        return new Tabs(this);
+    }
+}
+
+@defaultPath("installedApps")
+export class Apps extends GraphQueryableCollection {
+
+    /**
+     * Creates a new App in the Team
+     * @param appUrl The url to an app ex: https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a
+     * 
+     */
+    public add(appUrl: string): Promise<any> {
+
+        const postBody = {
+            "teamsApp@odata.bind": appUrl,
+        };
+
+        return this.postCore({
+            body: jsS(postBody),
+        }).then(r => {
+            return {
+                data: r,
+            };
+        });
+    }
+
+    /**
+     * Deletes this app
+     */
+    public remove(): Promise<void> {
+        return this.deleteCore();
+    }
+}
+
+@defaultPath("tabs")
+export class Tabs extends GraphQueryableCollection {
+
+    /**
+     * Adds a tab to the cahnnel
+     * @param name The name of the new Tab
+     * @param appUrl The url to an app ex: https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a
+     * @param tabsConfiguration visit https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/teamstab_add for reference
+     */
+    public add(name: string, appUrl: string, properties: TabsConfiguration): Promise<TabCreateResult> {
+
+        const postBody = extend({
+            name: name,
+            "teamsApp@odata.bind": appUrl,
+        }, properties);
+
+        return this.postCore({
+            body: jsS(postBody),
+        }).then(r => {
+            return {
+                data: r,
+                tab: this.getById(r.id),
+            };
+        });
+
+    }
+
+    public getById(id: string): Tab {
+        return new Tab(this, id);
+    }
+
+}
+
+/**
+ * Represents a Microsoft Team
+ */
+@defaultPath("tab")
+export class Tab extends GraphQueryableInstance<TeamProperties> {
+
+    /**
+     * Updates this tab
+     * 
+     * @param properties The set of properties to update
+     */
+    // TODO:: update properties to be typed once type is available in graph-types
+    public update(properties: TypedHash<string | number | boolean | string[]>): Promise<TabUpdateResult> {
+
+        return this.clone(Tab, "").patchCore({
+            body: jsS(properties),
+        }).then(data => {
+            return {
+                data: data,
+                tab: this,
+            };
+        });
+    }
+
+    /**
+     * Deletes this tab
+     */
+    public remove(): Promise<void> {
+        return this.deleteCore();
     }
 }
 
@@ -69,4 +297,19 @@ export interface TeamCreateResult {
     data: any;
     group: Group;
     team: Team;
+}
+
+export interface ChannelCreateResult {
+    data: any;
+    channel: Channel;
+}
+
+export interface TabCreateResult {
+    data: any;
+    tab: Tab;
+}
+
+export interface TabUpdateResult {
+    data: any;
+    tab: Tab;
 }

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -51,3 +51,16 @@ export interface TeamProperties {
         "allowCustomMemes"?: boolean;
     };
 }
+
+export interface TabsConfiguration {
+
+    configuration: {
+        "entityId": string;
+        "contentUrl": string;
+        "websiteUrl": string;
+        "removeUrl": string;
+
+    };
+
+}
+

--- a/packages/graph/src/users.ts
+++ b/packages/graph/src/users.ts
@@ -4,6 +4,8 @@ import { Contacts, ContactFolders } from "./contacts";
 import { OneNote, OneNoteMethods } from "./onenote";
 import { Drive, Drives } from "./onedrive";
 import { Tasks } from "./planner";
+import { Teams } from "./teams";
+
 
 
 /**
@@ -40,6 +42,9 @@ export class User extends GraphQueryableInstance {
         return new Contacts(this);
     }
 
+    public get joinedTeams(): Teams {
+        return new Teams(this, "joinedTeams");
+    }
     /**
     * The Contact Folders associated with the user
     */


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ X ] New feature?
- [ ] New sample?
- [ X ] Documentation update?

#### What's in this Pull Request?
- Changed the function that creates both a group and a Team. The group needs to have an Owner or else we get an error. 

- Removed Beta endpoints

Added a few things in Teams:
- GetById
- Archive
- Unarchive
- Clone
- Get all Channels
- Get Channel by Id
- Create a new channel
- Get installed apps
- Add an app
- Remove an app
- Get tabs from channel
- Get tab by Id
- Add new tab
- And in User.ts we now have `graph.users.getById('ID').joinedTeams.get()`

This solves #372 