### PR TITLE
Fix typo "on-premises"

### DIFF
--- a/packages/documentation/getting-started.md
+++ b/packages/documentation/getting-started.md
@@ -29,7 +29,7 @@ import { getRandomString } from "@pnp/common";
 
 ## Getting Started with SharePoint Framework
 
-The @pnp/sp and @pnp/graph libraries are designed to work seamlessly within SharePoint Framework projects with a small amount of upfront configuration. If you are running in 2016 on-premesis please [read this note](SPFx-On-Premesis-2016.md) on a workaround for the included TypeScript version. If you are targetting SharePoint online you do not need to take any additional steps.
+The @pnp/sp and @pnp/graph libraries are designed to work seamlessly within SharePoint Framework projects with a small amount of upfront configuration. If you are running in 2016 on-premises please [read this note](SPFx-On-Premesis-2016.md) on a workaround for the included TypeScript version. If you are targetting SharePoint online you do not need to take any additional steps.
 
 ### Establish Context
 


### PR DESCRIPTION
Fixed a typo: changed "on-premesis" for the correct form "on-premises".
There is also a page with the incorrect name, linked from here, but it should be changed carefully for not breaking any other links: SPFx-On-Premesis-2016.md

#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?


#### What's in this Pull Request?
Fixed a typo: changed "on-premesis" for the correct form "on-premises".

