### PR TITLE
Update storage.ts to handle getter promise reject.

### DIFF
--- a/packages/common/src/storage.ts
+++ b/packages/common/src/storage.ts
@@ -99,7 +99,7 @@ export class PnPClientStorageWrapper implements PnPClientStore {
                 return d;
             });
         } else {
-            return o;
+            return Promise.resolve(o);
         }
     }
 

--- a/packages/common/src/storage.ts
+++ b/packages/common/src/storage.ts
@@ -90,7 +90,7 @@ export class PnPClientStorageWrapper implements PnPClientStore {
         if (!this.enabled) {
             return getter();
         }
-        
+
         const o = this.get<T>(key);
 
         if (o == null) {

--- a/packages/common/src/storage.ts
+++ b/packages/common/src/storage.ts
@@ -90,20 +90,17 @@ export class PnPClientStorageWrapper implements PnPClientStore {
         if (!this.enabled) {
             return getter();
         }
+        
+        const o = this.get<T>(key);
 
-        return new Promise((resolve) => {
-
-            const o = this.get<T>(key);
-
-            if (o == null) {
-                getter().then((d) => {
-                    this.put(key, d, expire);
-                    resolve(d);
-                });
-            } else {
-                resolve(o);
-            }
-        });
+        if (o == null) {
+            return getter().then((d) => {
+                this.put(key, d, expire);
+                return d;
+            });
+        } else {
+            return o;
+        }
     }
 
     /**


### PR DESCRIPTION
Hello,

When using PnPClientStorageWrapper, sometimes the getter function may return a rejected promise and there was no way to know.

The proposed file change should fix that.

Thanks for considering it,
Charles

#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

Didn't find an existing issue.


