### PR TITLE
Add missing group calendar endpoints / user calendar endpoints

### DIFF
--- a/packages/graph/calendars/groups.ts
+++ b/packages/graph/calendars/groups.ts
@@ -4,10 +4,12 @@ import { Calendar, ICalendar, IEvents, Events } from "./types";
 
 declare module "../groups/types" {
     interface _Group {
+        readonly calendar: ICalendar;
         readonly attachmentFiles: ICalendar;
         readonly events: IEvents;
     }
     interface IGroup {
+        readonly calendar: ICalendar;
         readonly attachmentFiles: ICalendar;
         readonly events: IEvents;
     }

--- a/packages/graph/calendars/index.ts
+++ b/packages/graph/calendars/index.ts
@@ -1,4 +1,5 @@
 import "./groups";
+import "./users";
 
 export {
     Calendar,

--- a/packages/graph/calendars/types.ts
+++ b/packages/graph/calendars/types.ts
@@ -5,14 +5,6 @@ import { defaultPath, IDeleteable, deleteable, IUpdateable, updateable, getById,
 import { graphPost } from "../operations";
 
 /**
- * Calendars
- */
-@defaultPath("calendars")
-export class _Calendars extends _GraphQueryableCollection<ICalendarType[]> { }
-export interface ICalendars<GetType = any> extends _Calendars { }
-export const Calendars = graphInvokableFactory<ICalendars>(_Calendars);
-
-/**
  * Calendar
  */
 export class _Calendar extends _GraphQueryableInstance<ICalendarType> {
@@ -23,6 +15,15 @@ export class _Calendar extends _GraphQueryableInstance<ICalendarType> {
 }
 export interface ICalendar extends _Calendar { }
 export const Calendar = graphInvokableFactory<ICalendar>(_Calendar);
+
+/**
+ * Calendars
+ */
+@defaultPath("calendars")
+@getById(Calendar)
+export class _Calendars extends _GraphQueryableCollection<ICalendarType[]> { }
+export interface ICalendars<GetType = any> extends _Calendars, IGetById<ICalendar> { }
+export const Calendars = graphInvokableFactory<ICalendars>(_Calendars);
 
 /**
  * Event

--- a/packages/graph/calendars/users.ts
+++ b/packages/graph/calendars/users.ts
@@ -1,0 +1,22 @@
+import { addProp } from "@pnp/odata";
+import { _User } from "../users/types";
+import { Calendar, ICalendar, IEvents, Events, Calendars, ICalendars } from "./types";
+
+declare module "../users/types" {
+    interface _User {
+        readonly calendar: ICalendar;
+        readonly calendars: ICalendars;
+        readonly attachmentFiles: ICalendar;
+        readonly events: IEvents;
+    }
+    interface IUser {
+        readonly calendar: ICalendar;
+        readonly calendars: ICalendars;
+        readonly attachmentFiles: ICalendar;
+        readonly events: IEvents;
+    }
+}
+
+addProp(_User, "calendar", Calendar, "calendar");
+addProp(_User, "calendars", Calendars, "calendars");
+addProp(_User, "events", Events);


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

Re-adds functionality from #789, as well as adding extra functionality.

#### What's in this Pull Request?

- The `calendar` object for groups was defined but not typed. It can now be accessed (`graph.groups.getById('').calendar`)
- User calendars have been implemented:
  - `graph.users.getById('').calendar`
  - `graph.users.getById('').calendars`
  - `graph.users.getById('').calendars.getById('')`

If this all looks okay, I'll update the docs in this PR before it's merged.
