### PR TITLE
SP queryable: fix alias matching regex

### DIFF
--- a/packages/sp/src/sharepointqueryable.ts
+++ b/packages/sp/src/sharepointqueryable.ts
@@ -88,7 +88,8 @@ export class SharePointQueryable<GetType = any> extends ODataQueryable<SPBatch, 
 
         const aliasedParams = new Map<string, string>(this.query);
 
-        let url = this.toUrl().replace(/'!(@.*?)::(.*?)'/ig, (match, labelName, value) => {
+        // This regex uses negative lookbehind and lookahead to include escaped apostrophes in the value
+        let url = this.toUrl().replace(/'!(@.*?)::(.*?)(?<!')'(?!')/ig, (match, labelName, value) => {
             Logger.write(`Rewriting aliased parameter from match ${match} to label: ${labelName} value: ${value}`, LogLevel.Verbose);
             aliasedParams.set(labelName, `'${value}'`);
             return labelName;


### PR DESCRIPTION
The alias matching regex fails for values with embedded apostrophes, even if they are escaped by doubling them.

#### Category
- [x] Bug fix?

#### Related Issues

fixes #772 for Chrome and Node.js

#### What's in this Pull Request?

alias matching happens after URLifying, so embedded apostrophes need to have been escaped by doubling them. This changes the regex so embedded apostrophes are part of the name

HOWEVER. This uses lookbehind, which only works in chrome and nodejs. So it's not really the perfect solution.

What would help is that all arguments that will become aliases will have the `'` changed to `%27%27` but then that can't be double-encoded as will happen in v2.