### PR TITLE
[V2] Fix for getPage search method

### DIFF
--- a/packages/sp/search/query.ts
+++ b/packages/sp/search/query.ts
@@ -133,7 +133,7 @@ export class _Search extends _SharePointQueryableInstance {
         }
 
         const data = await spPost(this, postBody);
-        return new SearchResults(data, this.toUrl(), query);
+        return new SearchResults(data, this.parentUrl, query);
     }
 
     /**

--- a/test/sp/search.ts
+++ b/test/sp/search.ts
@@ -31,4 +31,10 @@ describe.skip("Search", () => {
 
         return expect(sp.searchSuggest({ querytext: "test" })).to.eventually.be.fulfilled;
     });
+
+    it(".getpage", async function () {
+
+        const result = await sp.search("test");
+        return expect(result.getPage(1)).to.eventually.be.fulfilled;
+    });
 });


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #991

#### What's in this Pull Request?
Fixes the getPage search method, which had a wrong _url property passed by the search.execute method.

@patrick-rodgers can you please review this?