### PR TITLE
Add GitHub Actions workflows for running tests (replaces Travis)

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,17 @@
+name: Testing
+on: pull_request
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "10"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint
+        run: npm run lint
+      - name: Run tests
+        run: npx mocha --mode pr --cleanup

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,7 +1,7 @@
-name: Testing
+name: Pull Request Testing
 on: pull_request
 jobs:
-  run_tests:
+  run_pr_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,7 +1,7 @@
-name: Testing
+name: Push Testing
 on: push
 jobs:
-  run_tests:
+  run_push_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,17 @@
+name: Testing
+on: push
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "10"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint 
+        run: npm run lint
+      - name: Run tests
+        run: npx mocha --mode push --cleanup


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

- Resolves https://github.com/pnp/pnpjs/issues/1405

#### What's in this Pull Request?

- Implements your existing travis CI workflows in GitHub Actions
- Two different workflows are included: one will run on every push and the other will run on pull requests when they are opened or updated
  - This is what you previously had configured in travis

Once this has been merged, you'll see the status of each run on every future commit pushed to this repo on any branch. You can see all the Actions in the Actions tab of the repo. Ideally you'll also want to set a rule on the repo that any pull requests must receive a pass status for this action in order to be merged

