### PR TITLE
feat(sp): ability to use sitecollection app catalogs 

### DIFF
--- a/docs/sp/alm.md
+++ b/docs/sp/alm.md
@@ -15,7 +15,7 @@ import { sp } from "@pnp/sp";
 import "@pnp/sp/appcatalog";
 import "@pnp/sp/webs";
 
-// get the current context web's app catalog
+// get the current context web's tenant app catalog
 const catalog = await sp.web.getAppCatalog()();
 
 // you can also chain off the app catalog
@@ -36,10 +36,9 @@ const appCatalog = await appCatWeb.getAppCatalog()();
 // get the tenant app catalog
 const tenantCatalog = await sp.web.getAppCatalog("https://mytenant.sharepoint.com/sites/appcatalog")();
 
-// get a different app catalog
+// get a different web's tenant app catalog
 const catalog = await sp.web.getAppCatalog("https://mytenant.sharepoint.com/sites/anothersite")();
 ```
-
 ```TypeScript
 // alternatively you can create a new app catalog instance directly by importing the AppCatalog class
 import { IAppCatalog, AppCatalog } from '@pnp/sp/appcatalog';
@@ -54,6 +53,21 @@ import { AppCatalog } from '@pnp/sp/appcatalog';
 
 const web = Web("https://mytenant.sharepoint.com/sites/apps");
 const catalog = await AppCatalog(web)();
