### PR TITLE
Added functionality to set mailnickname when creating a team

### DIFF
--- a/packages/graph/docs/teams.md
+++ b/packages/graph/docs/teams.md
@@ -37,7 +37,7 @@ Then create
 ```TypeSCript
 import { graph } from "@pnp/graph";
 
-const createdGroupTeam = await graph.teams.create('Groupname', 'description', 'OwnerId',{ 
+const createdGroupTeam = await graph.teams.create('Groupname', 'mailNickname', 'description', 'OwnerId',{ 
 "memberSettings": {
     "allowCreateUpdateChannels": true
 },
@@ -91,7 +91,7 @@ const archived = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528
 import { graph } from "@pnp/graph";
 
 const clonedTeam = await graph.teams.getById('3531f3fb-f9ee-4f43-982a-6c90d8226528').cloneTeam(
-'Cloned','description','apps,tabs,settings,channels,members','public');
+'Cloned','mailNickname','description','apps,tabs,settings,channels,members','public');
 
 ```
 ## Get all channels of a Team

--- a/packages/graph/src/teams.ts
+++ b/packages/graph/src/teams.ts
@@ -11,10 +11,11 @@ export class Teams extends GraphQueryableCollection {
     /**
      * Creates a new team and associated Group with the given information
      * @param name The name of the new Group
+     * @param mailNickname The email alias for the group
      * @param description Optional description of the group
      * @param ownerId Add an owner with a user id from the graph
      */
-    public create(name: string, description = "", ownerId: string, teamProperties: TeamProperties = {}): Promise<TeamCreateResult> {
+    public create(name: string, mailNickname: string, description = "", ownerId: string, teamProperties: TeamProperties = {}): Promise<TeamCreateResult> {
 
         const groupProps = {
             "description": description && description.length > 0 ? description : "",
@@ -23,7 +24,7 @@ export class Teams extends GraphQueryableCollection {
             ],
         };
 
-        return graph.groups.add(name, name, GroupType.Office365, groupProps).then((gar: GroupAddResult) => {
+        return graph.groups.add(name, mailNickname, GroupType.Office365, groupProps).then((gar: GroupAddResult) => {
             return gar.group.createTeam(teamProperties).then(data => {
                 return {
                     data: data,
@@ -116,17 +117,18 @@ export class Team extends GraphQueryableInstance<TeamProperties> {
     /**
      * Clones this Team
      * @param name The name of the new Group
+     * @param mailNickname The email alias for the group
      * @param description Optional description of the group
      * @param partsToClone Parts to clone ex: apps,tabs,settings,channels,members
      * @param visibility Set visibility to public or private 
      */
     // TODO:: update properties to be typed once type is available in graph-types
-    public cloneTeam(name: string, description = "", partsToClone: string, visibility: string): Promise<TeamUpdateResult> {
+    public cloneTeam(name: string, mailNickname: string, description = "", partsToClone: string, visibility: string): Promise<TeamUpdateResult> {
 
         const postBody = {
             description: description ? description : "",
             displayName: name,
-            mailNickname: name,
+            mailNickname: mailNickname,
             partsToClone: partsToClone,
             visibility: visibility,
         };


### PR DESCRIPTION
Group names may often consist of special characters, spaces and other characters which is not supported in an email address. This presents the need to be able to set a mailNickname different from the group name.

#### Category
- [x] Bug fix?
- [x] New feature?
- [ ] New sample?
- [X] Documentation update?

#### Related Issues

If creating a team with a complex name which contains special characters, the current implementation throws an error due to limitations in the mailNickname.

#### What's in this Pull Request?

Added mailNickname to the teams.create and teams.clone functions, and updated documentation.


