### PR TITLE
Bug setting TaxonomyFieldTypeMulti

### DIFF
--- a/packages/sp/column-defaults/list.ts
+++ b/packages/sp/column-defaults/list.ts
@@ -166,7 +166,6 @@ _List.prototype.setDefaultColumnValues = async function (this: _List, defaults: 
                 if (isArray(fieldDefault.value)) {
                     value = (<{ wssId: string; termName: string; termId: string }[]>fieldDefault.value).map(v => `${v.wssId};#${v.termName}|${v.termId}`).join(";#");
                 }
-                value = `${(<any>fieldDefault.value).wssId};#${(<any>fieldDefault.value).termName}|${(<any>fieldDefault.value).termId}`;
                 break;
         }
 


### PR DESCRIPTION
The value for TaxonomyFieldTypeMulti is correctly set on row 167 but was overwritten 2 rows down by using the structure from TaxonomyFieldType

#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes issues saving default values for multi taxonomy field in a library

#### What's in this Pull Request?

The value for TaxonomyFieldTypeMulti is correctly set on row 167 but was overwritten 2 rows down by using the structure from TaxonomyFieldType. Deleted one row that was probably added by mistake, overwriting the correct value

First pull request, so get back to me if I missed something...