### PR TITLE
Corrected tab's `displayName` property on v2

### DIFF
--- a/packages/graph/teams/types.ts
+++ b/packages/graph/teams/types.ts
@@ -136,7 +136,7 @@ export class _Tabs extends _GraphQueryableCollection {
     public async add(name: string, appUrl: string, properties: ITabsConfiguration): Promise<ITabCreateResult> {
 
         const postBody = assign({
-            name,
+            displayName: name,
             "teamsApp@odata.bind": appUrl,
         }, properties);
 


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

Same as PR #1055 but for v2

Tab's name property should be `displayName` instead of `name`.
[See documentation](https://docs.microsoft.com/en-us/graph/api/teamstab-add?view=graph-rest-1.0)