### PR TITLE
fixing issue #1208, add uri encoding for filter, select, expand, and …

### DIFF
--- a/packages/graph/graphqueryable.ts
+++ b/packages/graph/graphqueryable.ts
@@ -57,7 +57,7 @@ export class _GraphQueryable<GetType = any> extends Queryable<GetType> implement
      */
     public select(...selects: string[]): this {
         if (selects.length > 0) {
-            this.query.set("$select", selects.join(","));
+            this.query.set("$select", selects.map(encodeURIComponent).join(","));
         }
         return this;
     }
@@ -69,7 +69,7 @@ export class _GraphQueryable<GetType = any> extends Queryable<GetType> implement
      */
     public expand(...expands: string[]): this {
         if (expands.length > 0) {
-            this.query.set("$expand", expands.join(","));
+            this.query.set("$expand", expands.map(encodeURIComponent).join(","));
         }
         return this;
     }
@@ -184,7 +184,7 @@ export class _GraphQueryableCollection<GetType = any[]> extends _GraphQueryable<
     public orderBy(orderBy: string, ascending = true): this {
         const o = "$orderby";
         const query = this.query.has(o) ? this.query.get(o).split(",") : [];
-        query.push(`${orderBy} ${ascending ? "asc" : "desc"}`);
+        query.push(`${encodeURIComponent(orderBy)} ${ascending ? "asc" : "desc"}`);
         this.query.set(o, query.join(","));
         return this;
     }

--- a/packages/sp/sharepointqueryable.ts
+++ b/packages/sp/sharepointqueryable.ts
@@ -108,7 +108,7 @@ export class _SharePointQueryable<GetType = any> extends Queryable<GetType> {
      */
     public select(...selects: string[]): this {
         if (selects.length > 0) {
-            this.query.set("$select", selects.join(","));
+            this.query.set("$select", selects.map(encodeURIComponent).join(","));
         }
         return this;
     }
@@ -124,7 +124,7 @@ export class _SharePointQueryable<GetType = any> extends Queryable<GetType> {
      */
     public expand(...expands: string[]): this {
         if (expands.length > 0) {
-            this.query.set("$expand", expands.join(","));
+            this.query.set("$expand", expands.map(encodeURIComponent).join(","));
         }
         return this;
     }
@@ -196,7 +196,7 @@ export class _SharePointQueryableCollection<GetType = any[]> extends _SharePoint
      * @param filter The string representing the filter query
      */
     public filter(filter: string): this {
-        this.query.set("$filter", filter);
+        this.query.set("$filter", encodeURIComponent(filter));
         return this;
     }
 
@@ -209,7 +209,7 @@ export class _SharePointQueryableCollection<GetType = any[]> extends _SharePoint
     public orderBy(orderBy: string, ascending = true): this {
         const o = "$orderby";
         const query = this.query.has(o) ? this.query.get(o).split(",") : [];
-        query.push(`${orderBy} ${ascending ? "asc" : "desc"}`);
+        query.push(`${encodeURIComponent(orderBy)} ${ascending ? "asc" : "desc"}`);
         this.query.set(o, query.join(","));
         return this;
     }

--- a/test/graph/groups.ts
+++ b/test/graph/groups.ts
@@ -39,7 +39,7 @@ describe("Groups", function () {
       });
       return expect(groupExists).is.not.true;
     });
-    it.only("getById()", async function () {
+    it("getById()", async function () {
       // Create a new group
       const groupName = `TestGroup_${getRandomString(4)}`;
       const groupAddResult = await graph.groups.add(groupName, groupName, GroupType.Office365);

--- a/test/sp/files.ts
+++ b/test/sp/files.ts
@@ -87,6 +87,14 @@ describe("files", () => {
             expect(file.Name).to.eq(name);
         });
 
+        it("addUsingPath (silly chars)", async function () {
+
+            const name = `Testing Add & = + - ${getRandomString(4)}.txt`;
+            const res = await files.addUsingPath(name, "Some test text content.");
+            const file = await sp.web.getFileByServerRelativePath(res.data.ServerRelativeUrl)();
+            expect(file.Name).to.eq(name);
+        });
+
         it("addUsingPath (overwrite)", async function () {
 
             const name = `Testing Add %# - ${getRandomString(4)}.txt`;
@@ -127,6 +135,14 @@ describe("files", () => {
             const far = await files.add(name, "Some test text content.");
             const fileById = await sp.web.getFileById(far.data.UniqueId).select("UniqueId")();
             return expect(far.data.UniqueId).to.eq(fileById.UniqueId);
+        });
+
+        it("filter works for silly chars (issue # 1208)", async function () {
+
+            const name = `Testing Silly Chars & = + - ${getRandomString(4)}.txt`;
+            await files.addUsingPath(name, "Some test text content.");
+            const fileList = await files.filter(`Name eq '${name}'`)();
+            return expect(fileList).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
         });
     }
 });

--- a/test/sp/sites.ts
+++ b/test/sp/sites.ts
@@ -49,7 +49,7 @@ describe("Sites", () => {
       return expect(webIDResult.web.lists()).to.eventually.be.fulfilled;
     });
 
-    it.only(".exists", async function () {
+    it(".exists", async function () {
       const oWeb = await sp.site();
       const exists: boolean = await sp.site.exists(oWeb.Url);
       const notExists: boolean = await sp.site.exists(`${oWeb.Url}/RANDOM`);


### PR DESCRIPTION
…order by query params

#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1208

#### What's in this Pull Request?

Adds encoding for filter, select, expand, and order by query params when they are added through the methods. Change applies to both sp and graph