### PR TITLE
added more parameters to list subscription update method

### DIFF
--- a/packages/sp/src/subscriptions.ts
+++ b/packages/sp/src/subscriptions.ts
@@ -61,7 +61,7 @@ export class Subscription extends SharePointQueryableInstance {
       };
 
       if (expirationDate) {
-        postBody.expirationDate = expirationDate;
+        postBody.expirationDateTime = expirationDate;
       }
 
       if (notificationUrl) {

--- a/packages/sp/src/subscriptions.ts
+++ b/packages/sp/src/subscriptions.ts
@@ -51,7 +51,7 @@ export class Subscription extends SharePointQueryableInstance {
     /**
      * Renews this webhook subscription
      *
-     * @param expirationDate The date and time to expire the subscription in the form YYYY-MM-ddTHH:mm:ss+00:00 (maximum of 6 months)
+     * @param expirationDate The date and time to expire the subscription in the form YYYY-MM-ddTHH:mm:ss+00:00 (maximum of 6 months, optional)
      * @param notificationUrl The url to receive the notifications (optional)
      * @param clientState A client specific string (optional)
      */

--- a/packages/sp/src/subscriptions.ts
+++ b/packages/sp/src/subscriptions.ts
@@ -8,10 +8,10 @@ import { jsS } from "@pnp/common";
 @defaultPath("subscriptions")
 export class Subscriptions extends SharePointQueryableCollection {
 
-    /**	  
-     * Returns all the webhook subscriptions or the specified webhook subscription	    
-     *	     
-     * @param subscriptionId The id of a specific webhook subscription to retrieve, omit to retrieve all the webhook subscriptions	   
+    /**
+     * Returns all the webhook subscriptions or the specified webhook subscription
+     *
+     * @param subscriptionId The id of a specific webhook subscription to retrieve, omit to retrieve all the webhook subscriptions
      */
     public getById(subscriptionId: string): Subscription {
         const s = new Subscription(this);
@@ -52,17 +52,30 @@ export class Subscription extends SharePointQueryableInstance {
      * Renews this webhook subscription
      *
      * @param expirationDate The date and time to expire the subscription in the form YYYY-MM-ddTHH:mm:ss+00:00 (maximum of 6 months)
+     * @param notificationUrl The url to receive the notifications (optional)
+     * @param clientState A client specific string (optional)
      */
-    public update(expirationDate: string): Promise<SubscriptionUpdateResult> {
+    public update(expirationDate?: string, notificationUrl?: string, clientState?: string): Promise<SubscriptionUpdateResult> {
 
-        const postBody = jsS({
-            "expirationDateTime": expirationDate,
-        });
+      const postBody: any = {
+      };
 
-        return this.patchCore({ body: postBody, headers: { "Content-Type": "application/json" } }).then(data => {
-            return { data: data, subscription: this };
-        });
-    }
+      if (expirationDate) {
+        postBody.expirationDate = expirationDate;
+      }
+
+      if (notificationUrl) {
+        postBody.notificationUrl = notificationUrl;
+      }
+
+      if (clientState) {
+        postBody.clientState = clientState;
+      }
+
+      return this.patchCore({ body: jsS(postBody), headers: { "Content-Type": "application/json" } }).then(data => {
+          return { data: data, subscription: this };
+      });
+  }
 
     /**
      * Removes this webhook subscription


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

While refactoring the list subscription **add** method, realised that when **updating** the list subscription, you can update all the parameters: **expirationDate** and **notificationUrl** and **clientState**, before it was only possible to update the **expirationDate**. So I made all the parameters optional in the update method. I was wondering should we create methods for each case?

Also this should be backward compatible with earlier PnPjs versions.

