### PR TITLE
feat(graph): add event instances function

### DIFF
--- a/docs/graph/calendars.md
+++ b/docs/graph/calendars.md
@@ -232,3 +232,27 @@ const rooms2 = await graph.users.getById('user@tenant.onmicrosoft.com').findRoom
 // you can use select, top, etc to filter your returned results
 const rooms3 = await graph.users.getById('user@tenant.onmicrosoft.com').findRooms().select('name').top(10)();
 ```
+
+## Get Event Instances
+
+_Added in 2.8.0_
+Get the instances (occurrences) of an event for a specified time range.
+
+If the event is a `seriesMaster` type, this returns the occurrences and exceptions of the event in the specified time range. 
+
+```ts
+import { graph } from '@pnp/graph';
+import '@pnp/graph/calendars';
+import '@pnp/graph/users';
+
+const event = graph.me.events.getById('');
+
+// basic request, note need to invoke the returned queryable
+const instances = await event.instances("2020-01-01", "2020-03-01")();
+
+// you can use select, top, etc to filter your returned results
+const instances2 = await event.instances("2020-01-01", "2020-03-01").select("subject").top(3)();
+
+// you can specify times along with the dates
+const instance3 = await event.instances("2020-01-01T19:00:00-08:00", "2020-03-01T19:00:00-08:00")(); 
+```

--- a/packages/graph/calendars/funcs.ts
+++ b/packages/graph/calendars/funcs.ts
@@ -2,6 +2,13 @@ import { IGraphQueryable, GraphQueryableCollection, IGraphQueryableCollection } 
 import { EmailAddress, Event as IEvent } from "@microsoft/microsoft-graph-types";
 
 /**
+ * Temporary until graph types include this type
+ */
+interface IEventWithTag extends IEvent {
+    "@odata.etag": string;
+}
+
+/**
  * Get the occurrences, exceptions, and single instances of events in a calendar view defined by a time range,
  * from the user's default calendar, or from some other calendar of the user's
  *
@@ -17,12 +24,7 @@ export function calendarView(this: IGraphQueryable, start: string, end: string):
     return query;
 }
 
-/**
- * Temporary until graph types include this type
- */
-export interface ICalendarViewInfo extends IEvent {
-    "@odata.etag": string;
-}
+export type ICalendarViewInfo = IEventWithTag;
 
 /**
  * Get the emailAddress objects that represent all the meeting rooms in the user's tenant or in a specific room list.
@@ -38,3 +40,21 @@ export function findRooms(this: IGraphQueryable, roomList?: string): IGraphQuery
     }
     return query;
 }
+
+/**
+ * Get the instances (occurrences) of an event for a specified time range.
+ * If the event is a seriesMaster type, this returns the occurrences and exceptions of the event in the specified time range.
+ *
+ * @param this IGraphQueryable instance
+ * @param start start time
+ * @param end end time
+ */
+export function instances(this: IGraphQueryable, start: string, end: string): IGraphQueryableCollection<IInstance[]> {
+    const query = this.clone(GraphQueryableCollection, "instances");
+    query.query.set("startDateTime", encodeURIComponent(start));
+    query.query.set("endDateTime", encodeURIComponent(end));
+    return query;
+}
+
+export type IInstance = IEventWithTag;
+

--- a/packages/graph/calendars/types.ts
+++ b/packages/graph/calendars/types.ts
@@ -3,7 +3,7 @@ import { Event as IEventType, Calendar as ICalendarType } from "@microsoft/micro
 import { _GraphQueryableCollection, _GraphQueryableInstance, graphInvokableFactory } from "../graphqueryable.js";
 import { defaultPath, IDeleteable, deleteable, IUpdateable, updateable, getById, IGetById } from "../decorators.js";
 import { graphPost } from "../operations.js";
-import { calendarView } from "./funcs.js";
+import { calendarView, instances } from "./funcs.js";
 
 /**
  * Calendar
@@ -33,7 +33,9 @@ export const Calendars = graphInvokableFactory<ICalendars>(_Calendars);
  */
 @deleteable()
 @updateable()
-export class _Event extends _GraphQueryableInstance<IEventType> { }
+export class _Event extends _GraphQueryableInstance<IEventType> {
+    public instances = instances;
+}
 export interface IEvent extends _Event, IDeleteable, IUpdateable { }
 export const Event = graphInvokableFactory<IEvent>(_Event);
 

--- a/test/graph/calendars.ts
+++ b/test/graph/calendars.ts
@@ -45,6 +45,18 @@ describe("Calendar", function () {
                         "timeZone": "Pacific Standard Time",
                     },
                     "subject": "Let's go for lunch",
+                    "recurrence": {
+                        "pattern": {
+                            "type": "weekly",
+                            "interval": 1,
+                            "daysOfWeek": [ "monday" ],
+                        },
+                        "range": {
+                            "type": "endDate",
+                            "startDate": "2017-09-04",
+                            "endDate": "2017-12-31",
+                        },
+                    },
                 });
             testEventID = event.data.id;
         });
@@ -201,6 +213,15 @@ describe("Calendar", function () {
         it("Find Rooms", async function () {
             const rooms = await graph.users.getById(testUserName).findRooms();
             return expect(rooms.length).is.greaterThan(0);
+        });
+
+        it("Get Instances", async function () {
+            const startDate: Date = new Date();
+            const endDate: Date = new Date();
+            endDate.setDate(endDate.getDate() + 10);
+            const event = graph.users.getById(testUserName).events.getById(testEventID);
+            const instances = await event.instances(startDate.toISOString(), endDate.toISOString())();
+            return expect(instances.length).is.greaterThan(0);
         });
 
         // Remove the test data we created


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [x] Documentation update?

#### What's in this Pull Request?

Adds new function to events to get all instances. Requires start and end date or datetime, and errors if the event is not recurring. 

Includes new test and related doc update.

https://docs.microsoft.com/en-us/graph/api/event-list-instances

```ts
import { graph } from '@pnp/graph';
import '@pnp/graph/calendars';
import '@pnp/graph/users';
const event = graph.me.events.getById('');
const instances = await event.instances("2020-01-01", "2020-03-01")();
```
