### PR TITLE
feat(graph): map user/calendar findrooms endpoint

### DIFF
--- a/docs/graph/calendars.md
+++ b/docs/graph/calendars.md
@@ -212,3 +212,23 @@ const view3 = await graph.users.getById('user@tenant.onmicrosoft.com').calendarV
 
 const view4 = await graph.me.calendarView("2020-01-01", "2020-03-01")();
 ```
+
+## Find Rooms
+
+_Added in 2.5.0_
+Gets the `emailAddress` objects that represent all the meeting rooms in the user's tenant or in a specific room list.
+
+```ts
+import { graph } from '@pnp/graph';
+import '@pnp/graph/calendars';
+import '@pnp/graph/users';
+
+// basic request, note need to invoke the returned queryable
+const rooms1 = await graph.users.getById('user@tenant.onmicrosoft.com').findRooms()();
+
+// you can pass a room list to filter results
+const rooms2 = await graph.users.getById('user@tenant.onmicrosoft.com').findRooms('roomlist@tenant.onmicrosoft.com')();
+
+// you can use select, top, etc to filter your returned results
+const rooms3 = await graph.users.getById('user@tenant.onmicrosoft.com').findRooms().select('name').top(10)();
+```

--- a/packages/graph/calendars/funcs.ts
+++ b/packages/graph/calendars/funcs.ts
@@ -31,10 +31,10 @@ export interface ICalendarViewInfo extends IEvent {
  * @param roomList The SMTP address associated with the room list.
  */
 export function findRooms(this: IGraphQueryable, roomList?: string): IGraphQueryableCollection<EmailAddress[]> {
-    const query = this.clone(GraphQueryableCollection, "findRooms");
+    const query = this.clone(GraphQueryableCollection, roomList ? "findRooms(RoomList=@roomList)" : "findRooms");
     query.setEndpoint("beta");
     if(roomList) {
-        query.query.set("RoomList", encodeURIComponent(roomList));
+        query.query.set("@roomList", `'${encodeURIComponent(roomList)}'`);
     }
     return query;
 }

--- a/packages/graph/calendars/funcs.ts
+++ b/packages/graph/calendars/funcs.ts
@@ -1,5 +1,5 @@
 import { IGraphQueryable, GraphQueryableCollection, IGraphQueryableCollection } from "../graphqueryable.js";
-import { Event as IEvent } from "@microsoft/microsoft-graph-types";
+import { EmailAddress, Event as IEvent } from '@microsoft/microsoft-graph-types';
 
 /**
  * Get the occurrences, exceptions, and single instances of events in a calendar view defined by a time range,
@@ -22,4 +22,19 @@ export function calendarView(this: IGraphQueryable, start: string, end: string):
  */
 export interface ICalendarViewInfo extends IEvent {
     "@odata.etag": string;
+}
+
+/**
+ * Get the emailAddress objects that represent all the meeting rooms in the user's tenant or in a specific room list.
+ *
+ * @param this IGraphQueryable instance
+ * @param roomList The SMTP address associated with the room list.
+ */
+export function findRooms(this: IGraphQueryable, roomList?: string): IGraphQueryableCollection<EmailAddress[]> {
+    const query = this.clone(GraphQueryableCollection, "findRooms");
+    query.setEndpoint("beta");
+    if(roomList) {
+        query.query.set("RoomList", encodeURIComponent(roomList));
+    }
+    return query;
 }

--- a/packages/graph/calendars/funcs.ts
+++ b/packages/graph/calendars/funcs.ts
@@ -1,5 +1,5 @@
 import { IGraphQueryable, GraphQueryableCollection, IGraphQueryableCollection } from "../graphqueryable.js";
-import { EmailAddress, Event as IEvent } from '@microsoft/microsoft-graph-types';
+import { EmailAddress, Event as IEvent } from "@microsoft/microsoft-graph-types";
 
 /**
  * Get the occurrences, exceptions, and single instances of events in a calendar view defined by a time range,

--- a/packages/graph/calendars/users.ts
+++ b/packages/graph/calendars/users.ts
@@ -1,8 +1,9 @@
 import { addProp } from "@pnp/odata";
 import { _User } from "../users/types.js";
 import { Calendar, ICalendar, IEvents, Events, Calendars, ICalendars } from "./types.js";
-import { calendarView, ICalendarViewInfo } from "./funcs.js";
+import { calendarView, findRooms, ICalendarViewInfo } from "./funcs.js";
 import { IGraphQueryableCollection } from "../graphqueryable.js";
+import { EmailAddress } from "@microsoft/microsoft-graph-types";
 
 declare module "../users/types" {
     interface _User {
@@ -11,6 +12,7 @@ declare module "../users/types" {
         readonly attachmentFiles: ICalendar;
         readonly events: IEvents;
         calendarView(start: string, end: string): IGraphQueryableCollection<ICalendarViewInfo[]>;
+        findRooms(roomList?: string): IGraphQueryableCollection<EmailAddress[]>;
     }
     interface IUser {
         readonly calendar: ICalendar;
@@ -18,6 +20,7 @@ declare module "../users/types" {
         readonly attachmentFiles: ICalendar;
         readonly events: IEvents;
         calendarView(start: string, end: string): IGraphQueryableCollection<ICalendarViewInfo[]>;
+        findRooms(roomList?: string): IGraphQueryableCollection<EmailAddress[]>;
     }
 }
 
@@ -26,3 +29,4 @@ addProp(_User, "calendars", Calendars, "calendars");
 addProp(_User, "events", Events);
 
 _User.prototype.calendarView = calendarView;
+_User.prototype.findRooms = findRooms;

--- a/test/graph/calendars.ts
+++ b/test/graph/calendars.ts
@@ -198,6 +198,11 @@ describe("Calendar", function () {
             return expect(view.length).is.greaterThan(0);
         });
 
+        it("Find Rooms", async function () {
+            const rooms = await graph.users.getById(testUserName).findRooms();
+            return expect(rooms.length).is.greaterThan(0);
+        });
+
         // Remove the test data we created
         this.afterAll(async function () {
 


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

Implements the `findRooms` function endpoint documented here:
<https://docs.microsoft.com/en-us/graph/api/user-findrooms?view=graph-rest-beta&tabs=http>

Usage:
```ts
import { graph } from '@pnp/graph'
import '@pnp/graph/users';
import '@pnp/graph/calendars'

graph.me.findRooms().get().then(console.log); // Get all
graph.me.findRooms('roomlist1@contoso.onmicrosoft.com').get().then(console.log); // Get for specific list
```