### PR TITLE
Removed .only() from social sub-module test file

### DIFF
--- a/test/sp/social.ts
+++ b/test/sp/social.ts
@@ -25,7 +25,7 @@ describe("Social", function () {
       const f = await sp.social.follow(actor);
       return expect(f).to.not.be.null;
     });
-    it.only("is followed (test site)", function () {
+    it("is followed (test site)", function () {
       const actor: ISocialActorInfo = {
         ActorType: SocialActorType.Site,
         ContentUri: testSettings.sp.url,


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?
#### What's in this Pull Request?
One of the test cases in social are having .only which is getting executed when we develop/test the test scripts for other sub modules. Removed .only() form the test case of social sub module.
