### PR TITLE
People Graph functionality

### DIFF
--- a/packages/graph/docs/people.md
+++ b/packages/graph/docs/people.md
@@ -1,0 +1,16 @@
+# @pnp/graph/people
+
+The ability to retrieve a list of person objects ordered by their relevance to the user, which is determined by the user's communication and collaboration patterns, and business relationships.
+
+## Get all of the people
+
+Using the people.get() you can retrieve a list of person objects ordered by their relevance to the user.
+
+```TypeScript
+import { graph } from "@pnp/graph";
+
+const people = await graph.users.getById('user@tenant.onmicrosoft.com').people.get();
+
+const people = await graph.me.people.get();
+
+```

--- a/packages/graph/src/graph.ts
+++ b/packages/graph/src/graph.ts
@@ -41,3 +41,5 @@ export * from "./directoryobjects";
 export * from "./invitations";
 
 export * from "./subscriptions";
+
+export * from "./people";

--- a/packages/graph/src/people.ts
+++ b/packages/graph/src/people.ts
@@ -1,0 +1,5 @@
+import { GraphQueryableCollection, defaultPath } from "./graphqueryable";
+import { Person as IPerson } from "@microsoft/microsoft-graph-types";
+
+@defaultPath("people")
+export class People extends GraphQueryableCollection<IPerson[]> { }

--- a/packages/graph/src/users.ts
+++ b/packages/graph/src/users.ts
@@ -11,6 +11,7 @@ import {
 } from "@microsoft/microsoft-graph-types";
 import { Messages, MailboxSettings, MailFolders } from "./messages";
 import { DirectoryObjects } from "./directoryobjects";
+import { People } from "./people";
 
 /**
  * Describes a collection of Users objects
@@ -174,5 +175,12 @@ export class User extends GraphQueryableInstance<IUser> {
         return this.clone(User, "sendMail").postCore({
             body: jsS(message),
         });
+    }
+
+    /**
+    * People ordered by their relevance to the user
+    */
+    public get people(): People {
+        return new People(this);
     }
 }


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [X] Documentation update?

The ability to retrieve a list of person objects ordered by their relevance to the user, which is determined by the user's communication and collaboration patterns, and business relationships.