### PR TITLE
fix getParentWeb method

### DIFF
--- a/packages/sp/src/webs.ts
+++ b/packages/sp/src/webs.ts
@@ -111,7 +111,7 @@ export class Web extends SharePointQueryableShareableWeb {
      */
     public getParentWeb(): Promise<{ data: any; web: Web }> {
         return this.select("ParentWeb/Id").expand("ParentWeb").get()
-            .then(({ ParentWeb }) => new Site(this.toUrlAndQuery().split("/_api")[0]).openWebById(ParentWeb.Id));
+            .then(({ ParentWeb }) => ParentWeb ? new Site("").openWebById(ParentWeb.Id) : null);
     }
 
     /**
@@ -593,9 +593,9 @@ export class Web extends SharePointQueryableShareableWeb {
 
     /**
      * Gets hub site data for the current web.
-     * 
-     * @param forceRefresh Default value is false. When false, the data is returned from the server's cache. 
-     * When true, the cache is refreshed with the latest updates and then returned. 
+     *
+     * @param forceRefresh Default value is false. When false, the data is returned from the server's cache.
+     * When true, the cache is refreshed with the latest updates and then returned.
      * Use this if you just made changes and need to see those changes right away.
      */
     public hubSiteData(forceRefresh = false): Promise<void> {

--- a/packages/sp/src/webs.ts
+++ b/packages/sp/src/webs.ts
@@ -111,7 +111,7 @@ export class Web extends SharePointQueryableShareableWeb {
      */
     public getParentWeb(): Promise<{ data: any; web: Web }> {
         return this.select("ParentWeb/Id").expand("ParentWeb").get()
-            .then(({ ParentWeb }) => ParentWeb ? new Site("").openWebById(ParentWeb.Id) : null);
+            .then(({ ParentWeb }) => ParentWeb ? new Site(this.parentUrl).openWebById(ParentWeb.Id) : null);
     }
 
     /**


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #441

#### What's in this Pull Request?

There was error constructing new Site. Also if Web is rootWeb, it does not have ParentWeb, so made it to return null in that case.