### PR TITLE
WIP: Add getStream

### DIFF
--- a/packages/odata/parsers.ts
+++ b/packages/odata/parsers.ts
@@ -5,6 +5,11 @@ export interface IODataParser<T> {
     parse(r: Response): Promise<T>;
 }
 
+export interface IResponseBodyStream {
+    body: ReadableStream<Uint8Array>;
+    knownLength: number;
+}
+
 export class ODataParser<T = any> implements IODataParser<T> {
 
     public parse(r: Response): Promise<T> {
@@ -89,6 +94,12 @@ export class BlobParser extends ODataParser<Blob> {
     protected parseImpl(r: Response, resolve: (value: any) => void): void {
 
         r.blob().then(resolve);
+    }
+}
+export class StreamParser extends ODataParser<IResponseBodyStream> {
+
+    protected parseImpl(r: Response, resolve: (value: any) => void): void {
+        resolve({ body: r.body, knownLength: parseInt(r.headers['content-length'],10)})
     }
 }
 

--- a/packages/odata/parsers.ts
+++ b/packages/odata/parsers.ts
@@ -99,7 +99,7 @@ export class BlobParser extends ODataParser<Blob> {
 export class StreamParser extends ODataParser<IResponseBodyStream> {
 
     protected parseImpl(r: Response, resolve: (value: any) => void): void {
-        resolve({ body: r.body, knownLength: parseInt(r.headers['content-length'],10)})
+        resolve({ body: r.body, knownLength: parseInt(r.headers["content-length"], 10) });
     }
 }
 

--- a/packages/odata/queryable.ts
+++ b/packages/odata/queryable.ts
@@ -13,6 +13,13 @@ import { PipelineMethod } from "./pipeline";
 import { IODataParser, ODataParser } from "./parsers";
 
 export function cloneQueryableData(source: Partial<IQueryableData>): Partial<IQueryableData> {
+  let body;
+  // this handles bodies that cannot be JSON encoded (Blob, etc)
+  // Note however, even bodies that can be serialized will not be cloned.
+  if (source.options && source.options.body) {
+    body = source.options.body;
+    source.options.body = "-"
+  }
 
   const s = JSON.stringify(source, (key: string, value: any) => {
 
@@ -53,9 +60,8 @@ export function cloneQueryableData(source: Partial<IQueryableData>): Partial<IQu
     }
   });
 
-  // this handles bodies that cannot be JSON encoded (Blob, etc)
-  if (source.options && source.options.body) {
-    parsed.options.body = source.options.body;
+  if (body) {
+    parsed.options.body = body;
   }
 
   return parsed;

--- a/packages/odata/queryable.ts
+++ b/packages/odata/queryable.ts
@@ -18,7 +18,7 @@ export function cloneQueryableData(source: Partial<IQueryableData>): Partial<IQu
   // Note however, even bodies that can be serialized will not be cloned.
   if (source.options && source.options.body) {
     body = source.options.body;
-    source.options.body = "-"
+    source.options.body = "-";
   }
 
   const s = JSON.stringify(source, (key: string, value: any) => {

--- a/packages/odata/queryable.ts
+++ b/packages/odata/queryable.ts
@@ -62,6 +62,8 @@ export function cloneQueryableData(source: Partial<IQueryableData>): Partial<IQu
 
   if (body) {
     parsed.options.body = body;
+    // Since we're attempting to clone the source to avoid changing it, the least we can do with the body is keep the reference intact.
+    source.options.body = body;
   }
 
   return parsed;

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -367,6 +367,17 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
 
         return this.clone(File, "$value", false).usingParser(new BufferParser())(headers({ "binaryStringResponseBody": "true" }));
     }
+    
+    /**
+     * Gets the contents of a Node Stream, works ONLY in Node.js. Not supported in batching.
+     */
+    @tag("fi.getStream")
+    public getStream(): Promise<ArrayBuffer> {
+
+        return this.clone(File, "$value", false).usingParser({ parse(r) {
+            return Promise.resolve(r.body)
+        }})(headers({ "binaryStringResponseBody": "true" }));
+    }
 
     /**
      * Gets the contents of a file as an ArrayBuffer, works in Node.js. Not supported in batching.

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -26,7 +26,7 @@ import { toResourcePath } from "../utils/toResourcePath";
 export class _Files extends _SharePointQueryableCollection<IFileInfo[]> {
 
     /**
-     * Gets a File by filenameany
+     * Gets a File by filename
      *
      * @param name The name of the file, including extension.
      */


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?


#### What's in this Pull Request?

I had to put a lot of research in to figure out how to get a stream instead of loading the whole thing into memory.
Without reading the code of getBlob I wouldn't be able to do it.
This is a WIP to check if the contribution like this is welcome.

I'm aware the parser would need to go to the odata package and inherit properly.
I'm aware docs would follow.

It seemed odd this method is not there yet, so I'm checking if there wasn't a reason behind it.

Please comment.