### PR TITLE
fix for #1311

### DIFF
--- a/packages/sp/webs/types.ts
+++ b/packages/sp/webs/types.ts
@@ -85,7 +85,7 @@ export class _Web extends _SharePointQueryableInstance<IWebInfo> {
     @tag("w.getParentWeb")
     public async getParentWeb(): Promise<IOpenWebByIdResult> {
         const { ParentWeb } = await spGet(this.select("ParentWeb/Id").expand("ParentWeb"));
-        return ParentWeb ? Site(this.parentUrl).openWebById(ParentWeb.Id) : null;
+        return ParentWeb?.Id ? Site(this.parentUrl).openWebById(ParentWeb.Id) : null;
     }
 
     /**


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1311

#### What's in this Pull Request?

Fixes an issue for users not using minimal meta-data where unpatched 2016 returns verbose results that caused an error in getParentWeb.