### PR TITLE
Corrected tab's `displayName` property on v1

### DIFF
--- a/packages/graph/src/teams.ts
+++ b/packages/graph/src/teams.ts
@@ -234,7 +234,7 @@ export class Tabs extends GraphQueryableCollection {
     public add(name: string, appUrl: string, properties: TabsConfiguration): Promise<TabCreateResult> {
 
         const postBody = extend({
-            name: name,
+            displayName: name,
             "teamsApp@odata.bind": appUrl,
         }, properties);
 


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

Tab's name property should be `displayName` instead of `name`.
[See documentation](https://docs.microsoft.com/en-us/graph/api/teamstab-add?view=graph-rest-1.0)