### PR TITLE
Updated version number in documentation to match released version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,7 +117,7 @@ plugins:
   - search
   - markdownextradata
 extra:
-  version: '1.2.3'
+  version: '1.2.7'
   social:
     - type: 'twitter'
       link: 'https://twitter.com/officedevpnp'


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [X] Documentation update?

#### What's in this Pull Request?

Updated mkdocs.yml with version number matching the latest released version. [https://pnp.github.io/pnpjs/](https://pnp.github.io/pnpjs/) and locally generated documentation was showing version 1.2.3 when the current version is 1.2.7.


