### PR TITLE
Fixed a bug: getToken method of AdalClient returned null on first run

### DIFF
--- a/packages/adaljsclient/adalclient.ts
+++ b/packages/adaljsclient/adalclient.ts
@@ -74,17 +74,16 @@ export class AdalClient extends BearerTokenFetchClient {
         await this.ensureAuthContext();
         await this.login();
 
-        let token = null;
-        AdalClient._authContext.acquireToken(resource, (message: string, tok: string) => {
+        return new Promise((resolve, reject) => {
+            AdalClient._authContext.acquireToken(resource, (message: string, token: string) => {
 
-            if (message) {
-                throw Error(message);
-            }
+                if (message) {
+                    reject(Error(message));
+                }
 
-            token = tok;
+                resolve(token);
+            });
         });
-
-        return token;
     }
 
     /**


### PR DESCRIPTION
getToken was working incorrectly - it always returned null on the first execution.

#### Category
- [x] Bug fix?

#### What's in this Pull Request?

A fix for getToken method of the AdalClient - now it waits until the token is resolved.