### PR TITLE
adding support for file.Exists to handle errors #1320

### DIFF
--- a/docs/sp/files.md
+++ b/docs/sp/files.md
@@ -403,4 +403,18 @@ import "@pnp/sp/files";
 await sp.web.rootFolder.files.getByName("name.txt").deleteWithParams({
     BypassSharedLock: true,
 });
-```  
+```
+
+### exists
+
+_Added in 2.0.9_
+
+Checks to see if a file exists
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/files";
+
+const exists = await sp.web.rootFolder.files.getByName("name.txt").exists();
+```

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -359,6 +359,8 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
             const r = await this.clone(File).select("Exists")();
             return r.Exists;
         } catch (e) {
+            // this treats any error here as the file not existing, which
+            // might not be true, but is good enough.
             return false;
         }
     }

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -350,6 +350,20 @@ export class _File extends _SharePointQueryableInstance<IFileInfo> {
     }
 
     /**
+     * Checks to see if the file represented by this object exists
+     *
+     */
+    @tag("fi.exists")
+    public async exists(): Promise<boolean> {
+        try {
+            const r = await this.clone(File).select("Exists")();
+            return r.Exists;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    /**
      * Gets the contents of the file as text. Not supported in batching.
      *
      */

--- a/test/sp/files.ts
+++ b/test/sp/files.ts
@@ -275,6 +275,22 @@ describe("file", () => {
             expect(r.length).to.eq(0);
         });
 
+        it("exists - true", async function () {
+
+            const name = `Testing Exists - ${getRandomString(4)}.txt`;
+            await files.add(name, "Some test text content.");
+            const exists = await files.getByName(name).exists();
+            // tslint:disable-next-line: no-unused-expression
+            expect(exists).to.be.true;
+        });
+
+        it("exists - false", async function () {
+
+            const exists = await files.getByName(`Testing Exists - ${getRandomString(4)}.txt`).exists();
+            // tslint:disable-next-line: no-unused-expression
+            expect(exists).to.be.false;
+        });
+
         it("setContent", async function () {
 
             const name = `Testing setContent - ${getRandomString(4)}.txt`;


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1320

#### What's in this Pull Request?

Adds a method to check to see if a file exists while trapping the error so you get back a client true/false.

> This method treats any error in the request as the file not existing. This is fine but something to note.