### PR TITLE
adding support for azure ad client credentials with certificate oauth flow

### DIFF
--- a/packages/nodejs/docs/adal-certificate-fetch-client.md
+++ b/packages/nodejs/docs/adal-certificate-fetch-client.md
@@ -1,0 +1,41 @@
+# @pnp/nodejs/adalcertificatefetchclient
+
+The AdalCertificateFetchClient class depends on the adal-node package to authenticate against Azure AD using the client credentials with a client certificate flow.  The example below
+outlines usage with the @pnp/graph library, though it would work in any case where an Azure AD Bearer token is expected.
+
+```TypeScript
+import { AdalCertificateFetchClient } from "@pnp/nodejs";
+import { graph } from "@pnp/graph";
+import * as fs from "fs";
+import * as path from "path";
+
+// Get the private key from a file (Assuming it's a .pem file)
+const keyPemFile = "/path/to/privatekey.pem";
+const privateKey = fs.readFileSync(
+    path.resolve(__dirname, keyPemFile), 
+    { encoding : 'utf8'}
+);
+
+// setup the client using graph setup function
+graph.setup({
+    graph: {
+        fetchClientFactory: () => {
+            return new AdalCertificateFetchClient(
+                "{tenant id}", 
+                "{app id}", 
+                "{certificate thumbprint}",
+                privateKey);
+        },
+    },
+});
+
+// execute a library request as normal
+graph.groups.get().then(g => {
+
+    console.log(JSON.stringify(g, null, 4));
+
+}).catch(e => {
+
+    console.error(e);
+});
+```

--- a/packages/nodejs/src/net/adalcertificatefetchclient.ts
+++ b/packages/nodejs/src/net/adalcertificatefetchclient.ts
@@ -1,0 +1,102 @@
+import { AuthenticationContext, TokenResponse, ErrorResponse } from "adal-node";
+import {
+    combine,
+    objectDefinedNotNull,
+    HttpClientImpl,
+    isUrlAbsolute,
+    extend,
+} from "@pnp/common";
+import { NodeFetchClient } from ".";
+
+/**
+ * 
+ * Creates a fetch client that will aquire an access token using the client credentials
+ * flow with a certificate as the credentials.  Used for app only or server-to-server api
+ * requests.
+ * 
+ * See https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-oauth2-client-creds-grant-flow#service-to-service-access-token-request
+ */
+export class AdalCertificateFetchClient implements HttpClientImpl  {
+
+    private _authContext: AuthenticationContext;
+
+    /**
+     * 
+     * @param _tenant - Azure AD tenant id (guid)
+     * @param _clientId - Client Id from Azure AD app registration
+     * @param _thumbprint - Thumbprint of the client certificate
+     * @param _privateKey - The private key for the client certificate used to sign requests
+     * @param _resource - The resource the application is requesting access to i.e. https://graph.microsoft.com, https://<tenant>.sharepoint.com, etc
+     * @param _authority - OAuth 2 authority.  Defaults to https://login.windows.net as is the authority in most cases
+     * @param _fetchClient - The fetch client implementation to use when making HTTP request.  Defautls to NodeFetchClient to provide transient retries.
+     */
+    constructor(
+        private _tenant: string,
+        private _clientId: string,
+        private _thumbprint: string,
+        private _privateKey: string,
+        private _resource = "https://graph.microsoft.com",
+        private _authority = "https://login.windows.net",
+        protected _fetchClient: HttpClientImpl = new NodeFetchClient(),
+    ) {
+
+            this._authContext = new AuthenticationContext(combine(this._authority, this._tenant));
+
+    }
+
+    public async fetch(url: string, options: any = {}): Promise<Response> {
+
+        if (!objectDefinedNotNull(options)) {
+            options = {
+                headers: new Headers(),
+            };
+        } else if (!objectDefinedNotNull(options.headers)) {
+            options = extend(options, {
+                headers: new Headers(),
+            });
+        }
+
+        if (!isUrlAbsolute(url)) {
+            url = combine(this._resource, url);
+        }
+
+        const token = await this.acquireToken();
+
+        options.headers.set("Authorization", `${token.tokenType} ${token.accessToken}`);
+
+        return await this._fetchClient.fetch(url, options);
+
+    }
+
+    public async acquireToken(): Promise<TokenResponse> {
+
+        return new Promise<TokenResponse>((resolve, reject) => {
+
+            this._authContext.acquireTokenWithClientCertificate(
+                this._resource,
+                this._clientId,
+                this._privateKey,
+                this._thumbprint,
+                (err: Error, token: TokenResponse | ErrorResponse) => {
+
+                    if (err) {
+                        reject(err);
+                        return;
+                    }
+
+                    if ((token as ErrorResponse).error) {
+                        const tokenError = token as ErrorResponse;
+                        reject(new Error(`Error aquiring token.  Error: '${tokenError.error}' Error Description: ${tokenError.errorDescription}`));
+                        return;
+                    }
+
+                    resolve(token as TokenResponse);
+
+                },
+            );
+
+        });
+
+    }
+
+}

--- a/packages/nodejs/src/net/index.ts
+++ b/packages/nodejs/src/net/index.ts
@@ -1,4 +1,5 @@
 export { AdalFetchClient } from "./adalfetchclient";
+export { AdalCertificateFetchClient } from "./adalcertificatefetchclient";
 export { BearerTokenFetchClient} from "./bearertokenfetchclient";
 export { NodeFetchClient } from "./nodefetchclient";
 export { SPFetchClient } from "./spfetchclient";


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x ] New feature?
- [ ] New sample?
- [x ] Documentation update?

#### Related Issues

Related to #697

#### What's in this Pull Request?
Adding AdalCertificateFetchClient to wrap the adal-node "acquireTokenWithClientCertificate" function in order to support the client credentials with a certificate flow i.e., server-to-server.  Updated the documentation to reflect the new fetch client class.
