### PR TITLE
fix(graph): use advanced query for $count

### DIFF
--- a/packages/graph/graphqueryable.ts
+++ b/packages/graph/graphqueryable.ts
@@ -214,6 +214,12 @@ export class _GraphQueryableCollection<GetType = any[]> extends _GraphQueryable<
      * 	Retrieves the total count of matching resources
      */
     public get count(): this {
+        this.configure({
+            headers: {
+                ConsistencyLevel: "eventual",
+            },
+        });
+
         this.query.set("$count", "true");
         return this;
     }


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

The `$count` query param only takes effect if you perform an "advanced query", which just means the `ConsistencyLevel` must be set to `eventual` like it must for `$search`.

This automatically sets the header.
