### PR TITLE
mkdocs: remove duplicate Search item from the docs menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,6 @@ nav:
       - 'Related Items': 'sp/related-items.md'
       - Search: 'sp/search.md'
       - Security: 'sp/security.md'
-      - Search: 'sp/search.md'
       - Sharing: 'sp/sharing.md'
       - 'Site Designs': 'sp/site-designs.md'
       - 'Site Groups': 'sp/site-groups.md'


### PR DESCRIPTION
#### Category
- [x] Documentation update

#### What's in this Pull Request?

"Search" item is duplicated in the docs menu, so one can be removed.
![image](https://user-images.githubusercontent.com/1970236/87431003-3178d400-c610-11ea-98bb-ae51cf32877c.png)