+```
+
+### Site Collection App Catalog
+
+By default, getting an app catalog instance will return the tenant app catalog associated with that site. 
+Fetching the site collection's app catalog relies on a separate endpoint so must be explicitly requested.
+This can be done by passing a second argument to `getAppCatalog`:
+
+```ts
+import { sp } from "@pnp/sp";
+import "@pnp/sp/appcatalog";
+import "@pnp/sp/webs";
+
+// get the current context web's site collection app catalog
+const catalog = await sp.web.getAppCatalog(undefined, 'sitecollection')();
 ```
 
 The following examples make use of a variable "catalog" which is assumed to represent an AppCatalog instance obtained using one of the above methods, supporting code is omitted for brevity.

--- a/packages/sp/appcatalog/types.ts
+++ b/packages/sp/appcatalog/types.ts
@@ -16,16 +16,15 @@ export type AppCatalogScope = "tenant" | "sitecollection";
 
 export class _AppCatalog extends _SharePointQueryableCollection {
 
-    private readonly scope: AppCatalogScope;
+    private readonly catalogPath: string;
 
-    constructor(baseUrl: string | ISharePointQueryable, path?: string, scope: AppCatalogScope = "tenant") {
-        if(!path) {
-            path =  `_api/web/${scope}appcatalog/AvailableApps`;
-        }
-
+    constructor(baseUrl: string | ISharePointQueryable, path?: string) {
         super(extractWebUrl(typeof baseUrl === "string" ? baseUrl : baseUrl.toUrl()), path);
 
-        this.scope = scope;
+        // get the catalog path without the AvailableApps suffix
+        // used for adding, syncing to teams
+        const pathSplit = path.split("/");
+        this.catalogPath = pathSplit.slice(0, pathSplit.length-1).join("/");
     }
 
     /**
@@ -66,7 +65,7 @@ export class _AppCatalog extends _SharePointQueryableCollection {
             }
         }
 
-        const poster = tag.configure(AppCatalog(webUrl, `_api/web/${this.scope}appcatalog/SyncSolutionToTeams(id=${appId})`), "ac.syncSolutionToTeams");
+        const poster = tag.configure(AppCatalog(webUrl, `${this.catalogPath}/SyncSolutionToTeams(id=${appId})`), "ac.syncSolutionToTeams");
         poster.configureFrom(this);
         return await spPost(poster, {});
     }
@@ -80,9 +79,8 @@ export class _AppCatalog extends _SharePointQueryableCollection {
      * @returns Promise<IAppAddResult>
      */
     public async add(filename: string, content: string | ArrayBuffer | Blob, shouldOverWrite = true): Promise<IAppAddResult> {
-
         // you don't add to the availableapps collection
-        const adder = tag.configure(AppCatalog(extractWebUrl(this.toUrl()), `_api/web/${this.scope}appcatalog/add(overwrite=${shouldOverWrite},url='${filename}')`), "ac.add");
+        const adder = tag.configure(AppCatalog(extractWebUrl(this.toUrl()), `${this.catalogPath}/add(overwrite=${shouldOverWrite},url='${filename}')`), "ac.add");
         adder.configureFrom(this);
 
         const r = await spPost(adder, {

--- a/packages/sp/appcatalog/types.ts
+++ b/packages/sp/appcatalog/types.ts
@@ -12,10 +12,20 @@ import { tag } from "../telemetry.js";
 import { Web } from "../webs/index.js";
 import "../items/index.js";
 
+export type AppCatalogScope = "tenant" | "sitecollection";
+
 export class _AppCatalog extends _SharePointQueryableCollection {
 
-    constructor(baseUrl: string | ISharePointQueryable, path = "_api/web/tenantappcatalog/AvailableApps") {
+    private readonly scope: AppCatalogScope;
+
+    constructor(baseUrl: string | ISharePointQueryable, path?: string, scope: AppCatalogScope = "tenant") {
+        if(!path) {
+            path =  `_api/web/${scope}appcatalog/AvailableApps`;
+        }
+
         super(extractWebUrl(typeof baseUrl === "string" ? baseUrl : baseUrl.toUrl()), path);
+
+        this.scope = scope;
     }
 
     /**
@@ -56,7 +66,7 @@ export class _AppCatalog extends _SharePointQueryableCollection {
             }
         }
 
-        const poster = tag.configure(AppCatalog(webUrl, `_api/web/tenantappcatalog/SyncSolutionToTeams(id=${appId})`), "ac.syncSolutionToTeams");
+        const poster = tag.configure(AppCatalog(webUrl, `_api/web/${this.scope}appcatalog/SyncSolutionToTeams(id=${appId})`), "ac.syncSolutionToTeams");
         poster.configureFrom(this);
         return await spPost(poster, {});
     }
@@ -72,7 +82,7 @@ export class _AppCatalog extends _SharePointQueryableCollection {
     public async add(filename: string, content: string | ArrayBuffer | Blob, shouldOverWrite = true): Promise<IAppAddResult> {
 
         // you don't add to the availableapps collection
-        const adder = tag.configure(AppCatalog(extractWebUrl(this.toUrl()), `_api/web/tenantappcatalog/add(overwrite=${shouldOverWrite},url='${filename}')`), "ac.add");
+        const adder = tag.configure(AppCatalog(extractWebUrl(this.toUrl()), `_api/web/${this.scope}appcatalog/add(overwrite=${shouldOverWrite},url='${filename}')`), "ac.add");
         adder.configureFrom(this);
 
         const r = await spPost(adder, {

--- a/packages/sp/appcatalog/web.ts
+++ b/packages/sp/appcatalog/web.ts
@@ -1,5 +1,5 @@
 import { _Web } from "../webs/types.js";
-import { AppCatalog, IAppCatalog } from "./types.js";
+import { AppCatalog, AppCatalogScope, IAppCatalog } from "./types.js";
 
 declare module "../webs/types" {
     interface _Web {
@@ -16,6 +16,6 @@ declare module "../webs/types" {
     }
 }
 
-_Web.prototype.getAppCatalog = function (this: _Web, url?: string | _Web): IAppCatalog {
-    return AppCatalog(url || this).configureFrom(this);
+_Web.prototype.getAppCatalog = function (this: _Web, url?: string | _Web, scope: AppCatalogScope = "tenant"): IAppCatalog {
+    return AppCatalog(url || this, scope).configureFrom(this);
 };

--- a/packages/sp/appcatalog/web.ts
+++ b/packages/sp/appcatalog/web.ts
@@ -11,11 +11,12 @@ declare module "../webs/types" {
          * as an IAppCatalog instance
          *
          * @param url [Optional] Url of the web to get (default: current web)
+         * @param scope [Optional] The scope of the app catalog (default: tenant)
          */
-        getAppCatalog(url?: string | _Web): IAppCatalog;
+        getAppCatalog(url?: string | _Web, scope?: AppCatalogScope): IAppCatalog;
     }
 }
 
 _Web.prototype.getAppCatalog = function (this: _Web, url?: string | _Web, scope: AppCatalogScope = "tenant"): IAppCatalog {
-    return AppCatalog(url || this, scope).configureFrom(this);
+    return AppCatalog(url || this, `_api/web/${scope}appcatalog/AvailableApps`).configureFrom(this);
 };

--- a/test/sp/appcatalog.ts
+++ b/test/sp/appcatalog.ts
@@ -29,76 +29,93 @@ describe.skip("AppCatalog", function () {
         const sppkgData: Uint8Array = new Uint8Array(fs.readFileSync(dirname));
         const appId = "b1403d3c-d4c4-41f7-8141-776ff1498100";
 
-        before(async function () {
-            appCatWeb = await sp.getTenantAppCatalogWeb();
-            appCatalog = appCatWeb.getAppCatalog();
-            // return Promise.resolve();
-        });
+        const doCatalogTests = () => {
+            it("it gets all the apps", function () {
+                return expect(appCatalog.get(), "all apps should've been fetched").to.eventually.be.fulfilled;
+            });
 
-        it("it gets all the apps", function () {
-            return expect(appCatalog.get(), "all apps should've been fetched").to.eventually.be.fulfilled;
-        });
+            it("it adds an app", function () {
+                const appName: string = getRandomString(25);
+                return expect(appCatalog.add(appName, sppkgData), `app '${appName}' should've been added`).to.eventually.be.fulfilled;
+            });
 
