### PR TITLE
List subscription clientstate optional

### DIFF
--- a/packages/sp/src/subscriptions.ts
+++ b/packages/sp/src/subscriptions.ts
@@ -24,7 +24,7 @@ export class Subscriptions extends SharePointQueryableCollection {
      *
      * @param notificationUrl The url to receive the notifications
      * @param expirationDate The date and time to expire the subscription in the form YYYY-MM-ddTHH:mm:ss+00:00 (maximum of 6 months)
-     * @param clientState A client specific string (defaults to pnp-js-core-subscription when omitted)
+     * @param clientState A client specific string (optional)
      */
     public add(notificationUrl: string, expirationDate: string, clientState?: string): Promise<SubscriptionAddResult> {
 

--- a/packages/sp/src/subscriptions.ts
+++ b/packages/sp/src/subscriptions.ts
@@ -28,14 +28,17 @@ export class Subscriptions extends SharePointQueryableCollection {
      */
     public add(notificationUrl: string, expirationDate: string, clientState?: string): Promise<SubscriptionAddResult> {
 
-        const postBody = jsS({
-            "clientState": clientState || "pnp-js-core-subscription",
+        const postBody = {
             "expirationDateTime": expirationDate,
             "notificationUrl": notificationUrl,
             "resource": this.toUrl(),
-        });
+        };
 
-        return this.postCore({ body: postBody, headers: { "Content-Type": "application/json" } }).then(result => {
+        if (clientState) {
+            (postBody as any).clientState = clientState;
+        }
+        
+        return this.postCore({ body: jsS(postBody), headers: { "Content-Type": "application/json" } }).then(result => {
 
             return { data: result, subscription: this.getById(result.id) };
         });


### PR DESCRIPTION
Make clientState optional, remove default value "pnp-js-core-subscription"

#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #427

#### What's in this Pull Request?

With this PR it is possible to create list subscription without clientState. Before if clientState was not provided, it defaulted to "pnp-js-core-subscription".

