### PR TITLE
Fixes for proxy code, docs on accessing client-side webpart props, and address taxonomy issue

### DIFF
--- a/docs/sp/clientside-pages.md
+++ b/docs/sp/clientside-pages.md
@@ -298,7 +298,7 @@ part.DisplayTitle = "My New Title!";
 await page.save();
 ```
 
-> Unfortunately each webpart can be authored differently, so there isn't a way to know how the setting for a given webpart without loading it and examining how the properties are stored.
+> Unfortunately each webpart can be authored differently, so there isn't a way to know how the setting for a given webpart are stored without loading it and examining the properties.
 
 ## Page Operations
 

--- a/docs/sp/clientside-pages.md
+++ b/docs/sp/clientside-pages.md
@@ -8,7 +8,7 @@ The 'clientside-pages' module allows you to create, edit, and delete modern Shar
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Selective 1 | import { sp } from "@pnp/sp";<br />import { ClientsidePageFromFile, ClientsideText, ClientsideWebpartPropertyTypes, CreateClientsidePage, ClientsideWebpart, IClientsidePage } from "@pnp/sp/clientside-pages"; |
 | Selective 2 | import { sp } from "@pnp/sp";<br />import "@pnp/sp/clientside-pages";                                                                                                                                           |
-| Preset: All | import { sp, ClientsidePageFromFile, ClientsideText, ClientsideWebpartPropertyTypes, CreateClientsidePage, ClientsideWebpart, IClientsidePage } from "@pnp/sp/presets/all";                                    |
+| Preset: All | import { sp, ClientsidePageFromFile, ClientsideText, ClientsideWebpartPropertyTypes, CreateClientsidePage, ClientsideWebpart, IClientsidePage } from "@pnp/sp/presets/all";                                     |
 
 ## Create a new Page
 
@@ -260,6 +260,45 @@ page.addSection().addControl(part);
 
 await page.save();
 ```
+
+### Handle Different Webpart's Settings
+
+There are many ways that client side web parts are implemented and we can't provide handling within the library for all possibilities. This example shows how to handle a property set within the serverProcessedContent, in this case a List part's display title.
+
+```TypeScript
+import { sp } from "@pnp/sp";
+import "@pnp/sp/webs";
+import { ClientsideWebpart } from "@pnp/sp/clientside-pages";
+
+// we create a class to wrap our functionality in a reusable way
+class ListWebpart extends ClientsideWebpart {
+
+  constructor(control: ClientsideWebpart) {
+    super((<any>control).json);
+  }
+
+  // add property getter/setter for what we need, in this case "listTitle" within searchablePlainTexts
+  public get DisplayTitle(): string {
+    return this.json.webPartData?.serverProcessedContent?.searchablePlainTexts?.listTitle || "";
+  }
+
+  public set DisplayTitle(value: string) {
+    this.json.webPartData.serverProcessedContent.searchablePlainTexts.listTitle = value;
+  }
+}
+
+// now we load our page
+const page = await sp.web.loadClientsidePage("/sites/dev/SitePages/List-Web-Part.aspx");
+
+// get our part and pass it to the constructor of our wrapper class
+const part = new ListWebpart(page.sections[0].columns[0].getControl(0));
+
+part.DisplayTitle = "My New Title!";
+
+await page.save();
+```
+
+> Unfortunately each webpart can be authored differently, so there isn't a way to know how the setting for a given webpart without loading it and examining how the properties are stored.
 
 ## Page Operations
 

--- a/packages/nodejs/sptokenutils.ts
+++ b/packages/nodejs/sptokenutils.ts
@@ -1,8 +1,8 @@
 import { parse } from "url";
-import nodeFetch from "node-fetch";
 import * as jwt from "jsonwebtoken";
 import { ITypedHash } from "@pnp/common";
 import { AuthToken, SharePointServicePrincipal, ITokenCacheManager } from "./types.js";
+import { fetch } from "./net/fetch.js";
 
 class MapCacheManager implements ITokenCacheManager {
 
@@ -85,7 +85,7 @@ async function getTokenInternal(params: GetTokenInternalParams): Promise<AuthTok
     body.push(`client_secret=${encodeURIComponent(params.clientSecret)}`);
     body.push(`resource=${resource}`);
 
-    const r = await nodeFetch(params.stsUri, {
+    const r = await fetch(params.stsUri, {
         body: body.join("&"),
         headers: {
             "Content-Type": "application/x-www-form-urlencoded",

--- a/packages/sp/taxonomy/types.ts
+++ b/packages/sp/taxonomy/types.ts
@@ -124,6 +124,12 @@ export class _TermSet extends _SharePointQueryableInstance<ITermSetInfo> {
                         orderedChildren.push(found);
                     }
                 });
+                // we have a case where if a set is ordered and a term is added to that set
+                // AND the ordering information hasn't been updated the new term will not have
+                // any associated ordering information. See #1547 which reported this. So here we
+                // append any terms remaining in "terms" not in "orderedChildren" to the end of "orderedChildren"
+                orderedChildren.push(...terms.filter(info => ordering.indexOf(info.id) < 0));
+
                 return orderedChildren;
             }
             return terms;

--- a/test/nodejs/sp-extensions.ts
+++ b/test/nodejs/sp-extensions.ts
@@ -64,7 +64,7 @@ describe("nodejs - sp-extensions", () => {
                 (<any>fs).rmSync(tmpFilePath);
             } else {
                 fs.unlinkSync(tmpFilePath);
-            }            
+            }
         });
 
         it("Should allow adding chunks non-stream", async function () {


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [X] Documentation update?

#### Related Issues

fixes #1514
fixes #1543
fixes #1547



#### What's in this Pull Request?

- updates docs to include sample on accessing properties of list client-side webpart
- fixes a bug with setProxyUrl that was preventing authentication as proxy settings were being bypassed
- adds code to handle a situation where new custom ordered taxonomy terms don't have associated ordering information until the custom order is edited.