### PR TITLE
fix Folder.moveTo

### DIFF
--- a/packages/sp/src/folders.ts
+++ b/packages/sp/src/folders.ts
@@ -151,9 +151,9 @@ export class Folder extends SharePointQueryableShareableFolder {
      * @param destUrl Absolute or relative URL of the destination path
      */
     public moveTo(destUrl: string): Promise<void> {
-        return this.select("ServerRelativeUrl").get().then(({ ServerRelativeUrl: srcUrl }) => {
+        return this.select("ServerRelativeUrl").get().then(({ ServerRelativeUrl: srcUrl, ["odata.id"]: absoluteUrl }) => {
             const client = new SPHttpClient();
-            const webBaseUrl = this.toUrl().split("/_api")[0];
+            const webBaseUrl = absoluteUrl.split("/_api")[0];
             const hostUrl = webBaseUrl.replace("://", "___").split("/")[0].replace("___", "://");
             const methodUrl = `${webBaseUrl}/_api/SP.MoveCopyUtil.MoveFolder()`;
             return client.post(methodUrl, {


### PR DESCRIPTION
#### Category
- [ x ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes Folder.moveTo()

#### What's in this Pull Request?

The function Folder.moveTo() used the .toUrl() function, which returned a relative url, so it was not possible to get the host url. Because of this, it returned a 404 error. Replaced it with the value of "odata.id" which includes the absolute url.

