### PR TITLE
made sp.site.getContextInfo() compatible with SP2013

### DIFF
--- a/packages/sp/sites/types.ts
+++ b/packages/sp/sites/types.ts
@@ -66,7 +66,7 @@ export class _Site extends _SharePointQueryableInstance {
     public async getContextInfo(): Promise<IContextInfo> {
 
         const q = tag.configure(Site(this.parentUrl, "_api/contextinfo"), "si.getContextInfo");
-        const data = await spPost(q);
+        const data = await spPost(q, this.data.options);
 
         if (hOP(data, "GetContextWebInformation")) {
             const info = data.GetContextWebInformation;


### PR DESCRIPTION
#### Category
- [x ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues
-

#### What's in this Pull Request?

sp.site.getContextInfo() does not work on SP2013 as there is not way to set the 'Accept' HTTP header to 'application/json; odata=verbose'.
tried to configure sp.site this way:
sp.site.configure({headers: { 'accept': 'application/json; odata=verbose' } }).getContextInfo()
which does not work either.
My change ensures that the optional IFetchOptions object provided in the above configure() function call gets added to the getContextInfo() call...



