### PR TITLE
Feature : Added support for HubSiteId while creating modern sites

### DIFF
--- a/packages/sp/docs/sites.md
+++ b/packages/sp/docs/sites.md
@@ -166,6 +166,7 @@ Creates a modern communication site.
 ||||                               Showcase: 6142d2a0-63a5-4ba0-aede-d9fefca2c767
 ||||                               Blank: f6cc5403-0d63-442e-96c0-285923709ffc 
 ||||
+| hubSiteId | string | no | The Guid of the already existing Hub site
 
 ```TypeScript
 
@@ -178,7 +179,8 @@ sp.site.createCommunicationSite(
             "https://tenant.sharepoint.com/sites/commSite",
             "Description",
             "HBI",
-            "f6cc5403-0d63-442e-96c0-285923709ffc").then(d => {
+            "f6cc5403-0d63-442e-96c0-285923709ffc",
+            "a00ec589-ea9f-4dba-a34e-67e78d41e509").then(d => {
                 console.log(d);
             });
 
@@ -201,7 +203,7 @@ Creates a modern team site backed by O365 group.
 | description | string | no | The description of the modern team site. |
 | classification | string | no | The Site classification to use. For instance 'Contoso Classified'. See https://www.youtube.com/watch?v=E-8Z2ggHcS0 for more information
 | owners | string array (string[]) | no | The Owners of the site to be created
-
+| hubSiteId | string | no | The Guid of the already existing Hub site
 
 ```TypeScript
 
@@ -214,7 +216,8 @@ sp.site.createModernTeamSite(
         1033,
         "description",
         "HBI",
-        ["user1@tenant.onmicrosoft.com","user2@tenant.onmicrosoft.com","user3@tenant.onmicrosoft.com"])
+        ["user1@tenant.onmicrosoft.com","user2@tenant.onmicrosoft.com","user3@tenant.onmicrosoft.com"],
+        "a00ec589-ea9f-4dba-a34e-67e78d41e509")
         .then(d => {
             console.log(d);
         });

--- a/packages/sp/src/site.ts
+++ b/packages/sp/src/site.ts
@@ -166,11 +166,13 @@ export class Site extends SharePointQueryableInstance {
         description = "",
         classification = "",
         siteDesignId = "00000000-0000-0000-0000-000000000000",
+        hubSiteId = "00000000-0000-0000-0000-000000000000",
     ): Promise<void> {
 
         const props = {
             Classification: classification,
             Description: description,
+            HubSiteId: hubSiteId,
             Lcid: lcid,
             ShareByEmailEnabled: shareByEmailEnabled,
             SiteDesignId: siteDesignId,
@@ -221,6 +223,7 @@ export class Site extends SharePointQueryableInstance {
         description = "",
         classification = "",
         owners?: string[],
+        hubSiteId = "00000000-0000-0000-0000-000000000000",
     ): Promise<void> {
 
         const postBody = jsS({
@@ -230,7 +233,7 @@ export class Site extends SharePointQueryableInstance {
             optionalParams: {
                 Classification: classification,
                 CreationOptions: {
-                    "results": [`SPSiteLanguage:${lcid}`],
+                    "results": [`SPSiteLanguage:${lcid}`, `HubSiteId:${hubSiteId}`],
                 },
                 Description: description,
                 Owners: {


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

NA

#### What's in this Pull Request?

This PR adds the ability to create the modern sites like communication and team sites(O365 group based) and associate them directly to an already existing Hub Site at the time of creation