### PR TITLE
getAllChildrenAsOrderedTree and root folder getItem bug fixes

### DIFF
--- a/debug/launch/main.ts
+++ b/debug/launch/main.ts
@@ -8,7 +8,7 @@ import { ITestingSettings } from "../../test/settings.js";
 // add your debugging imports here and prior to submitting a PR git checkout debug/debug.ts
 // will allow you to keep all your debugging files locally
 // comment out the example
-import { Example } from "./taxonomy.js";
+import { Example } from "./sp.js";
 
 // setup the connection to SharePoint using the settings file, you can
 // override any of the values as you want here, just be sure not to commit

--- a/debug/launch/main.ts
+++ b/debug/launch/main.ts
@@ -8,7 +8,7 @@ import { ITestingSettings } from "../../test/settings.js";
 // add your debugging imports here and prior to submitting a PR git checkout debug/debug.ts
 // will allow you to keep all your debugging files locally
 // comment out the example
-import { Example } from "./sp.js";
+import { Example } from "./taxonomy.js";
 
 // setup the connection to SharePoint using the settings file, you can
 // override any of the values as you want here, just be sure not to commit

--- a/docs/npm-scripts.md
+++ b/docs/npm-scripts.md
@@ -112,7 +112,7 @@ _Added in 2.0.13_
 This flag opts into using msal authentication settings from the [settings.js](./concepts/settings.md) file.
 
 ```cmd
-npm test -- --spverbose
+npm test -- --msal
 ```
 
 #### spVerbose

--- a/packages/sp/folders/types.ts
+++ b/packages/sp/folders/types.ts
@@ -1,4 +1,4 @@
-import { assign, ITypedHash, isUrlAbsolute, combine } from "@pnp/common";
+import { assign, ITypedHash, isUrlAbsolute, combine, hOP } from "@pnp/common";
 import {
     SharePointQueryable,
     SharePointQueryableCollection,
@@ -151,6 +151,9 @@ export class _Folder extends _SharePointQueryableInstance<IFolderInfo> {
     @tag("f.getItem")
     public async getItem<T>(...selects: string[]): Promise<IItem & T> {
         const q = await this.listItemAllFields.select(...selects)();
+        if (hOP(q, "odata.null") && q["odata.null"]) {
+            throw Error("No associated item was found for this folder. It may be the root folder, which does not have an item.");
+        }
         return assign(Item(odataUrlFrom(q)), q);
     }
 

--- a/packages/sp/taxonomy/types.ts
+++ b/packages/sp/taxonomy/types.ts
@@ -1,3 +1,4 @@
+import { isArray } from "@pnp/common";
 import { defaultPath } from "../decorators.js";
 import { _SharePointQueryableCollection, spInvokableFactory, _SharePointQueryableInstance } from "../sharepointqueryable.js";
 import { tag } from "../telemetry.js";
@@ -23,7 +24,7 @@ export class _TermStore extends _SharePointQueryableInstance<ITermStoreInfo> {
         return tag.configure(TermSets(this), "txts.sets");
     }
 }
-export interface ITermStore extends _TermStore {}
+export interface ITermStore extends _TermStore { }
 export const TermStore = spInvokableFactory<ITermStore>(_TermStore);
 
 
@@ -39,7 +40,7 @@ export class _TermGroups extends _SharePointQueryableCollection<ITermGroupInfo[]
         return tag.configure(TermGroup(this, id), "txtgs.getById");
     }
 }
-export interface ITermGroups extends _TermGroups {}
+export interface ITermGroups extends _TermGroups { }
 export const TermGroups = spInvokableFactory<ITermGroups>(_TermGroups);
 
 export class _TermGroup extends _SharePointQueryableInstance<ITermGroupInfo> {
@@ -51,7 +52,7 @@ export class _TermGroup extends _SharePointQueryableInstance<ITermGroupInfo> {
         return tag.configure(TermSets(this, "sets"), "txtg.sets");
     }
 }
-export interface ITermGroup extends _TermGroup {}
+export interface ITermGroup extends _TermGroup { }
 export const TermGroup = spInvokableFactory<ITermGroup>(_TermGroup);
 
 
@@ -67,7 +68,7 @@ export class _TermSets extends _SharePointQueryableCollection<ITermSetInfo[]> {
         return tag.configure(TermSet(this, id), "txts.getById");
     }
 }
-export interface ITermSets extends _TermSets {}
+export interface ITermSets extends _TermSets { }
 export const TermSets = spInvokableFactory<ITermSets>(_TermSets);
 
 export class _TermSet extends _SharePointQueryableInstance<ITermSetInfo> {
@@ -105,7 +106,12 @@ export class _TermSet extends _SharePointQueryableInstance<ITermSetInfo> {
         const tree: IOrderedTermInfo[] = [];
 
         const ensureOrder = (terms: IOrderedTermInfo[], sorts: ITermSortOrderInfo[], setSorts?: string[]): IOrderedTermInfo[] => {
-            // handle custom sort order
+
+            // handle no custom sort information present
+            if (!isArray(sorts) && !isArray(setSorts)) {
+                return terms;
+            }
+
             let ordering: string[] = null;
             if (sorts === null && setSorts.length > 0) {
                 ordering = [...setSorts];
@@ -163,12 +169,12 @@ export class _TermSet extends _SharePointQueryableInstance<ITermSetInfo> {
         return ensureOrder(tree, null, setInfo.customSortOrder);
     }
 }
-export interface ITermSet extends _TermSet {}
+export interface ITermSet extends _TermSet { }
 export const TermSet = spInvokableFactory<ITermSet>(_TermSet);
 
 @defaultPath("children")
 export class _Children extends _SharePointQueryableCollection<ITermInfo[]> { }
-export interface IChildren extends _Children {}
+export interface IChildren extends _Children { }
 export const Children = spInvokableFactory<IChildren>(_Children);
 
 @defaultPath("terms")
@@ -199,7 +205,7 @@ export class _Term extends _SharePointQueryableInstance<ITermInfo> {
         return tag.configure(TermSet(this, "set"), "txt.set");
     }
 }
-export interface ITerm extends _Term {}
+export interface ITerm extends _Term { }
 export const Term = spInvokableFactory<ITerm>(_Term);
 
 
@@ -214,7 +220,7 @@ export class _Relations extends _SharePointQueryableCollection<IRelationInfo[]> 
         return tag.configure(Relation(this, id), "txrs.getById");
     }
 }
-export interface IRelations extends _Relations {}
+export interface IRelations extends _Relations { }
 export const Relations = spInvokableFactory<IRelations>(_Relations);
 
 export class _Relation extends _SharePointQueryableInstance<IRelationInfo> {
@@ -231,7 +237,7 @@ export class _Relation extends _SharePointQueryableInstance<IRelationInfo> {
         return tag.configure(TermSet(this, "set"), "txr.set");
     }
 }
-export interface IRelation extends _Relation {}
+export interface IRelation extends _Relation { }
 export const Relation = spInvokableFactory<IRelation>(_Relation);
 
 


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1567
fixes #1572

#### What's in this Pull Request?

- getAllChildrenAsOrderedTree bug when no custom sort order present.
- adds logic to throw an exception when no item is found for a folder when using getItem()