### PR TITLE
Add language support to code blocks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,6 +163,10 @@ markdown_extensions:
       #     format: !!python/name:pymdownx.superfences.fence_div_format
   - toc:
       permalink: true
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.snippets      
 
 plugins:
   - search


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [X] Documentation update?

#### What's in this Pull Request?

MkDocs with Material theme offers support for language highlighting of code blocks (https://squidfunk.github.io/mkdocs-material/reference/code-blocks/).
I was wondering if this was turned off by choice or it just was never activated.
Anyway, I added the support by updating the MkDocs configuration file accordingly.
I tested it locally and all code blocks now have nice color highlighting.