### PR TITLE
Map user photo endpoint

### DIFF
--- a/packages/graph/src/users.ts
+++ b/packages/graph/src/users.ts
@@ -12,7 +12,7 @@ import {
 import { Messages, MailboxSettings, MailFolders } from "./messages";
 import { DirectoryObjects } from "./directoryobjects";
 import { People } from "./people";
-import { Photo } from './photos';
+import { Photo } from "./photos";
 
 import { InsightsMethods, Insights } from "./insights";
 

--- a/packages/graph/src/users.ts
+++ b/packages/graph/src/users.ts
@@ -49,14 +49,14 @@ export class User extends GraphQueryableInstance<IUser> {
     public get contacts(): Contacts {
         return new Contacts(this);
     }
-    
+
      /**
      * The photo associated with the user
      */
     public get photo(): Photo {
         return new Photo(this);
     }
-    
+
     /**
     * The Teams associated with the user
     */

--- a/packages/graph/src/users.ts
+++ b/packages/graph/src/users.ts
@@ -12,6 +12,7 @@ import {
 import { Messages, MailboxSettings, MailFolders } from "./messages";
 import { DirectoryObjects } from "./directoryobjects";
 import { People } from "./people";
+import { Photo } from './photos';
 
 import { InsightsMethods, Insights } from "./insights";
 
@@ -48,6 +49,14 @@ export class User extends GraphQueryableInstance<IUser> {
     public get contacts(): Contacts {
         return new Contacts(this);
     }
+    
+     /**
+     * The photo associated with the user
+     */
+    public get photo(): Photo {
+        return new Photo(this);
+    }
+    
     /**
     * The Teams associated with the user
     */


### PR DESCRIPTION
Add missing `User#photo` to get the photo for a user.

#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

Adds functionality enquired about in https://github.com/pnp/pnpjs/issues/693#issue-445355847

#### What's in this Pull Request?

The endpoint `/users/$id/photo` was not mapped. This maps the endpoint.
