### PR TITLE
Use string values for the BasePermission High and Low properties in SP RoleDef updates.

### DIFF
--- a/packages/sp/security/types.ts
+++ b/packages/sp/security/types.ts
@@ -170,6 +170,10 @@ export class _RoleDefinition extends _SharePointQueryableInstance<IRoleDefinitio
         const s = ["BasePermissions"];
         if (hOP(properties, s[0]) !== undefined) {
             properties[s[0]] = assign(metadata(`SP.${s[0]}`), properties[s[0]]);
+
+            const bpObj = properties[s[0]];
+            bpObj.High = bpObj.High.toString();
+            bpObj.Low = bpObj.Low.toString();
         }
 
         const postBody = body(assign(metadata("SP.RoleDefinition"), properties), headers({ "X-HTTP-Method": "MERGE" }));


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

Code change and supporting test to allow updating an SP RoleDef's BasePermission value.

Current implementation passes numbers rather than strings for the BasePermission Low and High value when updating a RoleDef. Strings are already used for these properties when creating a RoleDef so this PR does the same for updates.

See https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-rest-reference/dn531432(v=office.15)#roledefinition-resource for use of strings in REST calls updating a RoleDefinition resource.

Please note that the test operates on the parent web, rather than the temporary subsite created during a test run. This is due to RoleDefs being inherited by subsites meaning any RoleDef testing must be performed on a root site.
