### PR TITLE
Push tags on release

### DIFF
--- a/tools/publish/publish-win.bat
+++ b/tools/publish/publish-win.bat
@@ -30,6 +30,7 @@ call npm install
 ::
 call npm version patch
 git push
+git push --tags
 
 ::
 :: publish the packages


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1484

#### What's in this Pull Request?

The `npm version patch` command that is used during publishing new releases already git tags the version, so the only thing that seems missing is a `git push --tags`.

See https://git-scm.com/book/en/v2/Git-Basics-Tagging#_sharing_tags