-        it("it adds an app", function () {
-            const appName: string = getRandomString(25);
-            return expect(appCatalog.add(appName, sppkgData), `app '${appName}' should've been added`).to.eventually.be.fulfilled;
-        });
+            it("it gets an app by id", async function () {
+                return expect(appCatalog.getAppById(appId).get(), `app '${appId}' should've been fetched`).to.eventually.be.fulfilled;
+            });
 
-        it("it gets an app by id", async function () {
-            return expect(appCatalog.getAppById(appId).get(), `app '${appId}' should've been fetched`).to.eventually.be.fulfilled;
-        });
+            it("it deploys an app", async function () {
+                const myApp = appCatalog.getAppById(appId);
+                return expect(myApp.deploy(), `app '${appId}' should've been deployed`).to.eventually.be.fulfilled;
+            });
 
-        it("it deploys an app", async function () {
-            const myApp = appCatalog.getAppById(appId);
-            return expect(myApp.deploy(), `app '${appId}' should've been deployed`).to.eventually.be.fulfilled;
-        });
+            it("it synchronizes a solution to the Microsoft Teams App Catalog", async function () {
+                return expect(appCatalog.syncSolutionToTeams(appId), `app '${appId}' should've been synchronized to the Microsoft Teams App Catalog`).to.eventually.be.fulfilled;
+            });
 
-        it("it synchronizes a solution to the Microsoft Teams App Catalog", async function () {
-            return expect(appCatalog.syncSolutionToTeams(appId), `app '${appId}' should've been synchronized to the Microsoft Teams App Catalog`).to.eventually.be.fulfilled;
-        });
+            it("it fails to synchronize a solution to the Microsoft Teams App Catalog using a non existing app", async function () {
+                const msg = "app 'random' should not have been synchronized to the Microsoft Teams App Catalog";
+                return expect(appCatalog.syncSolutionToTeams("random"), msg).to.not.eventually.be.fulfilled;
+            });
 
-        it("it fails to synchronize a solution to the Microsoft Teams App Catalog using a non existing app", async function () {
-            const msg = "app 'random' should not have been synchronized to the Microsoft Teams App Catalog";
-            return expect(appCatalog.syncSolutionToTeams("random"), msg).to.not.eventually.be.fulfilled;
-        });
+            it("it installs an app on a web", async function () {
+                const myApp = Web(testSettings.sp.webUrl).getAppCatalog().getAppById(appId);
+                return expect(myApp.install(), `app '${appId}' should've been installed on web ${testSettings.sp.webUrl}`).to.eventually.be.fulfilled;
+            });
 
