### PR TITLE
feat(list): get validation message endpoint

### DIFF
--- a/packages/sp/lists/types.ts
+++ b/packages/sp/lists/types.ts
@@ -172,7 +172,7 @@ export class _List extends _SharePointQueryableInstance<IListInfo> {
      * Gets the user validation message for this list
      *
      */
-    public get validationMessage() {
+    public get validationMessage(): ISharePointQueryable<string> {
         return tag.configure(SharePointQueryable(this, "validationMessage"), "l.validationMessage");
     }
 

--- a/packages/sp/lists/types.ts
+++ b/packages/sp/lists/types.ts
@@ -169,6 +169,14 @@ export class _List extends _SharePointQueryableInstance<IListInfo> {
     }
 
     /**
+     * Gets the user validation message for this list
+     *
+     */
+    public get validationMessage() {
+        return tag.configure(SharePointQueryable(this, "validationMessage"), "l.validationMessage");
+    }
+
+    /**
      * Updates this list intance with the supplied properties
      *
      * @param properties A plain object hash of values to update for the list


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

Adds a missing mapping for an endpoint:

```ts
sp.web.lists.getByTitle("Some List").validationMessage().then(console.log) // → validation message string
```

Note: this is the user message set in the list validation settings.
