### PR TITLE
fix for #419, improvement to batch blocking

### DIFF
--- a/packages/graph/src/graphqueryable.ts
+++ b/packages/graph/src/graphqueryable.ts
@@ -142,10 +142,11 @@ export class GraphQueryable<GetType = any> extends ODataQueryable<GraphBatch, Ge
         parser: ODataParser<T>,
         pipeline: Array<(c: RequestContext<T>) => Promise<RequestContext<T>>>): Promise<RequestContext<T>> {
 
-        // TODO:: add batch support
+        const dependencyDispose = this.hasBatch ? this._batchDependency : () => { return; };
+
         return Promise.resolve({
             batch: this.batch,
-            batchDependency: () => void (0),
+            batchDependency: dependencyDispose,
             cachingOptions: this._cachingOptions,
             clientFactory: () => new GraphHttpClient(),
             isBatched: this.hasBatch,

--- a/packages/odata/src/odatabatch.ts
+++ b/packages/odata/src/odatabatch.ts
@@ -98,7 +98,6 @@ export abstract class ODataBatch {
         // we need to check the dependencies twice due to how different engines handle things.
         // We can get a second set of promises added during the first set resolving
         return Promise.all(this._deps)
-            .then(() => Promise.all(this._deps))
             .then(() => this.executeImpl())
             .then(() => Promise.all(this._rDeps))
             .then(() => void (0));

--- a/packages/odata/src/queryable.ts
+++ b/packages/odata/src/queryable.ts
@@ -272,9 +272,15 @@ export abstract class ODataQueryable<BatchType extends ODataBatch, GetType = any
      */
     protected _batch: BatchType | null;
 
+    /**
+     * Allows us to properly block batch execution until everything is loaded
+     */
+    protected _batchDependency: () => void | null;
+
     constructor() {
         super();
         this._batch = null;
+        this._batchDependency = null;
     }
 
     /**
@@ -295,6 +301,7 @@ export abstract class ODataQueryable<BatchType extends ODataBatch, GetType = any
         }
 
         this._batch = batch;
+        this._batchDependency = batch.addDependency();
 
         return this;
     }

--- a/packages/odata/src/queryable.ts
+++ b/packages/odata/src/queryable.ts
@@ -300,8 +300,10 @@ export abstract class ODataQueryable<BatchType extends ODataBatch, GetType = any
             throw Error("This query is already part of a batch.");
         }
 
-        this._batch = batch;
-        this._batchDependency = batch.addDependency();
+        if (objectDefinedNotNull(batch)) {
+            this._batch = batch;
+            this._batchDependency = batch.addDependency();
+        }
 
         return this;
     }

--- a/packages/sp-clientsvc/src/clintsvcqueryable.ts
+++ b/packages/sp-clientsvc/src/clintsvcqueryable.ts
@@ -29,12 +29,19 @@ export class ClientSvcQueryable<GetType = any> extends Queryable<GetType> implem
     /**
      * Tracks the batch of which this query may be part
      */
-    protected _batch: IObjectPathBatch;
+    protected _batch: IObjectPathBatch | null;
+
+    /**
+     * Allows us to properly block batch execution until everything is loaded
+     */
+    protected _batchDependency: () => void | null;
 
     constructor(parent: ClientSvcQueryable | string = "", protected _objectPaths: ObjectPathQueue | null = null) {
         super();
 
         this._selects = [];
+        this._batch = null;
+        this._batchDependency = null;
 
         if (typeof parent === "string") {
 
@@ -83,6 +90,7 @@ export class ClientSvcQueryable<GetType = any> extends Queryable<GetType> implem
         }
 
         this._batch = batch;
+        this._batchDependency = batch.addDependency();
 
         return this;
     }
@@ -291,7 +299,7 @@ export class ClientSvcQueryable<GetType = any> extends Queryable<GetType> implem
                 }
             }
 
-            const dependencyDispose = this.hasBatch ? this.addBatchDependency() : () => { return; };
+            const dependencyDispose = this.hasBatch ? this._batchDependency : () => { return; };
 
             // build our request context
             const context: RequestContext<T> = {

--- a/packages/sp-clientsvc/src/clintsvcqueryable.ts
+++ b/packages/sp-clientsvc/src/clintsvcqueryable.ts
@@ -75,13 +75,6 @@ export class ClientSvcQueryable<GetType = any> extends Queryable<GetType> implem
     /**
      * Adds this query to the supplied batch
      *
-     * @example
-     * ```
-     *
-     * let b = pnp.sp.createBatch();
-     * pnp.sp.web.inBatch(b).get().then(...);
-     * b.execute().then(...)
-     * ```
      */
     public inBatch(batch: IObjectPathBatch): this {
 
@@ -89,8 +82,10 @@ export class ClientSvcQueryable<GetType = any> extends Queryable<GetType> implem
             throw Error("This query is already part of a batch.");
         }
 
-        this._batch = batch;
-        this._batchDependency = batch.addDependency();
+        if (objectDefinedNotNull(batch)) {
+            this._batch = batch;
+            this._batchDependency = batch.addDependency();
+        }
 
         return this;
     }

--- a/packages/sp/src/sharepointqueryable.ts
+++ b/packages/sp/src/sharepointqueryable.ts
@@ -182,7 +182,7 @@ export class SharePointQueryable<GetType = any> extends ODataQueryable<SPBatch, 
         parser: ODataParser<T>,
         pipeline: Array<(c: RequestContext<T>) => Promise<RequestContext<T>>>): Promise<RequestContext<T>> {
 
-        const dependencyDispose = this.hasBatch ? this.addBatchDependency() : () => { return; };
+        const dependencyDispose = this.hasBatch ? this._batchDependency : () => { return; };
 
         return toAbsoluteUrl(this.toUrlAndQuery()).then(url => {
 


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #419 

#### What's in this Pull Request?

Improves how batches are blocked to ensure requests are properly added before the batch is executed. Change is to add the batch dependency when the request is first added to the batch by a call to inBatch. This ensures the batch is holding the dependency and removes all the async timing issues by waiting until toRequestContext.

This approach also removes the need to check the dependencies twice in batch.execute, again due to removing the async issues which existed previously.
