### PR TITLE
feat(graph): ability to control max batch requests

### DIFF
--- a/packages/graph/rest.ts
+++ b/packages/graph/rest.ts
@@ -15,8 +15,8 @@ export class GraphRest {
      */
     constructor(private _options: IConfigOptions = {}, private _baseUrl: "v1.0" | "beta" = "v1.0", private _runtime = DefaultRuntime) {    }
 
-    public createBatch(): GraphBatch {
-        return new GraphBatch().setRuntime(this._runtime);
+    public createBatch(maxRequests?: number): GraphBatch {
+        return new GraphBatch(undefined, maxRequests).setRuntime(this._runtime);
     }
 
     public setup(config: IGraphConfiguration | ISPFXContext) {


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

Adds the ability to customize the `maxRequests` parameter of the `GraphBatch` class when creating a new batch using `graph.createBatch`.

This is useful as some of the service limits are actually lower than the default 20 concurrent requests (mailboxes for example only allow 4).

If you know you'll be working with mailboxes:

```ts
// new way
const batch = graph.createBatch(4);
```

This is currently technically possible but requires a hack:

```ts
// old hacky way
const batch = new GraphBatch(undefined, 4).setRuntime((graph as any)._runtime);
```