### PR TITLE
missing "await" added when retriving termset by name

### DIFF
--- a/docs/v1/sp-taxonomy/docs/term-sets/index.html
+++ b/docs/v1/sp-taxonomy/docs/term-sets/index.html
@@ -1768,7 +1768,7 @@
 
 <span class="kr">const</span> <span class="nx">set</span> <span class="o">=</span> <span class="nx">store</span><span class="p">.</span><span class="nx">getTermSetsByName</span><span class="p">(</span><span class="s2">&quot;my set&quot;</span><span class="p">,</span> <span class="mi">1031</span><span class="p">).</span><span class="nx">getById</span><span class="p">(</span><span class="s2">&quot;0ba6845c-1468-4ec5-a5a8-718f1fb05431&quot;</span><span class="p">);</span>
 
-<span class="kr">const</span> <span class="nx">setWithData</span> <span class="o">=</span> <span class="nx">store</span><span class="p">.</span><span class="nx">getTermSetsByName</span><span class="p">(</span><span class="s2">&quot;my set&quot;</span><span class="p">,</span> <span class="mi">1031</span><span class="p">).</span><span class="nx">getByName</span><span class="p">(</span><span class="s2">&quot;my set&quot;</span><span class="p">).</span><span class="nx">get</span><span class="p">();</span>
+<span class="kr">const</span> <span class="nx">setWithData</span> <span class="o">=</span> <span class="nx">await store</span><span class="p">.</span><span class="nx">getTermSetsByName</span><span class="p">(</span><span class="s2">&quot;my set&quot;</span><span class="p">,</span> <span class="mi">1031</span><span class="p">).</span><span class="nx">getByName</span><span class="p">(</span><span class="s2">&quot;my set&quot;</span><span class="p">).</span><span class="nx">get</span><span class="p">();</span>
 </pre></div>
 
 


### PR DESCRIPTION
const setWithData = store.getTermSetsByName("my set", 1031).getByName("my set").get();    
    =>       
 const setWithData = **await** store.getTermSetsByName("my set", 1031).getByName("my set").get();

#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ x] Documentation update?

#### Related Issues

none

#### What's in this Pull Request?

Just added the "await" syntax to properly call  `store.getTermSetsByName("my set", 1031).getByName("my set").get();`
