### PR TITLE
feat(graph): implement search param

### DIFF
--- a/packages/graph/graphqueryable.ts
+++ b/packages/graph/graphqueryable.ts
@@ -261,7 +261,7 @@ export interface IGraphQueryableCollection<GetType = any[]> extends IInvokable, 
 }
 export const GraphQueryableCollection = graphInvokableFactory<IGraphQueryableCollection>(_GraphQueryableCollection);
 
-export class _GraphQueryableSearchableCollection extends _GraphQueryableCollection {
+export class _GraphQueryableSearchableCollection<GetType = any[]> extends _GraphQueryableCollection<GetType> {
 
     /**
      * 	To request second and subsequent pages of Graph data

--- a/packages/graph/groups/types.ts
+++ b/packages/graph/groups/types.ts
@@ -1,7 +1,7 @@
 import { assign, ITypedHash } from "@pnp/common";
 import { Event as IEventType, Group as IGroupType } from "@microsoft/microsoft-graph-types";
 import { body } from "@pnp/odata";
-import { _GraphQueryableCollection, graphInvokableFactory } from "../graphqueryable.js";
+import { _GraphQueryableSearchableCollection, graphInvokableFactory } from "../graphqueryable.js";
 import { defaultPath, deleteable, IDeleteable, updateable, IUpdateable, getById, IGetById } from "../decorators.js";
 import { graphPost } from "../operations.js";
 import { _DirectoryObject } from "../directory-objects/types.js";
@@ -82,7 +82,7 @@ export const Group = graphInvokableFactory<IGroup>(_Group);
  */
 @defaultPath("groups")
 @getById(Group)
-export class _Groups extends _GraphQueryableCollection<IGroupType[]> {
+export class _Groups extends _GraphQueryableSearchableCollection<IGroupType[]> {
 
     /**
      * Create a new group as specified in the request body.

--- a/packages/graph/messages/types.ts
+++ b/packages/graph/messages/types.ts
@@ -1,5 +1,5 @@
 import { Message as IMessageType, MailFolder as IMailFolderType, MailboxSettings as IMailboxSettingsType } from "@microsoft/microsoft-graph-types";
-import { _GraphQueryableCollection, _GraphQueryableInstance, graphInvokableFactory } from "../graphqueryable.js";
+import { _GraphQueryableCollection, _GraphQueryableInstance, _GraphQueryableSearchableCollection, graphInvokableFactory } from "../graphqueryable.js";
 import { defaultPath, getById, addable, IGetById, IAddable, updateable, IUpdateable } from "../decorators.js";
 
 /**
@@ -15,7 +15,7 @@ export const Message = graphInvokableFactory<IMessage>(_Message);
 @defaultPath("messages")
 @getById(Message)
 @addable()
-export class _Messages extends _GraphQueryableCollection<IMessageType[]> { }
+export class _Messages extends _GraphQueryableSearchableCollection<IMessageType[]> { }
 export interface IMessages extends _Messages, IGetById<IMessage>, IAddable<IMessageType> { }
 export const Messages = graphInvokableFactory<IMessages>(_Messages);
 

--- a/packages/graph/users/types.ts
+++ b/packages/graph/users/types.ts
@@ -1,4 +1,4 @@
-import { _GraphQueryableCollection, graphInvokableFactory } from "../graphqueryable.js";
+import { _GraphQueryableSearchableCollection, graphInvokableFactory } from "../graphqueryable.js";
 import { User as IUserType, Person as IPersonType } from "@microsoft/microsoft-graph-types";
 import { _DirectoryObject, DirectoryObjects, IDirectoryObjects } from "../directory-objects/types.js";
 import { defaultPath, updateable, deleteable, IUpdateable, IDeleteable, getById, IGetById } from "../decorators.js";
@@ -39,11 +39,11 @@ export const User = graphInvokableFactory<IUser>(_User);
 
 @defaultPath("users")
 @getById(User)
-export class _Users extends _GraphQueryableCollection<IUserType[]> { }
+export class _Users extends _GraphQueryableSearchableCollection<IUserType[]> { }
 export interface IUsers extends _Users, IGetById<IUser> { }
 export const Users = graphInvokableFactory<IUsers>(_Users);
 
 @defaultPath("people")
-export class _People extends _GraphQueryableCollection<IPersonType[]> { }
+export class _People extends _GraphQueryableSearchableCollection<IPersonType[]> { }
 export interface IPeople extends _People { }
 export const People = graphInvokableFactory<IPeople>(_People);


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

Implements #1807

#### What's in this Pull Request?

Adds the `$search` query param for messages, people and directory objects. The typings were already present but not used.

```ts
import { graph } from '@pnp/graph/presets/all';

graph.users.search("displayName:Jake").get();
```
Documented here <https://docs.microsoft.com/en-us/graph/search-query-parameter#using-search-on-directory-object-collections>

I couldn't find any docs or tests around the existing params; if you'd like those added for this please let me know where they should be and I'll get that done :)
