### PR TITLE
#420 - No groups property in TermStore object

### DIFF
--- a/packages/sp-taxonomy/src/termgroup.ts
+++ b/packages/sp-taxonomy/src/termgroup.ts
@@ -67,9 +67,12 @@ export type TermGroupUpdateProps = {
     Description?: string,
 };
 
+/**
+ * Term Groups collection in Term Store
+ */
 export class TermGroups extends ClientSvcQueryable implements ITermGroups {
     /**
-     * Gets the termsets in this collection
+     * Gets the groups in this collection
      */
     public get(): Promise<(ITermGroupData & ITermGroup)[]> {
         return this.sendGetCollection<ITermGroupData, ITermGroup>((d: ITermGroupData) => {
@@ -78,14 +81,14 @@ export class TermGroups extends ClientSvcQueryable implements ITermGroups {
             } else if (!stringIsNullOrEmpty(d.Id)) {
                 return this.getById(d.Id);
             }
-            throw Error("Could not find Value in Labels.get(). You must include at least one of these in your select fields.");
+            throw Error("Could not find Name or Id in TermGroups.get(). You must include at least one of these in your select fields.");
         });
     }
 
     /**
-     * Gets a TermSet from this collection by id
+     * Gets a TermGroup from this collection by id
      * 
-     * @param id TermSet id
+     * @param id TermGroup id
      */
     public getById(id: string): ITermGroup {
 
@@ -96,9 +99,9 @@ export class TermGroups extends ClientSvcQueryable implements ITermGroups {
     }
 
     /**
-     * Gets a TermSet from this collection by name
+     * Gets a TermGroup from this collection by name
      * 
-     * @param name TermSet name
+     * @param name TErmGroup name
      */
     public getByName(name: string): ITermGroup {
 

--- a/packages/sp-taxonomy/src/termgroup.ts
+++ b/packages/sp-taxonomy/src/termgroup.ts
@@ -1,7 +1,13 @@
-import { extend, getGUID, sanitizeGuid } from "@pnp/common";
+import { extend, getGUID, sanitizeGuid, stringIsNullOrEmpty } from "@pnp/common";
 import { ClientSvcQueryable, IClientSvcQueryable, MethodParams, ObjectPathQueue } from "@pnp/sp-clientsvc";
 import { ITermSet, ITermSetData, ITermSets, TermSets } from "./termsets";
 import { ITermStore, TermStore } from "./termstores";
+
+export interface ITermGroups extends IClientSvcQueryable {
+    get(): Promise<(ITermGroupData & ITermGroup)[]>;
+    getById(id: string): ITermGroup;
+    getByName(name: string): ITermGroup;
+}
 
 export interface ITermGroupData {
     CreatedDate?: string;
@@ -60,6 +66,48 @@ export interface ITermGroup extends IClientSvcQueryable {
 export type TermGroupUpdateProps = {
     Description?: string,
 };
+
+export class TermGroups extends ClientSvcQueryable implements ITermGroups {
+    /**
+     * Gets the termsets in this collection
+     */
+    public get(): Promise<(ITermGroupData & ITermGroup)[]> {
+        return this.sendGetCollection<ITermGroupData, ITermGroup>((d: ITermGroupData) => {
+            if (!stringIsNullOrEmpty(d.Name)) {
+                return this.getByName(d.Name);
+            } else if (!stringIsNullOrEmpty(d.Id)) {
+                return this.getById(d.Id);
+            }
+            throw Error("Could not find Value in Labels.get(). You must include at least one of these in your select fields.");
+        });
+    }
+
+    /**
+     * Gets a TermSet from this collection by id
+     * 
+     * @param id TermSet id
+     */
+    public getById(id: string): ITermGroup {
+
+        const params = MethodParams.build()
+            .string(sanitizeGuid(id));
+
+        return this.getChild(TermGroup, "GetById", params);
+    }
+
+    /**
+     * Gets a TermSet from this collection by name
+     * 
+     * @param name TermSet name
+     */
+    public getByName(name: string): ITermGroup {
+
+        const params = MethodParams.build()
+            .string(name);
+
+        return this.getChild(TermGroup, "GetByName", params);
+    }
+}
 
 /**
  * Represents a group in the taxonomy heirarchy

--- a/packages/sp-taxonomy/src/termstores.ts
+++ b/packages/sp-taxonomy/src/termstores.ts
@@ -1,6 +1,6 @@
 import { extend, getGUID, sanitizeGuid, stringIsNullOrEmpty } from "@pnp/common";
 import { ClientSvcQueryable, IClientSvcQueryable, MethodParams, ObjectPathQueue, method, objConstructor, objectPath, objectProperties, opQuery, property } from "@pnp/sp-clientsvc";
-import { ITermGroup, ITermGroupData, TermGroup } from "./termgroup";
+import { ITermGroup, ITermGroupData, TermGroup, ITermGroups, TermGroups } from "./termgroup";
 import { ITerm, ITerms, Term, Terms } from "./terms";
 import { ITermSet, ITermSets, TermSet, TermSets } from "./termsets";
 import { ChangeInformation, ChangedItem, ILabelMatchInfo } from "./types";
@@ -69,6 +69,7 @@ export interface ITermStore extends IClientSvcQueryable {
     readonly keywordsTermSet: ITermSet;
     readonly orphanedTermsTermSet: ITermSet;
     readonly systemGroup: ITermGroup;
+    readonly groups: ITermGroups;
     addGroup(name: string, id?: string): Promise<ITermGroup & ITermGroupData>;
     addLanguage(lcid: number): Promise<void>;
     commitAll(): Promise<void>;
@@ -126,6 +127,10 @@ export class TermStore extends ClientSvcQueryable implements ITermStore {
 
     public get systemGroup(): ITermGroup {
         return this.getChildProperty(TermGroup, "SystemGroup");
+    }
+
+    public get groups(): ITermGroups {
+        return this.getChildProperty(TermGroups, "Groups");
     }
 
     /**

--- a/packages/sp-taxonomy/tests/termstore.test.ts
+++ b/packages/sp-taxonomy/tests/termstore.test.ts
@@ -65,6 +65,13 @@ describe("TermStore", () => {
             return expect(p).to.eventually.be.fulfilled;
         });
 
+        it("Should get groups", () => {
+
+            const p = taxonomy.getDefaultSiteCollectionTermStore().groups.get();
+
+            return expect(p).to.eventually.be.fulfilled;
+        });
+
         it("Should get a term by id", () => {
 
             if (termId !== null) {


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #420 

#### What's in this Pull Request?

Adds `groups` property to `TermStore` object in `sp-taxonomy`.