### PR TITLE
feat(graph): add outlook user endpoints

### DIFF
--- a/docs/graph/outlook.md
+++ b/docs/graph/outlook.md
@@ -1,0 +1,48 @@
+# @pnp/graph/outlook
+
+Represents the Outlook services available to a user. Currently, only interacting with categories is supported. 
+
+You can learn more  by reading the [Official Microsoft Graph Documentation](https://docs.microsoft.com/en-us/graph/api/resources/outlookuser?view=graph-rest-1.0).
+
+## IUsers, IUser, IPeople
+
+[![Invokable Banner](https://img.shields.io/badge/Invokable-informational.svg)](../concepts/invokable.md) [![Selective Imports Banner](https://img.shields.io/badge/Selective%20Imports-informational.svg)](../concepts/selective-imports.md)  
+
+|Scenario|Import Statement|
+|--|--|
+|Selective 1|import { graph } from "@pnp/graph";<br />import {Outlook, IOutlook, MasterCategories, IMasterCategories} from "@pnp/graph/outlook";|
+|Selective 2|import { graph } from "@pnp/graph";<br />import "@pnp/graph/outlook";|
+|Preset: All|import { graph, Outlook, IOutlook, MasterCategories, IMasterCategories } from "@pnp/graph/presets/all";|
+
+## Current User Outlook Services
+
+```TypeScript
+import { graph } from "@pnp/graph";
+import "@pnp/graph/users";
+import "@pnp/graph/outlook";
+
+const currentOutlookUser = await graph.me.outlook();
+```
+
+## Get All Categories for Current User
+
+```TypeScript
+import { graph } from "@pnp/graph";
+import "@pnp/graph/users";
+import "@pnp/graph/outlook";
+
+const categories = await graph.me.outlook.masterCategories();
+```
+
+## Add Category for Current User
+
+```TypeScript
+import { graph } from "@pnp/graph";
+import "@pnp/graph/users";
+import "@pnp/graph/outlook";
+
+await graph.me.outlook.masterCategories.add({
+  displayName: 'Newsletters', 
+  color: 'preset2'
+});
+```

--- a/packages/graph/outlook/index.ts
+++ b/packages/graph/outlook/index.ts
@@ -1,0 +1,9 @@
+import "./users.js";
+
+export {
+    Outlook,
+    IOutlook,
+    IMasterCategories,
+    MasterCategories,
+    IMasterCategoryAddResult,
+} from "./types.js";

--- a/packages/graph/outlook/types.ts
+++ b/packages/graph/outlook/types.ts
@@ -5,7 +5,7 @@ import { graphPost } from "@pnp/graph";
 import { body } from "@pnp/odata";
 
 /**
- * Calendar
+ * Outlook
  */
 export class _Outlook extends _GraphQueryableInstance<IOutlookType> {
 

--- a/packages/graph/outlook/types.ts
+++ b/packages/graph/outlook/types.ts
@@ -1,0 +1,47 @@
+import { _GraphQueryableCollection, _GraphQueryableInstance, graphInvokableFactory } from "@pnp/graph/graphqueryable";
+import { OutlookUser as IOutlookType, OutlookCategory as IOutlookCategoryType } from "@microsoft/microsoft-graph-types";
+import { defaultPath } from "@pnp/graph/decorators";
+import { graphPost } from "@pnp/graph";
+import { body } from "@pnp/odata";
+
+/**
+ * Calendar
+ */
+export class _Outlook extends _GraphQueryableInstance<IOutlookType> {
+
+    public get masterCategories(): IMasterCategories {
+        return MasterCategories(this);
+    }
+}
+export interface IOutlook extends _Outlook {}
+export const Outlook = graphInvokableFactory<IOutlook>(_Outlook);
+
+/**
+ * Categories
+ */
+@defaultPath("masterCategories")
+export class _MasterCategories extends _GraphQueryableCollection<IOutlookCategoryType[]> {
+
+    /**
+     * Adds a new event to the collection
+     *
+     * @param properties The set of properties used to create the event
+     */
+    public async add(properties: IOutlookCategoryType): Promise<IMasterCategoryAddResult> {
+
+        const data = await graphPost(this, body(properties));
+
+        return {
+            data,
+        };
+    }
+}
+export interface IMasterCategories extends _MasterCategories { }
+export const MasterCategories = graphInvokableFactory<IMasterCategories>(_MasterCategories);
+
+/**
+ * MasterCategoryAddResult
+ */
+export interface IMasterCategoryAddResult {
+    data: IOutlookCategoryType;
+}

--- a/packages/graph/outlook/users.ts
+++ b/packages/graph/outlook/users.ts
@@ -1,0 +1,14 @@
+import { addProp } from "@pnp/odata";
+import { _User } from "../users/types.js";
+import { Outlook, IOutlook } from "./types.js";
+
+declare module "../users/types" {
+    interface _User {
+        readonly outlook: IOutlook;
+    }
+    interface IUser {
+        readonly outlook: IOutlook;
+    }
+}
+
+addProp(_User, "outlook", Outlook, "outlook");

--- a/test/graph/outlook.ts
+++ b/test/graph/outlook.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import { graph } from "@pnp/graph";
+import "@pnp/graph/users";
+import "@pnp/graph/outlook";
+import { testSettings } from "../main";
+import { OutlookCategory } from "@microsoft/microsoft-graph-types";
+import { getRandomString } from "@pnp/common";
+
+describe("Outlook", function () {
+    // We can't test for graph.me calls in an application context
+    if (testSettings.enableWebTests) {
+
+        it("Get current Outlook user", async function () {
+            const outlookUser = await graph.me.outlook();
+            return expect(outlookUser).is.not.null;
+        });
+
+        it("Get all categories for current user", async function () {
+            const categories = await graph.me.outlook.masterCategories();
+            return expect(categories.length).is.gt(0);
+        });
+
+        it("Add category for current user", async function () {
+            // there is no method to clean up after add, so generate a random name
+            const presetCategory: OutlookCategory = {
+                displayName: `Test category-${getRandomString(8)}`,
+                color: "preset2",
+            };
+
+            const addedCategory = await graph.me.outlook.masterCategories.add(presetCategory);
+
+            return expect(addedCategory).is.not.null;
+        });
+    }
+});


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

This adds mapping for the following endpoints:

- `GET /me/outlook`
- `GET /me/outlook/masterCategories`
-  `POST /me/outlook/masterCategories`

<https://docs.microsoft.com/en-us/graph/api/resources/outlookuser?view=graph-rest-1.0>

Example:
```ts
import '@pnp/graph/users';
import '@pnp/graph/outlook';

await graph.me.outlook.get().then(console.log)
await graph.me.outlook.masterCategories.get().then(console.log);
await graph.me.outlook.masterCategories.add({displayName: 'Test category', color: 'preset2'});
```

Let me know if I missed anything of there's something that needs changing :)