### PR TITLE
updates to adjust taxonomy support and docs to reflect changes in api…

### DIFF
--- a/docs/sp/taxonomy.md
+++ b/docs/sp/taxonomy.md
@@ -2,6 +2,8 @@
 
 Provides access to the v2.1 api term store
 
+### Docs updated with v2.0.9 release as the underlying API changed.
+
 > NOTE: This API may change so please be aware updates to the taxonomy module will not trigger a major version bump in PnPjs even if they are breaking. Once things stabalize this note will be removed.
 
 [![Invokable Banner](https://img.shields.io/badge/Invokable-informational.svg)](../concepts/invokable.md) [![Selective Imports Banner](https://img.shields.io/badge/Selective%20Imports-informational.svg)](../concepts/selective-imports.md)
@@ -30,11 +32,8 @@ import { sp } from "@pnp/sp";
 import "@pnp/sp/taxonomy";
 import { ITermGroupInfo } from "@pnp/sp/taxonomy";
 
-// get term groups data
-const info: ITermGroupInfo[] = await sp.termStore.termGroups();
-
-// seems to get the same information
-const info2: ITermGroupInfo[] = await sp.termStore.groups();
+// get term groups
+const info: ITermGroupInfo[] = await sp.termStore.groups();
 ```
 
 ### Get By Id
@@ -45,9 +44,7 @@ import "@pnp/sp/taxonomy";
 import { ITermGroupInfo } from "@pnp/sp/taxonomy";
 
 // get term groups data
-const info: ITermGroupInfo = await sp.termStore.termGroups.getById("338666a8-1111-2222-3333-f72471314e72")();
-
-const info2: ITermGroupInfo = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72")();
+const info: ITermGroupInfo = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72")();
 ```
 
 ## Term Sets
@@ -61,11 +58,11 @@ import { sp } from "@pnp/sp";
 import "@pnp/sp/taxonomy";
 import { ITermSetInfo } from "@pnp/sp/taxonomy";
 
-// get term set data
-const info: ITermSetInfo[] = await sp.termStore.termGroups.getById("338666a8-1111-2222-3333-f72471314e72").termSets();
+// get get set info
+const info: ITermSetInfo[] = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets();
 
-// seems to get the same information
-const info2: ITermSetInfo[] = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets();
+// also works to get sets not in groups
+const info: ITermSetInfo[] = await sp.termStore.sets();
 ```
 
 ### Get By Id
@@ -76,9 +73,9 @@ import "@pnp/sp/taxonomy";
 import { ITermSetInfo } from "@pnp/sp/taxonomy";
 
 // get term set data
-const info: ITermSetInfo = await sp.termStore.termGroups.getById("338666a8-1111-2222-3333-f72471314e72").termSets.getById("338666a8-1111-2222-3333-f72471314e72")();
+const info: ITermSetInfo = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets.getById("338666a8-1111-2222-3333-f72471314e72")();
 
-const info2: ITermSetInfo = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets.getById("338666a8-1111-2222-3333-f72471314e72")();
+const info2: ITermSetInfo = await sp.termStore.sets.getById("338666a8-1111-2222-3333-f72471314e72")();
 ```
 
 ## Terms
@@ -92,11 +89,10 @@ import { sp } from "@pnp/sp";
 import "@pnp/sp/taxonomy";
 import { ITermInfo } from "@pnp/sp/taxonomy";
 
-// get term set data
-const info: ITermInfo = await sp.termStore.termGroups.getById("338666a8-1111-2222-3333-f72471314e72").termSets.getById("338666a8-1111-2222-3333-f72471314e72").terms();
+// list all the terms
+const info: ITermInfo = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets.getById("338666a8-1111-2222-3333-f72471314e72").children();
 
-// seems to get the same information
-const info2: ITermInfo = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets.getById("338666a8-1111-2222-3333-f72471314e72").terms();
+const info2: ITermInfo = await sp.termStore.sets.getById("338666a8-1111-2222-3333-f72471314e72").children();
 ```
 
 ### Get By Id
@@ -107,7 +103,7 @@ import "@pnp/sp/taxonomy";
 import { ITermInfo } from "@pnp/sp/taxonomy";
 
 // get term set data
-const info: ITermInfo = await sp.termStore.termGroups.getById("338666a8-1111-2222-3333-f72471314e72").termSets.getById("338666a8-1111-2222-3333-f72471314e72").terms.getById("338666a8-1111-2222-3333-f72471314e72")();
+const info: ITermInfo = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets.getById("338666a8-1111-2222-3333-f72471314e72").getTermById("338666a8-1111-2222-3333-f72471314e72")();
 
-const info2: ITermInfo = await sp.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets.getById("338666a8-1111-2222-3333-f72471314e72").terms.getById("338666a8-1111-2222-3333-f72471314e72")();
+const info2: ITermInfo = await sp.termStore.sets.getById("338666a8-1111-2222-3333-f72471314e72").getTermById("338666a8-1111-2222-3333-f72471314e72")();
 ```

--- a/packages/odata/queryable.ts
+++ b/packages/odata/queryable.ts
@@ -119,7 +119,7 @@ export abstract class Queryable<DefaultActionType = any> implements IQueryable<D
   }
 
   public set data(value: Partial<IQueryableData<DefaultActionType>>) {
-    this._data = Object.assign({}, cloneQueryableData(this.data), cloneQueryableData(value));
+    this._data = Object.assign({}, this.data, cloneQueryableData(value));
   }
 
   /**

--- a/packages/sp/taxonomy/index.ts
+++ b/packages/sp/taxonomy/index.ts
@@ -17,9 +17,7 @@ export {
     ITaxonomyProperty,
     ITermInfo,
     ITermSet,
-    ITerms,
     TermSet,
-    Terms,
     IRelation,
     IRelationInfo,
     IRelations,
@@ -27,6 +25,8 @@ export {
     Relation,
     Relations,
     Term,
+    Children,
+    IChildren,
 } from "./types";
 
 declare module "../rest" {

--- a/test/sp/taxonomy.ts
+++ b/test/sp/taxonomy.ts
@@ -7,7 +7,7 @@ import { testSettings } from "../main";
  * Skipping for now as the API is not fully deployed or stable yet. These tests passed within my tenant.
  * So it worked on my machine. ;)
  */
-describe.skip("Taxonomy", () => {
+describe("Taxonomy", () => {
 
     if (testSettings.enableWebTests) {
 
@@ -15,17 +15,6 @@ describe.skip("Taxonomy", () => {
 
             const info = await sp.termStore();
             return expect(info).has.property("id");
-        });
-
-        it("Get Term Group Info (termGroups)", async function () {
-
-            const info = await sp.termStore.termGroups();
-
-            if (info.length < 1) {
-                return;
-            }
-
-            return expect(info[0]).has.property("id");
         });
 
         it("Get Term Group Info (groups)", async function () {
@@ -37,17 +26,6 @@ describe.skip("Taxonomy", () => {
             }
 
             return expect(info[0]).has.property("id");
-        });
-
-        it("Get Term Group By Id Info (termGroups)", async function () {
-
-            const info = await sp.termStore.termGroups();
-
-            if (info.length < 1) {
-                return;
-            }
-
-            return expect(sp.termStore.termGroups.getById(info[0].id)()).to.eventually.have.property("id");
         });
 
         it("Get Term Group By Id Info (groups)", async function () {
@@ -65,23 +43,6 @@ describe.skip("Taxonomy", () => {
         /**
          * Term Sets
          */
-        it("Get Term Set Info (termSets)", async function () {
-
-            const info = await sp.termStore.groups.top(1)();
-
-            if (info.length < 1) {
-                return;
-            }
-
-            const info2 = await sp.termStore.groups.getById(info[0].id).sets();
-
-            if (info2.length < 1) {
-                return;
-            }
-
-            return expect(info2[0]).has.property("id");
-        });
-
         it("Get Term Set Info (sets)", async function () {
 
             const info = await sp.termStore.groups.top(1)();
@@ -97,24 +58,6 @@ describe.skip("Taxonomy", () => {
             }
 
             return expect(info2[0]).has.property("id");
-        });
-
-        it("Get Term Set By Id Info (termSets)", async function () {
-
-            const info = await sp.termStore.groups.top(1)();
-
-            if (info.length < 1) {
-                return;
-            }
-
-            const group = sp.termStore.groups.getById(info[0].id);
-            const info2 = await group.termSets();
-
-            if (info2.length < 1) {
-                return;
-            }
-
-            return expect(group.termSets.getById(info2[0].id)()).to.eventually.have.property("id");
         });
 
         it("Get Term Set By Id Info (sets)", async function () {
@@ -139,24 +82,6 @@ describe.skip("Taxonomy", () => {
         /**
          * Terms
          */
-        it("Get Terms Info (termSets)", async function () {
-
-            const info = await sp.termStore.termGroups.top(1)();
-
-            if (info.length < 1) {
-                return;
-            }
-
-            const group = sp.termStore.termGroups.getById(info[0].id);
-            const info2 = await group.termSets();
-
-            if (info2.length < 1) {
-                return;
-            }
-
-            return expect(group.termSets.getById(info2[0].id).terms()).to.eventually.be.fulfilled;
-        });
-
         it("Get Terms Info (sets)", async function () {
 
             const info = await sp.termStore.groups.top(1)();
@@ -172,31 +97,7 @@ describe.skip("Taxonomy", () => {
                 return;
             }
 
-            return expect(group.sets.getById(info2[0].id).terms()).to.eventually.be.fulfilled;
-        });
-
-        it("Get Term Info (termSets)", async function () {
-
-            const info = await sp.termStore.termGroups.top(1)();
-
-            if (info.length < 1) {
-                return;
-            }
-
-            const group = sp.termStore.termGroups.getById(info[0].id);
-            const info2 = await group.termSets();
-
-            if (info2.length < 1) {
-                return;
-            }
-
-            const info3 = await group.termSets.getById(info2[0].id).terms();
-
-            if (info3.length < 1) {
-                return;
-            }
-
-            return expect(group.termSets.getById(info2[0].id).terms.getById(info3[0].id)()).to.eventually.have.property("id");
+            return expect(group.sets.getById(info2[0].id).children()).to.eventually.be.fulfilled;
         });
 
         it("Get Term Info (sets)", async function () {
@@ -214,13 +115,13 @@ describe.skip("Taxonomy", () => {
                 return;
             }
 
-            const info3 = await group.sets.getById(info2[0].id).terms();
+            const info3 = await group.sets.getById(info2[0].id).children();
 
             if (info3.length < 1) {
                 return;
             }
 
-            return expect(group.sets.getById(info2[0].id).terms.getById(info3[0].id)()).to.eventually.have.property("id");
+            return expect(group.sets.getById(info2[0].id).getTermById(info3[0].id)).to.eventually.have.property("id");
         });
     }
 });


### PR DESCRIPTION
… #1332

#### Category
- [X] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1332 

Changes to taxonomy support to re-align to the server api.

- Adding a getTermById method to term sets
- Removing the terms property of term sets
- Updating children to only be a queryable collection
- Also taking this opportunity to remove the duplications and collapse on the sets and groups properties and removing termGroups and termSets props.