### PR TITLE
Copy move by path v2

### DIFF
--- a/docs/sp/files.md
+++ b/docs/sp/files.md
@@ -81,6 +81,7 @@ $(() => {
 ```
 
 ### Setting Associated Item Values
+
 You can also update the file properties of a newly uploaded file using code similar to the below snippet:
 
 ```TypeScript
@@ -109,7 +110,6 @@ import "@pnp/sp/folders";
 
 const file = await sp.web.getFolderByServerRelativeUrl("/sites/dev/Shared%20Documents/test/").files.addUsingPath("file%#%.name", "content");
 ```
-
 
 ## Update File Content
 
@@ -282,4 +282,64 @@ console.log(`Id: ${item.Id} -- ${item.Title}`);
 // You can also chain directly off this item instance
 const perms = await item.getCurrentUserEffectivePermissions();
 console.log(perms);
+```
+
+### move
+
+It's possible to move a file to a new destination within a site collection  
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/files";
+
+// destination is a server-relative url of a new file
+const destinationUrl = `sites/dev/SiteAssets/new-file.docx`;
+
+await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx").moveTo(destinationUrl);
+```  
+
+### copy
+
+It's possible to copy a file to a new destination within a site collection  
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/files";
+
+// destination is a server-relative url of a new file
+const destinationUrl = `sites/dev/SiteAssets/new-file.docx`;
+
+await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx").copyTo(destinationUrl, false);
+```  
+
+### move by path
+
+It's possible to move a file to a new destination within the same or a different site collection  
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/files";
+
+// destination is a server-relative url of a new file
+const destinationUrl = `sites/dev2/SiteAssets/new-file.docx`;
+
+await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx").moveByPath(destinationUrl, false, true);
+```  
+
+### copy by path
+
+It's possible to copy a file to a new destination within the same or a different site collection  
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/files";
+
+// destination is a server-relative url of a new file
+const destinationUrl = `sites/dev2/SiteAssets/new-file.docx`;
+
+await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx").copyByPath(destinationUrl, false, true);
 ```

--- a/docs/sp/folders.md
+++ b/docs/sp/folders.md
@@ -137,6 +137,36 @@ const destinationUrl = `sites/my-site/SiteAssets/new-folder`;
 await sp.web.rootFolder.folders.getByName("SiteAssets").folders.getByName("My Folder").copyTo(destinationUrl);
 ```  
 
+### move by path
+
+It's possible to move a folder to a new destination within the same or a different site collection  
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/folders";
+
+// destination is a server-relative url of a new folder
+const destinationUrl = `sites/my-site/SiteAssets/new-folder`;
+
+await sp.web.rootFolder.folders.getByName("SiteAssets").folders.getByName("My Folder").moveByPath(destinationUrl, true);
+```  
+
+### copy by path
+
+It's possible to copy a folder to a new destination within the same or a different site collection  
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/folders";
+
+// destination is a server-relative url of a new folder
+const destinationUrl = `sites/my-site/SiteAssets/new-folder`;
+
+await sp.web.rootFolder.folders.getByName("SiteAssets").folders.getByName("My Folder").copyByPath(destinationUrl, true);
+```  
+
 ### recycle
 
 Recycles a folder

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -7,13 +7,14 @@ import {
     IDeleteableWithETag,
     deleteableWithETag,
 } from "../sharepointqueryable";
-import { TextParser, BlobParser, JSONParser, BufferParser, headers } from "@pnp/odata";
-import { assign, getGUID, isFunc, stringIsNullOrEmpty } from "@pnp/common";
+import { TextParser, BlobParser, JSONParser, BufferParser, headers, body } from "@pnp/odata";
+import { assign, getGUID, isFunc, stringIsNullOrEmpty, isUrlAbsolute } from "@pnp/common";
 import { Item, IItem } from "../items";
 import { odataUrlFrom } from "../odata";
 import { defaultPath } from "../decorators";
 import { spPost } from "../operations";
 import { escapeQueryStrValue } from "../utils/escapeQueryStrValue";
+import { extractWebUrl } from "../utils/extractweburl";
 import { tag } from "../telemetry";
 
 /**
@@ -210,6 +211,44 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
     }
 
     /**
+     * Copies the file by path to destination path
+     *
+     * @param destUrl The absolute url or server relative url of the destination file path to copy to.
+     * @param shouldOverWrite Should a file with the same name in the same location be overwritten?
+     * @param keepBoth Keep both if file with the same name in the same location already exists? Only relevant when shouldOverWrite is set to false.
+     */
+    @tag("fi.copyByPath")
+    public async copyByPath(destUrl: string, shouldOverWrite: boolean, KeepBoth = false): Promise<void> {
+
+        const { ServerRelativeUrl: srcUrl, ["odata.id"]: absoluteUrl } = await this.select("ServerRelativeUrl")();
+        const webBaseUrl = extractWebUrl(absoluteUrl);
+        const hostUrl = webBaseUrl.replace("://", "___").split("/")[0].replace("___", "://");
+        await spPost(File(webBaseUrl, `/_api/SP.MoveCopyUtil.CopyFileByPath(overwrite=@a1)?@a1=${shouldOverWrite}`),
+            body({
+                destPath: {
+                    DecodedUrl: isUrlAbsolute(destUrl) ? destUrl : `${hostUrl}${destUrl}`,
+                    __metadata: {
+                        type: "SP.ResourcePath",
+                    },
+                },
+                options: {
+                    KeepBoth: KeepBoth,
+                    ResetAuthorAndCreatedOnCopy: true,
+                    ShouldBypassSharedLocks: true,
+                    __metadata: {
+                        type: "SP.MoveCopyOptions",
+                    },
+                },
+                srcPath: {
+                    DecodedUrl: `${hostUrl}${srcUrl}`,
+                    __metadata: {
+                        type: "SP.ResourcePath",
+                    },
+                },
+            }));
+    }
+
+    /**
      * Denies approval for a file that was submitted for content approval.
      * Only documents in lists that are enabled for content approval can be denied.
      *
@@ -232,6 +271,44 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
     @tag("fi.moveTo")
     public moveTo(url: string, moveOperations = MoveOperations.Overwrite): Promise<void> {
         return spPost(this.clone(File, `moveTo(newurl='${escapeQueryStrValue(url)}',flags=${moveOperations})`));
+    }
+
+    /**
+     * Moves the file by path to the specified destination url.
+     *
+     * @param destUrl The absolute url or server relative url of the destination file path to move to.
+     * @param shouldOverWrite Should a file with the same name in the same location be overwritten?
+     * @param keepBoth Keep both if file with the same name in the same location already exists? Only relevant when shouldOverWrite is set to false.
+     */
+    @tag("fi.moveByPath")
+    public async moveByPath(destUrl: string, shouldOverWrite: boolean, KeepBoth = false): Promise<void> {
+
+        const { ServerRelativeUrl: srcUrl, ["odata.id"]: absoluteUrl } = await this.select("ServerRelativeUrl")();
+        const webBaseUrl = extractWebUrl(absoluteUrl);
+        const hostUrl = webBaseUrl.replace("://", "___").split("/")[0].replace("___", "://");
+        await spPost(File(webBaseUrl, `/_api/SP.MoveCopyUtil.MoveFileByPath(overwrite=@a1)?@a1=${shouldOverWrite}`),
+            body({
+                destPath: {
+                    DecodedUrl: isUrlAbsolute(destUrl) ? destUrl : `${hostUrl}${destUrl}`,
+                    __metadata: {
+                        type: "SP.ResourcePath",
+                    },
+                },
+                options: {
+                    KeepBoth: KeepBoth,
+                    ResetAuthorAndCreatedOnCopy: false,
+                    ShouldBypassSharedLocks: true,
+                    __metadata: {
+                        type: "SP.MoveCopyOptions",
+                    },
+                },
+                srcPath: {
+                    DecodedUrl: `${hostUrl}${srcUrl}`,
+                    __metadata: {
+                        type: "SP.ResourcePath",
+                    },
+                },
+            }));
     }
 
     /**
@@ -600,6 +677,7 @@ export interface IAddUsingPathProps {
 }
 
 export interface IFileInfo {
+    readonly "odata.id": string;
     CheckInComment: string;
     CheckOutType: number;
     ContentTag: string;

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -211,7 +211,8 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
     }
 
     /**
-     * Copies the file by path to destination path
+     * Copies the file by path to destination path.
+     * Also works with different site collections.
      *
      * @param destUrl The absolute url or server relative url of the destination file path to copy to.
      * @param shouldOverWrite Should a file with the same name in the same location be overwritten?
@@ -275,6 +276,7 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
 
     /**
      * Moves the file by path to the specified destination url.
+     * Also works with different site collections.
      *
      * @param destUrl The absolute url or server relative url of the destination file path to move to.
      * @param shouldOverWrite Should a file with the same name in the same location be overwritten?

--- a/packages/sp/folders/types.ts
+++ b/packages/sp/folders/types.ts
@@ -176,6 +176,7 @@ export class _Folder extends _SharePointQueryableInstance<IFolderInfo> {
 
     /**
      * Moves a folder by path to destination path
+     * Also works with different site collections.
      *
      * @param destUrl Absolute or relative URL of the destination path
      * @param keepBoth Keep both if folder with the same name in the same location already exists?
@@ -231,6 +232,7 @@ export class _Folder extends _SharePointQueryableInstance<IFolderInfo> {
 
     /**
      * Copies a folder by path to destination path
+     * Also works with different site collections.
      *
      * @param destUrl Absolute or relative URL of the destination path
      * @param keepBoth Keep both if folder with the same name in the same location already exists?

--- a/packages/sp/folders/types.ts
+++ b/packages/sp/folders/types.ts
@@ -175,6 +175,43 @@ export class _Folder extends _SharePointQueryableInstance<IFolderInfo> {
     }
 
     /**
+     * Moves a folder by path to destination path
+     *
+     * @param destUrl Absolute or relative URL of the destination path
+     * @param keepBoth Keep both if folder with the same name in the same location already exists?
+     */
+    @tag("f.moveByPath")
+    public async moveByPath(destUrl: string, KeepBoth = false): Promise<void> {
+
+        const { ServerRelativeUrl: srcUrl, ["odata.id"]: absoluteUrl } = await this.select("ServerRelativeUrl")();
+        const webBaseUrl = extractWebUrl(absoluteUrl);
+        const hostUrl = webBaseUrl.replace("://", "___").split("/")[0].replace("___", "://");
+        await spPost(Folder(webBaseUrl, `/_api/SP.MoveCopyUtil.MoveFolderByPath()`),
+            body({
+                destPath: {
+                    DecodedUrl: isUrlAbsolute(destUrl) ? destUrl : `${hostUrl}${destUrl}`,
+                    __metadata: {
+                        type: "SP.ResourcePath",
+                    },
+                },
+                options: {
+                    KeepBoth: KeepBoth,
+                    ResetAuthorAndCreatedOnCopy: true,
+                    ShouldBypassSharedLocks: true,
+                    __metadata: {
+                        type: "SP.MoveCopyOptions",
+                    },
+                },
+                srcPath: {
+                    DecodedUrl: `${hostUrl}${srcUrl}`,
+                    __metadata: {
+                        type: "SP.ResourcePath",
+                    },
+                },
+            }));
+    }
+
+    /**
      * Copies a folder to destination path
      *
      * @param destUrl Absolute or relative URL of the destination path
@@ -189,6 +226,43 @@ export class _Folder extends _SharePointQueryableInstance<IFolderInfo> {
             body({
                 destUrl: isUrlAbsolute(destUrl) ? destUrl : `${hostUrl}${destUrl}`,
                 srcUrl: `${hostUrl}${srcUrl}`,
+            }));
+    }
+
+    /**
+     * Copies a folder by path to destination path
+     *
+     * @param destUrl Absolute or relative URL of the destination path
+     * @param keepBoth Keep both if folder with the same name in the same location already exists?
+     */
+    @tag("f.copyByPath")
+    public async copyByPath(destUrl: string, KeepBoth = false): Promise<void> {
+
+        const { ServerRelativeUrl: srcUrl, ["odata.id"]: absoluteUrl } = await this.select("ServerRelativeUrl")();
+        const webBaseUrl = extractWebUrl(absoluteUrl);
+        const hostUrl = webBaseUrl.replace("://", "___").split("/")[0].replace("___", "://");
+        await spPost(Folder(webBaseUrl, `/_api/SP.MoveCopyUtil.CopyFolderByPath()`),
+            body({
+                destPath: {
+                    DecodedUrl: isUrlAbsolute(destUrl) ? destUrl : `${hostUrl}${destUrl}`,
+                    __metadata: {
+                        type: "SP.ResourcePath",
+                    },
+                },
+                options: {
+                    KeepBoth: KeepBoth,
+                    ResetAuthorAndCreatedOnCopy: true,
+                    ShouldBypassSharedLocks: true,
+                    __metadata: {
+                        type: "SP.MoveCopyOptions",
+                    },
+                },
+                srcPath: {
+                    DecodedUrl: `${hostUrl}${srcUrl}`,
+                    __metadata: {
+                        type: "SP.ResourcePath",
+                    },
+                },
             }));
     }
 
@@ -243,6 +317,7 @@ export interface IFolderUpdateResult {
 }
 
 export interface IFolderInfo {
+    readonly "odata.id": string;
     Exists: boolean;
     IsWOPIEnabled: boolean;
     ItemCount: number;

--- a/test/sp/files.ts
+++ b/test/sp/files.ts
@@ -189,6 +189,36 @@ describe("file", () => {
             return expect(files.getByName(name2)()).to.eventually.be.fulfilled;
         });
 
+        it("copyByPath", async function () {
+
+            const rand = getRandomString(4);
+            const name = `Testing copyByPath - ${rand}.txt`;
+            await files.add(name, getRandomString(42));
+            const folderData = await sp.web.defaultDocumentLibrary.rootFolder.select("ServerRelativeUrl")();
+            const name2 = `I Copied - ${rand}.aspx`;
+            const path = combine("/", folderData.ServerRelativeUrl, name2);
+
+            await files.getByName(name).copyByPath(path, true);
+
+            // tslint:disable-next-line:no-unused-expression
+            return expect(files.getByName(name2)()).to.eventually.be.fulfilled;
+        });
+
+        it("moveByPath", async function () {
+
+            const rand = getRandomString(4);
+            const name = `Testing moveByPath - ${rand}.txt`;
+            await files.add(name, getRandomString(42));
+            const folderData = await sp.web.defaultDocumentLibrary.rootFolder.select("ServerRelativeUrl")();
+            const name2 = `I Copied - ${rand}.aspx`;
+            const path = combine("/", folderData.ServerRelativeUrl, name2);
+
+            await files.getByName(name).moveByPath(path, true);
+
+            // tslint:disable-next-line:no-unused-expression
+            return expect(files.getByName(name2)()).to.eventually.be.fulfilled;
+        });
+
         it("recycle", async function () {
 
             const name = `Testing Recycle - ${getRandomString(4)}.txt`;

--- a/test/sp/folders.ts
+++ b/test/sp/folders.ts
@@ -71,6 +71,22 @@ describe("Folder", () => {
             return expect(web.rootFolder.folders.getByName("SiteAssets").folders.getByName(folderName).copyTo(copyToUrl)).to.eventually.be.fulfilled;
         });
 
+        it("moves folder to a new destination by path", async function () {
+            const folderName = `test2_${getRandomString(5)}`;
+            await web.rootFolder.folders.getByName("SiteAssets").folders.add(folderName);
+            const { ServerRelativeUrl: srcUrl } = await web.select("ServerRelativeUrl")<{ ServerRelativeUrl: string }>();
+            const moveToUrl = `${srcUrl}/SiteAssets/moved_${getRandomString(5)}`;
+            return expect(web.rootFolder.folders.getByName("SiteAssets").folders.getByName(folderName).moveByPath(moveToUrl, true)).to.eventually.be.fulfilled;
+        });
+
+        it("copies folder to a new destination by path", async function () {
+            const folderName = `test2_${getRandomString(5)}`;
+            await web.rootFolder.folders.getByName("SiteAssets").folders.add(folderName);
+            const { ServerRelativeUrl: srcUrl } = await web.select("ServerRelativeUrl")<{ ServerRelativeUrl: string }>();
+            const copyToUrl = `${srcUrl}/SiteAssets/copied_${getRandomString(5)}`;
+            return expect(web.rootFolder.folders.getByName("SiteAssets").folders.getByName(folderName).copyByPath(copyToUrl, true)).to.eventually.be.fulfilled;
+        });
+
         it("recycles folder", async function () {
             await web.rootFolder.folders.getByName("SiteAssets").folders.add("test3");
             return expect(web.rootFolder.folders.getByName("SiteAssets").folders.getByName("test").recycle()).to.eventually.be.fulfilled;


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [x] Documentation update?


#### What's in this Pull Request?

Added functions to copy and move files and folders by path.
Parameters are send within the post body and not the url, so special characters in file path do not cause request errors.
This also allows files and folders to be copied/moved between different site collections, which was a limitation on the copyTo and moveTo endpoints.

Included tests and updated documentation.

