### PR TITLE
adding support for additional site creation props #1117

### DIFF
--- a/docs/sp/sites.md
+++ b/docs/sp/sites.md
@@ -108,7 +108,7 @@ Creates a modern communication site.
 import { sp } from "@pnp/sp";
 import "@pnp/sp/sites";
 
-const s = await sp.site.createCommunicationSite(
+const result = await sp.site.createCommunicationSite(
             "Title",
             1033,
             true,
@@ -120,6 +120,25 @@ const s = await sp.site.createCommunicationSite(
             "user@TENANT.onmicrosoft.com");
 
 ```
+
+### Create from Props
+
+You may need to supply additional parameters such as WebTemplate, to do so please use the `createCommunicationSiteFromProps` method.
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/sites";
+
+// in this case you supply a single struct deinfing the creation props
+const result = await sp.site.createCommunicationSiteFromProps({
+  Owner: "patrick@three18studios.com",
+  Title: "A Test Site",
+  Url: "https://318studios.sharepoint.com/sites/commsite2",
+  WebTemplate: "STS#3",
+});
+```
+
 
 ## Create a modern team site
 
@@ -148,7 +167,7 @@ Creates a modern team site backed by O365 group.
 import { sp } from "@pnp/sp";
 import "@pnp/sp/sites";
 
-const d = await sp.site.createModernTeamSite(
+const result = await sp.site.createModernTeamSite(
         "displayName",
         "alias",
         true,
@@ -161,6 +180,23 @@ const d = await sp.site.createModernTeamSite(
         );
 
 console.log(d);
+```
+
+### Create from Props
+
+You may need to supply additional parameters, to do so please use the `createModernTeamSiteFromProps` method.
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/sites";
+
+// in this case you supply a single struct deinfing the creation props
+const result = await sp.site.createModernTeamSiteFromProps({
+  alias: "JenniferGarner",
+  displayName: "A Test Site",
+  owners: ["patrick@three18studios.com"],
+});
 ```
 
 ## Delete a site collection

--- a/packages/sp/sharing/funcs.ts
+++ b/packages/sp/sharing/funcs.ts
@@ -22,6 +22,7 @@ import {
 import { spPost } from "../operations";
 import { tag } from "../telemetry";
 import { RoleDefinitions } from "../security/types";
+import { emptyGuid } from "../splibconfig";
 
 /**
  * Shares an object based on the supplied options
@@ -155,7 +156,7 @@ export function deleteLinkByKind(this: ShareableQueryable, linkKind: SharingLink
  * @param kind The kind of link to be deleted.
  * @param shareId
  */
-export function unshareLink(this: ShareableQueryable, linkKind: SharingLinkKind, shareId = "00000000-0000-0000-0000-000000000000"): Promise<void> {
+export function unshareLink(this: ShareableQueryable, linkKind: SharingLinkKind, shareId = emptyGuid): Promise<void> {
 
     return spPost(tag.configure(this.clone(SharePointQueryableInstance, "unshareLink"), "sh.unshareLink"), body({ linkKind, shareId }));
 }

--- a/packages/sp/splibconfig.ts
+++ b/packages/sp/splibconfig.ts
@@ -7,6 +7,8 @@ import {
     objectDefinedNotNull,
 } from "@pnp/common";
 
+export const emptyGuid = "00000000-0000-0000-0000-000000000000";
+
 export interface SPConfigurationPart {
     sp?: {
         /**


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1117

#### What's in this Pull Request?

Adds two methods `createCommunicationSiteFromProps` and `createModernTeamSiteFromProps` to allow passing props structs instead of using the parameterized methods. Adds a response type and cleans up the request logic.