### PR TITLE
Add additional checks for absolute Url

### DIFF
--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -236,7 +236,7 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
                         type: "SP.MoveCopyOptions",
                     },
                 },
-                srcPath: toResourcePath(`${hostUrl}${srcUrl}`),
+                srcPath: toResourcePath(isUrlAbsolute(srcUrl) ? srcUrl : `${hostUrl}${srcUrl}`),
             }));
     }
 
@@ -290,7 +290,7 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
                         type: "SP.MoveCopyOptions",
                     },
                 },
-                srcPath: toResourcePath(`${hostUrl}${srcUrl}`),
+                srcPath: toResourcePath(isUrlAbsolute(srcUrl) ? srcUrl : `${hostUrl}${srcUrl}`),
             }));
     }
 

--- a/packages/sp/folders/types.ts
+++ b/packages/sp/folders/types.ts
@@ -199,7 +199,7 @@ export class _Folder extends _SharePointQueryableInstance<IFolderInfo> {
                         type: "SP.MoveCopyOptions",
                     },
                 },
-                srcPath: toResourcePath(`${hostUrl}${srcUrl}`),
+                srcPath: toResourcePath(isUrlAbsolute(srcUrl) ? srcUrl : `${hostUrl}${srcUrl}`),
             }));
     }
 
@@ -245,7 +245,7 @@ export class _Folder extends _SharePointQueryableInstance<IFolderInfo> {
                         type: "SP.MoveCopyOptions",
                     },
                 },
-                srcPath: toResourcePath(`${hostUrl}${srcUrl}`),
+                srcPath: toResourcePath(isUrlAbsolute(srcUrl) ? srcUrl : `${hostUrl}${srcUrl}`),
             }));
     }
 


### PR DESCRIPTION
#### Category
- [x] Bug fix?

#### Related Issues
mentioned in #1104

#### What's in this Pull Request?

Add additional checks for absolute Url when copying or moving files/folders by path.
This is only to avoid errors if the user passes an absolute Url instead of relative.