### PR TITLE
Added new method to get the Team Site for a Group

### DIFF
--- a/docs/graph/groups.md
+++ b/docs/graph/groups.md
@@ -121,6 +121,14 @@ const endDate = new Date("2020-03-01");
 const events = graph.groups.getById("7d2b9355-0891-47d3-84c8-bf2cd9c62177").getCalendarView(startDate, endDate);
 ```
 
+## Get the Team Site for a Group
+```TypeScript
+import { graph } from "@pnp/graph";
+import "@pnp/graph/groups";
+
+const teamSite = await graph.groups.getById("7d2b9355-0891-47d3-84c8-bf2cd9c62177").sites.root();
+const url = teamSite.webUrl
+```
 ## Group Photo Operations
 
 See [Photos](./photos.md)

--- a/packages/graph/groups/index.ts
+++ b/packages/graph/groups/index.ts
@@ -8,6 +8,8 @@ export {
     IGroup,
     IGroupAddResult,
     IGroups,
+    Sites,
+    ISites,
 } from "./types";
 
 declare module "../rest" {

--- a/packages/graph/groups/types.ts
+++ b/packages/graph/groups/types.ts
@@ -72,6 +72,10 @@ export class _Group extends _DirectoryObject<IGroupType> {
         view.query.set("endDateTime", end.toISOString());
         return view();
     }
+
+    public get sites(): ISites {
+        return Sites(this);
+    }
 }
 export interface IGroup extends _Group, IDeleteable, IUpdateable { }
 export const Group = graphInvokableFactory<IGroup>(_Group);
@@ -127,3 +131,20 @@ export interface IGroupAddResult {
     group: IGroup;
     data: any;
 }
+
+
+/**
+ * Sites
+ */
+@defaultPath("sites")
+export class _Sites extends _GraphQueryableCollection {
+    /**
+     * Gets the team site for the group
+     */
+    public async root(): Promise<any> {
+        const root = this.clone(Sites, "root");
+        return root();
+    }
+}
+export interface ISites extends _Sites { }
+export const Sites = graphInvokableFactory<ISites>(_Sites);

--- a/packages/sp/items/types.ts
+++ b/packages/sp/items/types.ts
@@ -18,7 +18,7 @@ import { metadata } from "../utils/metadata";
 import { defaultPath } from "../decorators";
 import { spPost } from "../operations";
 import { tag } from "../telemetry";
-import { IResourcePath } from '../utils/toResourcePath';
+import { IResourcePath } from "../utils/toResourcePath";
 
 /**
  * Describes a collection of Item objects

--- a/test/graph/groups.ts
+++ b/test/graph/groups.ts
@@ -67,6 +67,30 @@ describe("Groups", function () {
       return expect(groupName === group.displayName).is.not.true;
     });
 
+    it("sites", async function() {
+      // Find an existing group
+      // This has to be tested on existing groups. On a newly created group, this returns an error often
+      // "Resource provisioning is in progress. Please try again.". This is expected as the team site provisioning takes a few seconds when creating a new group
+      const groups = await graph.groups();
+      const grpID = groups[0].id;
+
+      // Get sites within this group
+      const sites = await graph.groups.getById(grpID).sites.get();
+
+      return expect(sites.length).is.not.null;
+    });
+
+    it("sites/root", async function() {
+      // Find an existing group
+      const groups = await graph.groups();
+      const grpID = groups[0].id;
+
+      // Get the group team site
+      const root = await graph.groups.getById(grpID).sites.root();
+
+      return expect(root).is.not.null;
+    });
+
     // it("addFavorite()", async function () {
     //   // This is a user context function. Can't test in application context
     //   return expect(true).is.true;


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1444 

#### What's in this Pull Request?

Added a new method to IGroup to get the Team Site of a Group.

Usage: graph.groups.getById("group-id").sites.root();

Graph API Reference is [here](https://docs.microsoft.com/en-us/graph/api/site-get?view=graph-rest-1.0&tabs=http#access-a-group-team-site)

Unit tests and docs are updated.