### PR TITLE
fixed search query 'hitHighlightedProperties' property spelling

### DIFF
--- a/packages/sp/search/query.ts
+++ b/packages/sp/search/query.ts
@@ -24,7 +24,7 @@ const funcs = new Map<string, string>([
     ["hiddenConstraints", ""],
     ["sortList", ""],
     ["timeout", ""],
-    ["hithighlightedProperties", ""],
+    ["hitHighlightedProperties", ""],
     ["clientType", ""],
     ["personalizationData", ""],
     ["resultsURL", ""],

--- a/packages/sp/search/types.ts
+++ b/packages/sp/search/types.ts
@@ -32,7 +32,7 @@ export interface ISearchBuilder {
     hiddenConstraints(constraints: string): this;
     sortList(...sorts: ISort[]): this;
     timeout(milliseconds: number): this;
-    hithighlightedProperties(...properties: string[]): this;
+    hitHighlightedProperties(...properties: string[]): this;
     clientType(clientType: string): this;
     personalizationData(data: string): this;
     resultsURL(url: string): this;

--- a/tools/polyfill-ie11/searchquerybuilder.ts
+++ b/tools/polyfill-ie11/searchquerybuilder.ts
@@ -129,7 +129,7 @@ class SearchQueryBuilderImpl {
         return this.extendQuery({ Timeout: milliseconds });
     }
 
-    public hithighlightedProperties(...properties: string[]): this {
+    public hitHighlightedProperties(...properties: string[]): this {
         return this.extendQuery({ HitHighlightedProperties: properties });
     }
 


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

Fix for:
'The property 'HithighlightedProperties' does not exist on type 'Microsoft.Office.Server.Search.REST.SearchRequest'. Make sure to only use property names that are defined by the type.'

#### What's in this Pull Request?

- Fixed hitHighlightedProperties spelling

