### PR TITLE
Added some HubSite functionality and Types to the SP package fixing #487

### DIFF
--- a/packages/sp/src/hubsites.ts
+++ b/packages/sp/src/hubsites.ts
@@ -1,0 +1,23 @@
+import { SharePointQueryableInstance, SharePointQueryableCollection, defaultPath } from "./sharepointqueryable";
+import { HubSite as IHubSite } from "./types";
+
+/**
+ * Describes a collection of Hub Sites
+ *
+ */
+@defaultPath("_api/hubsites")
+export class HubSites extends SharePointQueryableCollection<IHubSite[]> {
+
+    /**	    
+     * Gets a Hub Site from the collection by id	     
+     *	    
+     * @param id The Id of the Hub Site	    
+     */
+    public getById(id: string): HubSite {
+        return new HubSite(this, `GetById?hubSiteId='${id}'`);
+
+    }
+
+}
+
+export class HubSite extends SharePointQueryableInstance<IHubSite> { }

--- a/packages/sp/src/rest.ts
+++ b/packages/sp/src/rest.ts
@@ -16,6 +16,7 @@ import {
     SPConfiguration,
 } from "./config/splibconfig";
 import { ICachingOptions } from "@pnp/odata";
+import { HubSites } from "./hubsites";
 
 /**
  * Root of the SharePoint REST module
@@ -152,6 +153,13 @@ export class SPRest {
      */
     public get siteDesigns(): SiteDesignsUtilityMethods {
         return this.create(SiteDesigns, "");
+    }
+
+    /**
+     * Access to Hub Site methods
+     */
+    public get hubSites(): HubSites {
+        return this.create(HubSites);
     }
 
     /**

--- a/packages/sp/src/sharepointqueryable.ts
+++ b/packages/sp/src/sharepointqueryable.ts
@@ -264,7 +264,7 @@ export class SharePointQueryableCollection<GetType = any[]> extends SharePointQu
  * Represents an instance that can be selected
  *
  */
-export class SharePointQueryableInstance extends SharePointQueryable {
+export class SharePointQueryableInstance<GetType = any> extends SharePointQueryable<GetType> {
 
     /**
      * Curries the update function into the common pieces

--- a/packages/sp/src/sp.ts
+++ b/packages/sp/src/sp.ts
@@ -247,3 +247,8 @@ export {
     SiteDesignInfo,
     SiteDesignPrincipals,
 } from "./sitedesigns";
+
+export {
+    HubSite,
+    HubSites,
+} from "./hubsites";

--- a/packages/sp/src/types.ts
+++ b/packages/sp/src/types.ts
@@ -1,6 +1,8 @@
 // reference: https://msdn.microsoft.com/en-us/library/office/dn600183.aspx
 import { TypedHash } from "@pnp/common";
 
+import { NavigationNode } from "./navigation";
+
 /**
  * Represents the unique sequential location of a change within the change log.
  */
@@ -1664,4 +1666,24 @@ export interface LikeData {
     id: number;
     email: string;
     creationDate: string;
+}
+
+export interface HubSite {
+    Id: string;
+    Title: string;
+    SiteId: string;
+    TenantInstanceId: string;
+    SiteUrl: string;
+    LogoUrl: string;
+    Description: string;
+    Targets: string;
+}
+
+export interface HubSiteData {
+    ThemeKey: string;
+    Name: string;
+    Url: string;
+    LogoUrl: string;
+    UsesMetadataNavigation: boolean;
+    Navigation?: NavigationNode;
 }

--- a/packages/sp/src/webs.ts
+++ b/packages/sp/src/webs.ts
@@ -11,7 +11,7 @@ import { ContentTypes } from "./contenttypes";
 import { RoleDefinitions } from "./roles";
 import { File } from "./files";
 import { extractWebUrl } from "./utils/extractweburl";
-import { ChangeQuery, StorageEntity } from "./types";
+import { ChangeQuery, StorageEntity, HubSiteData as IHubSiteData } from "./types";
 import { SiteUsers, SiteUser, CurrentUser, SiteUserProps } from "./siteusers";
 import { UserCustomActions } from "./usercustomactions";
 import { odataUrlFrom } from "./odata";
@@ -598,7 +598,7 @@ export class Web extends SharePointQueryableShareableWeb {
      * When true, the cache is refreshed with the latest updates and then returned.
      * Use this if you just made changes and need to see those changes right away.
      */
-    public hubSiteData(forceRefresh = false): Promise<void> {
+    public hubSiteData(forceRefresh = false): Promise<IHubSiteData> {
         return this.clone(Web, `hubSiteData(${forceRefresh})`).get();
     }
 


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #487

#### What's in this Pull Request?
- Addition of hubsites.ts, getting all hubsites and getting a hubsite by Id
- Changed in sharepointqueryable.ts so `SharePointQueryableInstance` can "have a Type"
- Created Types for `HubSite` and `HubsiteData`
- Using `HubSiteData` as return value instead of void in web.hubSiteData

Please check it out @patrick-rodgers if I am far off :)
Seems to be working while serving in the browser at least.

Maybe I should add some documentation as well.

/Simon