### PR TITLE
Check if CorporateCatalogUrl before returning Web

### DIFF
--- a/packages/sp/appcatalog/index.ts
+++ b/packages/sp/appcatalog/index.ts
@@ -22,6 +22,9 @@ SPRest.prototype.getTenantAppCatalogWeb = async function (this: SPRest): Promise
 
     return this.childConfigHook(async ({ options, runtime }) => {
         const data: { CorporateCatalogUrl: string } = await SharePointQueryable("/", "_api/SP_TenantSettings_Current").configure(options).setRuntime(runtime)();
+        if (!data?.CorporateCatalogUrl) {
+            return undefined;
+        }
         return Web(data.CorporateCatalogUrl).configure(options).setRuntime(runtime);
     });
 };

--- a/packages/sp/appcatalog/index.ts
+++ b/packages/sp/appcatalog/index.ts
@@ -23,7 +23,7 @@ SPRest.prototype.getTenantAppCatalogWeb = async function (this: SPRest): Promise
     return this.childConfigHook(async ({ options, runtime }) => {
         const data: { CorporateCatalogUrl: string } = await SharePointQueryable("/", "_api/SP_TenantSettings_Current").configure(options).setRuntime(runtime)();
         if (!data?.CorporateCatalogUrl) {
-            return undefined;
+            throw new Error("Failed to get tenant corporate app catalog, its not configured on the tenant.");
         }
         return Web(data.CorporateCatalogUrl).configure(options).setRuntime(runtime);
     });


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?


#### What's in this Pull Request?

On tenants without an corp. app catalog getTenantAppCatalogWeb throws an error because data.CorporateCatalogUrl isn't set. Data returned from _api/SP_TenantSettings_Current is similar to:

<?xml version="1.0" encoding="utf-8"?><entry xml:base="https://tenant.sharepoint.com/_api/" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml"><id>https://tenant.sharepoint.com/_api/SP_TenantSettings_Current</id><category term="SP.TenantSettings" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" /><link rel="edit" href="SP_TenantSettings_Current" /><title /><updated>2021-05-21T13:32:08Z</updated><author><name /></author><content type="application/xml"><m:properties><d:CorporateCatalogUrl m:null="true" /></m:properties></content></entry>

Note CorporateCatalogUrl m:null="true". This PR will check if CorporateCatalogUrl is set before constructing the Web.