### PR TITLE
Adds thumbnailUrl property to clientside page

### DIFF
--- a/docs/sp/clientside-pages.md
+++ b/docs/sp/clientside-pages.md
@@ -294,6 +294,24 @@ await page.save();
 
 > Banner images need to exist within the same site collection as the page where you want to use them.
 
+### thumbnailUrl
+
+Allows you to set the thumbnail used for the page independently of the banner.
+
+> If you set the bannerImageUrl property and ant thumbnailUrl the thumbnail will be reset to match the banner, mimicing the UI functionality.
+
+```TypeScript
+// our page instance
+const page: IClientsidePage;
+
+// get the current value
+const value = page.thumbnailUrl;
+
+// set the value
+page.thumbnailUrl = "/server/relative/path/to/image.png";
+await page.save();
+```
+
 ### topicHeader
 
 ```TypeScript
@@ -591,7 +609,7 @@ pageCopy2.save();
 
 ### setBannerImage
 
-Sets the banner image url and optionally additional properties. Similar to setting the bannerImageUrl property, however allows you to set additional properties if needed. If you do not need to set the additional properties they are equivalent.
+Sets the banner image url and optionally additional properties. Allows you to set additional properties if needed, if you do not need to set the additional properties they are equivalent.
 
 > Banner images need to exist within the same site collection as the page where you want to use them.
 

--- a/packages/sp/clientside-pages/types.ts
+++ b/packages/sp/clientside-pages/types.ts
@@ -313,7 +313,7 @@ export class _ClientsidePage extends _SharePointQueryable implements IClientside
 
             const site = Site(extractWebUrl(this.toUrl()));
             const web = Web(extractWebUrl(this.toUrl()));
-            const imgFile = web.getFileByServerRelativePath(origImgUrl.replace(/%20/i, " "));
+            const imgFile = web.getFileByServerRelativePath(origImgUrl.replace(/%20/ig, " "));
 
             let siteId = "";
             let webId = "";


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1263

#### What's in this Pull Request?

- Adds thumbnailUrl property to clientside page, allowing thumbnail to be set independently of the banner image
- Updates docs to include new property