### PR TITLE
fetch signal implementation

### DIFF
--- a/packages/common/net.ts
+++ b/packages/common/net.ts
@@ -12,6 +12,7 @@ export interface IConfigOptions {
 export interface IFetchOptions extends IConfigOptions {
     method?: string;
     body?: any;
+    signal?: AbortSignal;
 }
 
 export interface IHttpClientImpl {

--- a/packages/odata/queryable.ts
+++ b/packages/odata/queryable.ts
@@ -21,11 +21,19 @@ import { IODataParser, ODataParser } from "./parsers.js";
 export function cloneQueryableData(source: Partial<IQueryableData>): Partial<IQueryableData> {
 
     let body: any;
-    // this handles bodies that cannot be JSON encoded (Blob, etc)
-    // Note however, even bodies that can be serialized will not be cloned.
-    if (source.options && source.options.body) {
-        body = source.options.body;
-        source.options.body = "-";
+    let signal: any;
+    if (source.options) {
+        // this handles bodies that cannot be JSON encoded (Blob, etc)
+        // Note however, even bodies that can be serialized will not be cloned.
+        if(source.options.body) {
+            body = source.options.body;
+            source.options.body = "-";
+        }
+        // this handles signal objects that cannot be JSON encoded.
+        if(source.options.signal) {
+            signal = source.options.signal;
+            source.options.signal = null;
+        }
     }
 
     const s = JSON.stringify(source, (key: keyof IQueryableData, value: any) => {
@@ -62,6 +70,11 @@ export function cloneQueryableData(source: Partial<IQueryableData>): Partial<IQu
     if (body) {
         parsed.options.body = body;
         source.options.body = body;
+    }
+
+    if(signal) {
+        parsed.options.signal = signal;
+        source.options.signal = signal;
     }
 
     return parsed;

--- a/packages/sp/clientside-pages/types.ts
+++ b/packages/sp/clientside-pages/types.ts
@@ -312,7 +312,7 @@ export class _ClientsidePage extends _SharePointQueryable {
 
         const previewPartialUrl = "_layouts/15/getpreview.ashx";
 
-        //If new banner image, and banner image url is not in getpreview.ashx format
+        // If new banner image, and banner image url is not in getpreview.ashx format
         if (this._bannerImageDirty && !this.bannerImageUrl.includes(previewPartialUrl)) {
 
             const serverRelativePath = this.bannerImageUrl;
@@ -370,7 +370,7 @@ export class _ClientsidePage extends _SharePointQueryable {
             LayoutWebpartsContent: this.getLayoutWebpartsContent(),
             Title: this.title,
             TopicHeader: this.topicHeader,
-            BannerImageUrl: this.bannerImageUrl
+            BannerImageUrl: this.bannerImageUrl,
         });
 
         if (this._bannerImageDirty || this._bannerImageThumbnailUrlDirty) {


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?
I added fetch abort [signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/signal) support at the IFetchOptions. The pull request also contains some minor lint fixes.

My initial attempt was creating a custom fetch client and extend IFetchOptions from outside. Unfortunately, cloneQueryableData function creates a deep copy via Json serialization which breaks signal property before options hits the any custom/default client.



