### PR TITLE
Fix for 449, issue with usingCaching not respecting cloned ops

### DIFF
--- a/packages/sp-clientsvc/src/clintsvcqueryable.ts
+++ b/packages/sp-clientsvc/src/clintsvcqueryable.ts
@@ -56,7 +56,7 @@ export class ClientSvcQueryable<GetType = any> extends Queryable<GetType> implem
             this._parentUrl = parent._parentUrl;
             this._url = combine(parent._parentUrl, ProcessQueryPath);
             if (!objectDefinedNotNull(_objectPaths)) {
-                this._objectPaths = parent._objectPaths.copy();
+                this._objectPaths = parent._objectPaths.clone();
             }
             this.configureFrom(parent);
         }
@@ -288,7 +288,7 @@ export class ClientSvcQueryable<GetType = any> extends Queryable<GetType> implem
             if (this._useCaching) {
 
                 // because all the requests use the same url they would collide in the cache we use a special key
-                const cacheKey = `PnPjs.ProcessQueryClient(${getHashCode(this._objectPaths.toBody())})`;
+                const cacheKey = `PnPjs.ProcessQueryClient(${getHashCode(options.body)})`;
 
                 if (objectDefinedNotNull(this._cachingOptions)) {
                     // if our key ends in the ProcessQuery url we overwrite it


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #449

#### What's in this Pull Request?

Updates the toRequestContext method in sp-taxonomy to use the options.body and not regenerate the body, which was causing issues with the previous fix for batching as the original ops instances were getting updated.