### PR TITLE
Fixing name of node link from "teams" to "users"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,7 @@ nav:
       - planner: 'graph/planner.md'
       - subscriptions: 'graph/subscriptions.md'
       - teams: 'graph/teams.md'
-      - teams: 'graph/users.md'
+      - users: 'graph/users.md'
     - logging: 'logging/index.md'
     - nodejs:
       - nodejs: 'nodejs/index.md'


### PR DESCRIPTION

#### Category
- [X ] Documentation update?

#### What's in this Pull Request?

On documentation, there is a typo where teams are displayed twice on the left navigation,
URL - https://pnp.github.io/pnpjs/graph/users/
![image](https://user-images.githubusercontent.com/9557557/80914707-01d56200-8d6b-11ea-818b-918b7bd74c30.png)

Thanks
