### PR TITLE
Automatic retry on Gateway Timeout errors

### DIFF
--- a/packages/graph/src/net/graphhttpclient.ts
+++ b/packages/graph/src/net/graphhttpclient.ts
@@ -54,7 +54,8 @@ export class GraphHttpClient implements RequestClient {
 
                 // Check if request was throttled - http status code 429
                 // Check if request failed due to server unavailable - http status code 503
-                if (response.status !== 429 && response.status !== 503) {
+                // Check if request failed due to gateway timeout - http status code 504
+                if (response.status !== 429 && response.status !== 503 && response.status !== 504) {
                     ctx.reject(response);
                 }
 

--- a/packages/sp/src/net/sphttpclient.ts
+++ b/packages/sp/src/net/sphttpclient.ts
@@ -112,8 +112,8 @@ export class SPHttpClient implements RequestClient {
 
             }).catch((response: Response) => {
 
-                if (response.status === 503) {
-                    // http status code 503, we can retry this
+                if (response.status === 503 || response.status === 504) {
+                    // http status code 503 or 504, we can retry this
                     setRetry(response);
                 } else {
                     ctx.reject(response);


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues
fixes #1048 

#### What's in this Pull Request?
* Automatic retry of http requests that failed with a `Gateway Timeout (504)` error.
Added this change in both the `SPHttpClient` and the `GraphHttpClient` classes.

