### PR TITLE
Added mandatory eTag parameter to Graph.Planner.Task.delete()

### DIFF
--- a/packages/graph/docs/planner.md
+++ b/packages/graph/docs/planner.md
@@ -122,7 +122,8 @@ Using the delete() you can get delete a Task.
 ```TypeScript
 import { graph } from "@pnp/graph";
 
-const delTask = await graph.planner.tasks.getById('taskId').delete();
+const delTask = await graph.planner.tasks.getById('taskId').delete('taskEtag');
+
 
 ```
 

--- a/packages/graph/src/planner.ts
+++ b/packages/graph/src/planner.ts
@@ -149,8 +149,12 @@ export class Task extends GraphQueryableInstance<IPlannerTask> {
     /**
      * Deletes this Task
      */
-    public delete(): Promise<void> {
-        return this.deleteCore();
+    public delete(eTag = "*"): Promise<void> {
+        return this.deleteCore({
+            headers: {
+                "If-Match": eTag,
+            },
+        });
     }
 
     /**

--- a/packages/graph/src/planner.ts
+++ b/packages/graph/src/planner.ts
@@ -149,12 +149,12 @@ export class Task extends GraphQueryableInstance<IPlannerTask> {
     /**
      * Deletes this Task
      */
-    public delete(eTag = "*"): Promise<void> {
+    public delete(eTag: string): Promise<void> {
         return this.deleteCore({
             headers: {
                 "If-Match": eTag,
             },
-        });
+        );
     }
 
     /**


### PR DESCRIPTION
#### Category
[x ] Bug fix

#### Related Issues
fixes #987

#### What's in this Pull Request?
Added the eTAg of the task as mandatory parameter to the Planner task delete() function as this information is required by graph API (exception if not provided).

#### Testing
Calling graph.planner.tasks.getById('taskId').delete('taskEtag') with corrects task id and fresh task etag should succeed.

#### Warning !!! Guidance not followed !
* Please ensure you have updated/added tests to cover your change
   => do not know how to update test cover

I also did not test my fix as I don't know how to do it.