-        it("it installs an app on a web", async function () {
-            const myApp = Web(testSettings.sp.webUrl).getAppCatalog().getAppById(appId);
-            return expect(myApp.install(), `app '${appId}' should've been installed on web ${testSettings.sp.webUrl}`).to.eventually.be.fulfilled;
-        });
-
-        it("it uninstalls an app", async function () {
+            it("it uninstalls an app", async function () {
             // We have to make sure the app is installed before we can uninstall it otherwise we get the following error message:
             // Another job exists for this app instance. Please retry after that job is done.
-            const myApp = Web(testSettings.sp.webUrl).getAppCatalog().getAppById(appId);
-            let app = { InstalledVersion: "" };
-            let retryCount = 0;
+                const myApp = Web(testSettings.sp.webUrl).getAppCatalog().getAppById(appId);
+                let app = { InstalledVersion: "" };
+                let retryCount = 0;
 
-            do {
-                if (retryCount === 5) {
-                    break;
-                }
-                await sleep(10000); // Sleep for 10 seconds
-                app = await myApp.get();
-                retryCount++;
-            } while (app.InstalledVersion === "");
+                do {
+                    if (retryCount === 5) {
+                        break;
+                    }
+                    await sleep(10000); // Sleep for 10 seconds
+                    app = await myApp.get();
+                    retryCount++;
+                } while (app.InstalledVersion === "");
 
-            return expect(myApp.uninstall(), `app '${appId}' should've been uninstalled on web ${testSettings.sp.webUrl}`).to.eventually.be.fulfilled;
+                return expect(myApp.uninstall(), `app '${appId}' should've been uninstalled on web ${testSettings.sp.webUrl}`).to.eventually.be.fulfilled;
+            });
+
+            it("it upgrades an app", async function () {
+                const myApp = Web(testSettings.sp.webUrl).getAppCatalog().getAppById(appId);
+                return expect(myApp.upgrade(), `app '${appId}' should've been upgraded on web ${testSettings.sp.webUrl}`).to.eventually.be.fulfilled;
+            });
+
+            it("it retracts an app", async function () {
+                const myApp = appCatalog.getAppById(appId);
+                return expect(myApp.retract(), `app '${appId}' should've been retracted`).to.eventually.be.fulfilled;
+            });
+
+            it("it removes an app", async function () {
+                const myApp = appCatalog.getAppById(appId);
+                return expect(myApp.remove(), `app '${appId}' should've been removed`).to.eventually.be.fulfilled;
+            });
+        };
+
+        context("for tenant app catalog", () => {
+            before(async function () {
+                appCatWeb = await sp.getTenantAppCatalogWeb();
+                appCatalog = appCatWeb.getAppCatalog();
+            // return Promise.resolve();
+            });
+
+            doCatalogTests();
         });
 
-        it("it upgrades an app", async function () {
-            const myApp = Web(testSettings.sp.webUrl).getAppCatalog().getAppById(appId);
-            return expect(myApp.upgrade(), `app '${appId}' should've been upgraded on web ${testSettings.sp.webUrl}`).to.eventually.be.fulfilled;
+        context("for site collection app catalog", () => {
+            before(async function () {
+                appCatalog = sp.web.getAppCatalog(undefined, "sitecollection");
+            // return Promise.resolve();
+            });
+
+            doCatalogTests();
         });
 
-        it("it retracts an app", async function () {
-            const myApp = appCatalog.getAppById(appId);
-            return expect(myApp.retract(), `app '${appId}' should've been retracted`).to.eventually.be.fulfilled;
-        });
 
-        it("it removes an app", async function () {
-            const myApp = appCatalog.getAppById(appId);
-            return expect(myApp.remove(), `app '${appId}' should've been removed`).to.eventually.be.fulfilled;
-        });
     }
 });


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [x] Documentation update?

#### What's in this Pull Request?

Adds the ability to optionally get the site collection app catalog instead of the tenant app catalog when calling `getAppCatalog()`.

```ts
import { sp } from "@pnp/sp";
import "@pnp/sp/appcatalog";
import "@pnp/sp/webs";

// get the current context web's site collection app catalog
const catalog = await sp.web.getAppCatalog(undefined, 'sitecollection')();
```

I have defined a second argument for `getAppCatalog()` which allows the scope to be specified as `tenant` or `sitecollection`, allowing it to internally use the correct API endpoint.

This also includes documentation updates. I've tried to update the existing examples, but some could perhaps be better worded to emphasise the difference between tenant and site collection app catalogs, as it is a little counter-intuitive that you're working for the tenant app catalog for the web by default.

The tests suite that exists for the tenant app catalog have been modified to run against both kinds; this suite is currently disabled but will require a site collection app catalog to exist if re-enabled.