### PR TITLE
Remove id as param from contenttypes.add since it's not supported by the SP APIs #457

### DIFF
--- a/packages/sp/src/contenttypes.ts
+++ b/packages/sp/src/contenttypes.ts
@@ -40,7 +40,6 @@ export class ContentTypes extends SharePointQueryableCollection {
     /**
      * Adds a new content type to the collection
      *
-     * @param id The desired content type id for the new content type (also determines the parent content type)
      * @param name The name of the content type
      * @param description The description of the content type
      * @param group The group in which to add the content type
@@ -48,7 +47,6 @@ export class ContentTypes extends SharePointQueryableCollection {
      *
      */
     public add(
-        id: string,
         name: string,
         description = "",
         group = "Custom Content Types",
@@ -57,7 +55,6 @@ export class ContentTypes extends SharePointQueryableCollection {
         const postBody = jsS(Object.assign(metadata("SP.ContentType"), {
             "Description": description,
             "Group": group,
-            "Id": { "StringValue": id },
             "Name": name,
         }, additionalSettings));
 


### PR DESCRIPTION
#### Category
- [?] Bug fix
- [ ] New feature
- [ ] New sample
- [ ] Documentation update

#### Related Issues

https://github.com/pnp/pnpjs/issues/457


