### PR TITLE
Fix for batch issues when reusing object instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - @pnp/sp-taxonomy: Add support for add new term from term ([@siata13](https://github.com/siata13)) [[PR](https://github.com/pnp/pnpjs/pull/411)]
 - @pnp/sp: Added support for new location column creation ([@gautamdsheth](https://github.com/gautamdsheth)) [[PR](https://github.com/pnp/pnpjs/pull/413)]
+- @pnp/sp-taxonomy: Adds groups property to TermStore object in sp-taxonomy ([@AJIXuMuK](https://github.com/AJIXuMuK)) [[PR](https://github.com/pnp/pnpjs/pull/421)]
+
+### Changed
+
+- @pnp/sp: Changes clientstate to be optional when creating subscriptions ([@tavikukko](https://github.com/tavikukko)) [[PR](https://github.com/pnp/pnpjs/pull/431)]
+- @pnp/sp: Updates parameters when updating a subscription ([@tavikukko](https://github.com/tavikukko)) [[PR](https://github.com/pnp/pnpjs/pull/434)]
 
 ### Fixed
 
 - @pnp/sp: Fix for parsing html for ClientSidePages [[PR](https://github.com/pnp/pnpjs/pull/412)]
+- @pnp/logging: Fix to ensure logging never throws an exception [[PR](https://github.com/pnp/pnpjs/pull/416)]
+- @pnp/odata: Fix for how batches are prepared to remove timing errors [[PR](https://github.com/pnp/pnpjs/pull/432)]
+- @pnp/sp: Fix for ClientSidePages encoding of * and $ chars [[PR](https://github.com/pnp/pnpjs/pull/436)]
 
 ## 1.2.7 - 2018-12-10
 

--- a/packages/sp-clientsvc/src/objectpath.ts
+++ b/packages/sp-clientsvc/src/objectpath.ts
@@ -150,10 +150,21 @@ export class ObjectPathQueue {
     }
 
     /**
-     * Creates a copy of this ObjectPathQueue
+     * Creates a linked copy of this ObjectPathQueue
+     */
+    public copy(): ObjectPathQueue {
+        const copy = new ObjectPathQueue(this.toArray(), extend({}, this._relationships));
+        copy._contextIndex = this._contextIndex;
+        copy._siteIndex = this._siteIndex;
+        copy._webIndex = this._webIndex;
+        return copy;
+    }
+
+    /**
+     * Creates an independent clone of this ObjectPathQueue
      */
     public clone(): ObjectPathQueue {
-        const clone = new ObjectPathQueue(this.toArray(), extend({}, this._relationships));
+        const clone = new ObjectPathQueue(this.toArray().map(p => Object.assign({}, p)), extend({}, this._relationships));
         clone._contextIndex = this._contextIndex;
         clone._siteIndex = this._siteIndex;
         clone._webIndex = this._webIndex;

--- a/packages/sp-taxonomy/src/termstores.ts
+++ b/packages/sp-taxonomy/src/termstores.ts
@@ -220,7 +220,7 @@ export class TermStore extends ClientSvcQueryable implements ITermStore {
      */
     public getTerms(info: ILabelMatchInfo): ITerms {
 
-        const objectPaths = this._objectPaths.clone();
+        const objectPaths = this._objectPaths.copy();
 
         // this will be the parent of the GetTerms call, but we need to create the input param first
         const parentIndex = objectPaths.lastIndex;
@@ -256,7 +256,7 @@ export class TermStore extends ClientSvcQueryable implements ITermStore {
      */
     public getSiteCollectionGroup(createIfMissing = false): ITermGroup {
 
-        const objectPaths = this._objectPaths.clone();
+        const objectPaths = this._objectPaths.copy();
         const methodParent = objectPaths.lastIndex;
         const siteIndex = objectPaths.siteIndex;
 
@@ -347,7 +347,7 @@ export class TermStore extends ClientSvcQueryable implements ITermStore {
      */
     public updateUsedTermsOnSite(): Promise<void> {
 
-        const objectPaths = this._objectPaths.clone();
+        const objectPaths = this._objectPaths.copy();
         const methodParent = objectPaths.lastIndex;
         const siteIndex = objectPaths.siteIndex;
 
@@ -368,7 +368,7 @@ export class TermStore extends ClientSvcQueryable implements ITermStore {
      */
     public getChanges(info: ChangeInformation): Promise<ChangedItem[]> {
 
-        const objectPaths = this._objectPaths.clone();
+        const objectPaths = this._objectPaths.copy();
         const methodParent = objectPaths.lastIndex;
 
         const inputIndex = objectPaths.add(objConstructor("{1f849fb0-4fcb-4a54-9b01-9152b9e482d3}",


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #419 

#### What's in this Pull Request?

Adds a clone method to ObjectPathQueue and renames the old clone method to copy. The new clone method is used in ClientSvcQuery.send to ensure we are using an independent copy of the object paths for a request when the string ids will be updated.