### PR TITLE
Fixes issues with batching and cloned requests using sub-requests internally

### DIFF
--- a/debug/launch/sp.ts
+++ b/debug/launch/sp.ts
@@ -1,8 +1,8 @@
 import { Logger, LogLevel } from "@pnp/logging";
 import { sp } from "@pnp/sp";
-import { SPFetchClient, SPOAuthEnv } from "@pnp/nodejs";
+import { SPFetchClient, SPOAuthEnv /*, setProxyUrl*/ } from "@pnp/nodejs";
 
-declare var process: { exit(code?: number): void };
+declare var process: { env: any, exit(code?: number): void };
 
 export async function Example(settings: any) {
 
@@ -10,6 +10,13 @@ export async function Example(settings: any) {
     sp.setup({
         sp: {
             fetchClientFactory: () => {
+                // UNSAFE - USE NODE_TLS_REJECT_UNAUTHORIZED FOR TESTING ONLY
+                // process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+                // you can set a proxy to examine traffic or for use in a corp environment
+                // this example users fiddler
+                // setProxyUrl("http://127.0.0.1:8888");
+
                 return new SPFetchClient(settings.testing.sp.url, settings.testing.sp.id, settings.testing.sp.secret, SPOAuthEnv.SPO);
             },
         },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnp/monorepo",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2-0",
   "description": "A JavaScript library for SharePoint development.",
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "1.3.2-0",
   "description": "A JavaScript library for SharePoint development.",
-  "dependencies": {},
   "devDependencies": {
     "@microsoft/microsoft-graph-types": "1.5.0",
     "@types/adal-angular": "1.0.1",
@@ -13,6 +12,7 @@
     "@types/jsonwebtoken": "^7.2.8",
     "@types/mocha": "5.2.5",
     "@types/node": "10.11.3",
+    "@types/node-fetch": "^2.1.7",
     "@types/sharepoint": "2016.1.1",
     "@types/webpack": "4.4.17",
     "@types/whatwg-fetch": "0.0.33",
@@ -28,6 +28,7 @@
     "gulp-mocha": "5.0.0",
     "gulp-replace": "1.0.0",
     "gulp-tslint": "8.1.3",
+    "https-proxy-agent": "2.2.1",
     "jsonwebtoken": "8.3.0",
     "mocha": "5.2.0",
     "node-fetch": "2.2.0",

--- a/packages/graph/src/onedrive.ts
+++ b/packages/graph/src/onedrive.ts
@@ -1,5 +1,5 @@
 import { GraphQueryableInstance, GraphQueryableCollection, defaultPath } from "./graphqueryable";
-import { DriveItem as IDriveItem, Drive as IDrive } from "@microsoft/microsoft-graph-types";
+import { Drive as IDrive } from "@microsoft/microsoft-graph-types";
 import { jsS, TypedHash, extend } from "@pnp/common";
 
 export interface IDriveItemsMethods {
@@ -88,7 +88,7 @@ export class DriveItems extends GraphQueryableCollection implements IDriveItemsM
  * Describes a Drive Item instance
  *
  */
-export class DriveItem extends GraphQueryableInstance<IDriveItem> {
+export class DriveItem extends GraphQueryableInstance<any> {
 
     public get children(): Children {
         return new Children(this);
@@ -150,7 +150,7 @@ export class Children extends GraphQueryableCollection {
     * @param name The name of the Drive Item.
     * @param properties Type of Drive Item to create.
     * */
-    public add(name: string, driveItemType: IDriveItem): Promise<IDriveItemAddResult> {
+    public add(name: string, driveItemType: any): Promise<IDriveItemAddResult> {
 
         const postBody = extend({
             name: name,
@@ -183,6 +183,6 @@ export class DriveSearch extends GraphQueryableInstance { }
 export class Thumbnails extends GraphQueryableInstance { }
 
 export interface IDriveItemAddResult {
-    data: IDriveItem;
+    data: any;
     driveItem: DriveItem;
 }

--- a/packages/nodejs/docs/index.md
+++ b/packages/nodejs/docs/index.md
@@ -15,6 +15,7 @@ exported functionality.
 * [AdalFetchClient](adal-fetch-client.md)
 * [SPFetchClient](sp-fetch-client.md)
 * [BearerTokenFetchClient](bearer-token-fetch-client.md)
+* [Using A Proxy](proxy.md)
 
 ## UML
 ![Graphical UML diagram](../../documentation/img/pnpjs-nodejs-uml.svg)

--- a/packages/nodejs/docs/proxy.md
+++ b/packages/nodejs/docs/proxy.md
@@ -1,0 +1,46 @@
+# @pnp/nodejs/proxy
+
+_Added in 1.3.2_
+
+In some cases when deploying on node you may need to use a proxy as governed by corporate policy, or perhaps you want to examine the traffic using a tool such as Fiddler. In the 1.3.2 relesae we introduced the ability to use a proxy with the @pnp/nodejs library.
+
+## Basic Usage
+
+You need to import the new `setProxyUrl` function from the library and call it with your proxy url. Once done an [https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent) will be used with each request. This works across all clients within the @pnp/nodejs library.
+
+```TypeScript
+import { SPFetchClient, SPOAuthEnv, setProxyUrl } from "@pnp/nodejs";
+
+sp.setup({
+    sp: {
+        fetchClientFactory: () => {
+
+            // call the set proxy url function and it will be used for all requests regardless of client
+            setProxyUrl("{your proxy url}");
+            return new SPFetchClient(settings.testing.sp.url, settings.testing.sp.id, settings.testing.sp.secret, SPOAuthEnv.SPO);
+        },
+    },
+});
+```
+
+## Use with Fiddler
+
+To get Fiddler to work you may need to set an environment variable. __This should only be done for testing!__
+
+```TypeScript
+import { SPFetchClient, SPOAuthEnv, setProxyUrl } from "@pnp/nodejs";
+
+sp.setup({
+    sp: {
+        fetchClientFactory: () => {
+
+            // ignore certificate errors: ONLY FOR TESTING!!
+            process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+            // this is my fiddler url locally
+            setProxyUrl("http://127.0.0.1:8888");
+            return new SPFetchClient(settings.testing.sp.url, settings.testing.sp.id, settings.testing.sp.secret, SPOAuthEnv.SPO);
+        },
+    },
+});
+```         

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -6,6 +6,7 @@
   "typings": "./index",
   "dependencies": {
     "adal-node": "0.1.28",
+    "https-proxy-agent": "2.2.1",
     "jsonwebtoken": "8.3.0",
     "node-fetch": "2.2.0",
     "tslib": "1.9.3"

--- a/packages/nodejs/src/net/adalfetchclient.ts
+++ b/packages/nodejs/src/net/adalfetchclient.ts
@@ -1,6 +1,4 @@
-declare var require: (path: string) => any;
 import { AuthenticationContext } from "adal-node";
-const nodeFetch = require("node-fetch").default;
 import { AADToken } from "../types";
 import {
     combine,
@@ -9,6 +7,7 @@ import {
     isUrlAbsolute,
     extend,
 } from "@pnp/common";
+import { fetch } from "./fetch";
 
 export class AdalFetchClient implements HttpClientImpl {
 
@@ -43,7 +42,7 @@ export class AdalFetchClient implements HttpClientImpl {
 
             options.headers.set("Authorization", `${token.tokenType} ${token.accessToken}`);
 
-            return nodeFetch(url, options);
+            return fetch(url, options);
         });
     }
 

--- a/packages/nodejs/src/net/bearertokenfetchclient.ts
+++ b/packages/nodejs/src/net/bearertokenfetchclient.ts
@@ -1,7 +1,5 @@
-declare var require: (path: string) => any;
-
 import { HttpClientImpl, mergeHeaders, FetchOptions } from "@pnp/common";
-const nodeFetch = require("node-fetch").default;
+import { fetch } from "./fetch";
 
 /**
  * Makes requests using the fetch API adding the supplied token to the Authorization header
@@ -28,6 +26,6 @@ export class BearerTokenFetchClient implements HttpClientImpl {
 
         options.headers = headers;
 
-        return nodeFetch(url, options);
+        return fetch(url, options);
     }
 }

--- a/packages/nodejs/src/net/fetch.ts
+++ b/packages/nodejs/src/net/fetch.ts
@@ -1,0 +1,9 @@
+import { configureProxyOptions } from "./proxy";
+import { default as nodeFetch } from "node-fetch";
+
+export function fetch(url: string, options: any): Promise<any> {
+
+    options = configureProxyOptions(options);
+
+    return nodeFetch(url, options);
+}

--- a/packages/nodejs/src/net/nodefetchclient.ts
+++ b/packages/nodejs/src/net/nodefetchclient.ts
@@ -1,7 +1,6 @@
-declare var require: (path: string) => any;
 import { HttpClientImpl } from "@pnp/common";
 import { Logger, LogLevel } from "@pnp/logging";
-const nodeFetch = require("node-fetch").default;
+import { fetch } from "./fetch";
 
 /**
  * Payload from transient errors
@@ -34,7 +33,7 @@ export class NodeFetchClient implements HttpClientImpl {
             try {
 
                 // Try to make the request...
-                return await nodeFetch(url, options || {});
+                return await fetch(url, options || {});
 
             } catch (err) {
 
@@ -55,10 +54,10 @@ export class NodeFetchClient implements HttpClientImpl {
                     if (this.shouldRetry(retry)) {
                         await this.delay(retry.retryInterval);
                         return await wrapper(retry);
-                    } else { // max amount of retries reached, so throw the error
-                        throw err;
                     }
                 }
+
+                throw err;
             }
         };
 

--- a/packages/nodejs/src/net/proxy.ts
+++ b/packages/nodejs/src/net/proxy.ts
@@ -1,0 +1,25 @@
+import { stringIsNullOrEmpty, mergeOptions } from "@pnp/common";
+// @ts-ignore
+import * as HttpProxyAgent from "https-proxy-agent";
+
+let proxyUrl = "";
+
+export function configureProxyOptions<T>(opts: T): T & { agent?: any } {
+
+    if (!stringIsNullOrEmpty(proxyUrl)) {
+        mergeOptions(opts, <any>{
+            agent: new HttpProxyAgent(proxyUrl),
+        });
+    }
+
+    return opts;
+}
+
+/**
+ * Sets the given url as a proxy on all requests
+ * 
+ * @param url The url of the proxy
+ */
+export function setProxyUrl(url: string) {
+    proxyUrl = url;
+}

--- a/packages/nodejs/src/nodejs.ts
+++ b/packages/nodejs/src/nodejs.ts
@@ -20,3 +20,4 @@ const NodeFetch = require("node-fetch");
 export { AADToken, SPOAuthEnv } from "./types";
 export { ProviderHostedRequestContext } from "./providerhosted";
 export * from "./net/index";
+export { setProxyUrl } from "./net/proxy";

--- a/packages/odata/src/odatabatch.ts
+++ b/packages/odata/src/odatabatch.ts
@@ -98,6 +98,7 @@ export abstract class ODataBatch {
         // we need to check the dependencies twice due to how different engines handle things.
         // We can get a second set of promises added during the first set resolving
         return Promise.all(this._deps)
+            .then(() => Promise.all(this._deps))
             .then(() => this.executeImpl())
             .then(() => Promise.all(this._rDeps))
             .then(() => void (0));

--- a/packages/odata/src/queryable.ts
+++ b/packages/odata/src/queryable.ts
@@ -302,7 +302,6 @@ export abstract class ODataQueryable<BatchType extends ODataBatch, GetType = any
 
         if (objectDefinedNotNull(batch)) {
             this._batch = batch;
-            this._batchDependency = batch.addDependency();
         }
 
         return this;
@@ -344,6 +343,15 @@ export abstract class ODataQueryable<BatchType extends ODataBatch, GetType = any
 
     protected putCore<T = any>(options: FetchOptions = {}, parser: ODataParser<T> = new ODataDefaultParser()): Promise<T> {
         return super.putCore<T>(options, parser);
+    }
+
+    protected reqImpl<T>(method: string, options: FetchOptions = {}, parser: ODataParser<T>): Promise<T> {
+
+        if (this.hasBatch) {
+            this._batchDependency = this.addBatchDependency();
+        }
+
+        return super.reqImpl(method, options, parser);
     }
 
     /**

--- a/packages/sp/src/items.ts
+++ b/packages/sp/src/items.ts
@@ -130,19 +130,7 @@ export class Items extends SharePointQueryableCollection {
 
             const postBody = jsS(extend(metadata(listItemEntityType), properties));
 
-            // we need to create a compound dependency clearing function to clear both the batch dependency assigned to this object
-            // and the one created during the clone. See https://github.com/pnp/pnpjs/issues/468 for details.
-            const clonedReq = this.clone(Items, "");
-            if (clonedReq.hasBatch) {
-                const r = clonedReq._batchDependency;
-                const compoundDep = () => {
-                    this._batchDependency();
-                    r();
-                };
-                clonedReq._batchDependency = compoundDep;
-            }
-
-            const promise = clonedReq.postCore<{ Id: number }>({ body: postBody }).then((data) => {
+            const promise = this.clone(Items, "").postCore<{ Id: number }>({ body: postBody }).then((data) => {
                 return {
                     data: data,
                     item: this.getById(data.Id),

--- a/packages/sp/src/rest.ts
+++ b/packages/sp/src/rest.ts
@@ -163,6 +163,15 @@ export class SPRest {
     }
 
     /**
+     * Gets the Web instance representing the tenant app catalog web
+     */
+    public getTenantAppCatalogWeb(): Promise<Web> {
+        return this.create(Web, "_api/SP_TenantSettings_Current").get<{ CorporateCatalogUrl: string }>().then(r => {
+            return (new Web(r.CorporateCatalogUrl)).configure(this._options);
+        });
+    }
+
+    /**
      * Handles creating and configuring the objects returned from this class
      * 
      * @param fm The factory method used to create the instance

--- a/packages/sp/src/types.ts
+++ b/packages/sp/src/types.ts
@@ -1680,10 +1680,14 @@ export interface HubSite {
 }
 
 export interface HubSiteData {
-    ThemeKey: string;
-    Name: string;
-    Url: string;
-    LogoUrl: string;
-    UsesMetadataNavigation: boolean;
-    Navigation?: NavigationNode;
+    headerEmphasis: string | null;
+    logoUrl: string | null;
+    megaMenuEnabled: boolean;
+    name: string;
+    navigation: NavigationNode[];
+    requiresJoinApproval: boolean;
+    siteDesignId: string;
+    themeKey: string | null;
+    url: string;
+    usesMetadataNavigation: boolean;
 }

--- a/packages/sp/src/webs.ts
+++ b/packages/sp/src/webs.ts
@@ -625,8 +625,8 @@ export class Web extends SharePointQueryableShareableWeb {
      * When true, the cache is refreshed with the latest updates and then returned.
      * Use this if you just made changes and need to see those changes right away.
      */
-    public hubSiteData(forceRefresh = false): Promise<IHubSiteData> {
-        return this.clone(Web, `hubSiteData(${forceRefresh})`).get();
+    public async hubSiteData(forceRefresh = false): Promise<IHubSiteData> {
+        return this.clone(Web, `hubSiteData(${forceRefresh})`).get().then(r => JSON.parse(r));
     }
 
     /**

--- a/packages/sp/tests/batch.test.ts
+++ b/packages/sp/tests/batch.test.ts
@@ -105,5 +105,40 @@ describe("Batching", () => {
                 });
             })).to.eventually.eql([1, 2, 3]);
         });
+
+        it("Should execute batches that have internally cloned requests but aren't items.add", () => {
+
+            const web = new Web(testSettings.sp.webUrl);
+
+            const order = [];
+            let groupId = -1;
+            let loginName = "";
+
+            const batch = web.createBatch();
+
+            expect(Promise.all([
+                web.associatedVisitorGroup.select("id").get().then(r => groupId = r.Id),
+                web.siteUsers.top(1).select("loginName").get().then(r => loginName = r[0].LoginName),
+            ]).then(() => {
+
+                web.siteGroups.getById(groupId).users.inBatch(batch).get().then(() => {
+                    order.push(1);
+                });
+
+                web.siteGroups.getById(groupId).users.inBatch(batch).add(loginName).then(() => {
+                    order.push(2);
+                });
+
+                web.siteGroups.getById(groupId).users.inBatch(batch).get().then(() => {
+                    order.push(3);
+                });
+
+                return batch.execute().then(() => {
+                    order.push(4);
+                    return order;
+                });
+
+            })).to.eventually.eql([1, 2, 3, 4]);
+        });
     }
 });


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #564 
fixes #570
fixes #579
fixes #582 

#### What's in this Pull Request?

User found issue with batching related to a cloned request that also has an internal request and batching such as:

```TypeScript
    public add(loginName: string): Promise<SiteUser> {
        return this.clone(SiteUsers, null).postCore({
            body: jsS(extend(metadata("SP.User"), { LoginName: loginName })),
        }).then(() => this.getByLoginName(loginName));
    }
```

So what was happening is that the batch was blocked on resolving due to "this" having added a batch dependency that is never resolved AND the batch dependency that is resolved resulting from the clone process.

Fix is to add the dependency for the batch when it is sent in reqImpl that all requests pass through.


