### PR TITLE
Fix planner.tasks.add request data formating for field <assignments>

### DIFF
--- a/packages/graph/src/planner.ts
+++ b/packages/graph/src/planner.ts
@@ -122,10 +122,16 @@ export class Tasks extends GraphQueryableCollection<IPlannerTask[]> {
      */
     public add(planId: string, title: string, assignments?: TypedHash<any>, bucketId?: string): Promise<TaskAddResult> {
 
-        let postBody = extend({
+        let postBody = {
             planId: planId,
             title: title,
-        }, assignments);
+        };
+
+        if (assignments) {
+            postBody = extend(postBody, {
+                assignments: assignments,
+            });
+        }
 
         if (bucketId) {
             postBody = extend(postBody, {


### PR DESCRIPTION
### Category
- [x] Bug fix

### Related Issues
fixes #925 

Fixed request formating to follow the Graph API documentation (https://docs.microsoft.com/fr-fr/graph/api/planner-post-tasks?view=graph-rest-1.0&tabs=http#example).

Old request data format:
```typescript 
{
  "planId": "xqQg5FS2LkCp935s-FIFm2QAFkHM",
  "bucketId": "hsOf2dhOJkqyYYZEtdzDe2QAIUCR",
  "title": "Update client list",
  "fbab97d0-4932-4511-b675-204639209557": {
    "@odata.type": "#microsoft.graph.plannerAssignment",
    "orderHint": " !"
  }
}
```

Fixed request data format :
```typescript 
{
  "planId": "xqQg5FS2LkCp935s-FIFm2QAFkHM",
  "bucketId": "hsOf2dhOJkqyYYZEtdzDe2QAIUCR",
  "title": "Update client list",
  "assignments": {
    "fbab97d0-4932-4511-b675-204639209557": {
      "@odata.type": "#microsoft.graph.plannerAssignment",
      "orderHint": " !"
    }
  }
}
```

### Comments
!!! Be careful : This fix has not been tested as I don't know how to proceed

Thanks to @patrick-rodgers for his encouragements to propose a fix, and to @PopWarner to review (and help me to enhance if needed) my first ever pull request on a project that is not mine.