### PR TITLE
v2 - fix openWebById

### DIFF
--- a/packages/sp/sites/types.ts
+++ b/packages/sp/sites/types.ts
@@ -113,7 +113,7 @@ export class _Site extends _SharePointQueryableInstance {
         const data = await spPost(this.clone(Site, `openWebById('${webId}')`));
         return {
             data,
-            web: Web(odataUrlFrom(data)),
+            web: Web(odataUrlFrom(data).replace(/_api\/web\/?/i, "")),
         };
     }
 


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

When opening web using **openWebById**, all follow-up rest queries had double _apiWeb/_api/web in url.
```
import { sp } from "@pnp/sp/presets/all";

sp.site.openWebById('00000000-0000-0000-0000-000000000000').then(w => {
   console.log(w.web.toUrlAndQuery())
   //output: https://contoso.sharepoint.com/sites/myweb/_api/Web/_api/web
})
```
This PR fixes that issue


