### PR TITLE
add window.performance to prevent collisions

### DIFF
--- a/packages/common/src/util.ts
+++ b/packages/common/src/util.ts
@@ -75,10 +75,14 @@ export function getRandomString(chars: number): string {
  * Gets a random GUID value
  *
  * http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
+ * https://stackoverflow.com/a/8809472 updated to prevent collisions.
  */
 /* tslint:disable no-bitwise */
 export function getGUID(): string {
-    let d = new Date().getTime();
+    let d = Date.now();
+    if (typeof performance !== "undefined" && typeof performance.now === "function") {
+        d += performance.now(); // use high-precision timer if available
+    }
     const guid = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
         const r = (d + Math.random() * 16) % 16 | 0;
         d = Math.floor(d / 16);


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues
Not raised yet, checked references to method and found none. Could possibly be removed from code base.

#### What's in this Pull Request?

The getGuid method relies on the uniqueness of the generated number from the Date object, but during simple tests it is apparent that this is not always the case.

Tested in Firefox and Chrome, the uniqueness in Firefox stays the same.

Run this in the Chrome Browser Developer Console
```
for(var i = 0; i < 50; i++) {
    console.log(Date.now());
}
```
You could/should see something like this

![image](https://user-images.githubusercontent.com/10480670/49334160-6a447080-f5c6-11e8-8fb8-93dcac995293.png)


Run this
```
for(var i = 0; i < 50; i++) {
    console.log(performance.now());
}
```

You will see much more lines in the output, thus uniqueness
![image](https://user-images.githubusercontent.com/10480670/49334158-4f71fc00-f5c6-11e8-8327-5d7c55b1c7ba.png)

