### PR TITLE
Fix getting content type name in the proper language

### DIFF
--- a/packages/sp/regional-settings/content-type.ts
+++ b/packages/sp/regional-settings/content-type.ts
@@ -7,5 +7,5 @@ declare module "../content-types/types" {
     interface IContentType extends IUserResources {}
 }
 
-_ContentType.prototype.titleResource = getValueForUICultureBinder("titleResource");
+_ContentType.prototype.titleResource = getValueForUICultureBinder("nameResource");
 _ContentType.prototype.descriptionResource = getValueForUICultureBinder("descriptionResource");


### PR DESCRIPTION
calling web.contentTypes.getById("......").titleResource("en-US") was giving a 404 error.
The endpoint for content types is not titleResource but nameResource.

#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

There is no issue related.

#### What's in this Pull Request?

There is an issue when trying to get the Content Type titleResource. The endpoint returns a 404 because it is calling to 
POST https://sample.sharepoint.com/sites/whatever/_api/web/contenttypes('0x0100....')/titleResource/getValueForUICulture HTTP/1.1 but instead it shoud be calling
POST https://sample.sharepoint.com/sites/whatever/_api/web/contenttypes('0x0100....')/nameResource/getValueForUICulture 
