### PR TITLE
added getUsingAbsoluteUrl method and updated files.add to use new method

### DIFF
--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -38,6 +38,15 @@ export class _Files extends _SharePointQueryableCollection<IFileInfo[]> {
     }
 
     /**
+     * Gets a File by file absolute url
+     *
+     * @param fileUrl The absolute url of the file
+     */
+     public getUsingAbsoluteUrl(fileUrl: string): IFile {
+        return tag.configure(File(`${fileUrl}`), "fis.getFileUsingResponseUrl");
+    }
+
+    /**
      * Uploads a file. Not supported for batching
      *
      * @param url The folder-relative url of the file.
@@ -50,9 +59,10 @@ export class _Files extends _SharePointQueryableCollection<IFileInfo[]> {
         const response = await spPost(Files(this, `add(overwrite=${shouldOverWrite},url='${escapeQueryStrValue(url)}')`), {
             body: content,
         });
+
         return {
             data: response,
-            file: this.getByName(url),
+            file: this.getUsingAbsoluteUrl(response["odata.id"]),
         };
     }
 

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -8,7 +8,7 @@ import {
     deleteableWithETag,
 } from "../sharepointqueryable.js";
 import { TextParser, BlobParser, JSONParser, BufferParser, headers, body } from "@pnp/odata";
-import { assign, getGUID, isFunc, stringIsNullOrEmpty, isUrlAbsolute } from "@pnp/common";
+import { assign, getGUID, isFunc, stringIsNullOrEmpty, isUrlAbsolute, combine } from "@pnp/common";
 import { Item, IItem } from "../items/index.js";
 import { odataUrlFrom } from "../odata.js";
 import { defaultPath } from "../decorators.js";
@@ -42,8 +42,10 @@ export class _Files extends _SharePointQueryableCollection<IFileInfo[]> {
      *
      * @param fileUrl The absolute url of the file
      */
-     public getUsingAbsoluteUrl(fileUrl: string): IFile {
-        return tag.configure(File(`${fileUrl}`), "fis.getFileUsingResponseUrl");
+     public getByServerRelativeUrl(serverRelativePath: string): IFile {
+        const filePath = combine("/_api/Web/", `GetFileByServerRelativePath(decodedUrl='${escapeQueryStrValue(`!@p1::${serverRelativePath}`)}')`);
+
+        return tag.configure(File(filePath), "fis.getByServerRelativeUrl");
     }
 
     /**
@@ -62,7 +64,7 @@ export class _Files extends _SharePointQueryableCollection<IFileInfo[]> {
 
         return {
             data: response,
-            file: this.getUsingAbsoluteUrl(response["odata.id"]),
+            file: this.getByServerRelativeUrl(response["ServerRelativeUrl"]),
         };
     }
 

--- a/test/sp/files.ts
+++ b/test/sp/files.ts
@@ -12,6 +12,7 @@ import { IFiles, TemplateFileType, MoveOperations } from "@pnp/sp/files";
 import { readFileSync } from "fs";
 import { resolve, dirname } from "path";
 import findupSync = require("findup-sync");
+import { Readable } from "stream";
 
 // give ourselves a single reference to the projectRoot
 const projectRoot = resolve(dirname(findupSync("package.json")));
@@ -24,14 +25,13 @@ describe("files", () => {
         const testFileNamePercentPound = `testing %# - ${getRandomString(4)}.txt`;
         let testFileNamePercentPoundServerRelPath = "";
         let files: IFiles = null;
+        let oDataId:string = '';
 
         before(async function () {
-
             files = sp.web.defaultDocumentLibrary.rootFolder.files;
             // ensure we have at least one file to get
             await files.add(testFileName, "Test file!", true);
-            const res = await files.addUsingPath(testFileNamePercentPound, "Test file!", { Overwrite: true });
-            testFileNamePercentPoundServerRelPath = res.data.ServerRelativeUrl;
+            const res = await files.addUsingPath(testFileNamePercentPound, "Test file!", { Overwrite: true });            testFileNamePercentPoundServerRelPath = res.data.ServerRelativeUrl; oDataId = res.data['__metadata']['id'];
         });
 
         it("getByName", async function () {
@@ -147,6 +147,33 @@ describe("files", () => {
             await files.addUsingPath(name, "Some test text content.");
             const fileList = await files.filter(`Name eq '${name}'`)();
             return expect(fileList).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
+        });
+
+        it("getUsingAbsoluteUrl", async function () {
+            return expect(files.getUsingAbsoluteUrl(oDataId)()).to.eventually.be.fulfilled;
+        });
+
+        it("add stream file and get item fails with ECONNRESET", (done) => {
+            const contents = Readable.from("2131");
+            const name = `${getRandomString(4)}-upload-stream.txt`;
+            ( async () => {
+                await files.configure({ headers: { "content-length": "4", } }).add(name, contents, true);
+                try {
+                    await files.getByName(name).getItem();
+                } catch (e) {
+                    expect(e['code']).to.be.equal('ECONNRESET');
+                }
+                done();
+            })();
+        }).timeout(600000).retries(0);
+
+        it("add stream file and get item succeeds with getUsingAbsoluteUrl", async function () {
+            const contents = Readable.from("2131");
+            const name = `${getRandomString(4)}-upload-stream.txt`;
+            let response = await files.configure({ headers: { "content-length": "4", } }).add(name, contents, true);
+
+            const item = await files.getUsingAbsoluteUrl(response.data['__metadata']['id']).getItem();
+            return expect(item()).to.eventually.be.fulfilled;
         });
     }
 });

--- a/test/sp/files.ts
+++ b/test/sp/files.ts
@@ -25,13 +25,12 @@ describe("files", () => {
         const testFileNamePercentPound = `testing %# - ${getRandomString(4)}.txt`;
         let testFileNamePercentPoundServerRelPath = "";
         let files: IFiles = null;
-        let oDataId:string = '';
 
         before(async function () {
             files = sp.web.defaultDocumentLibrary.rootFolder.files;
             // ensure we have at least one file to get
             await files.add(testFileName, "Test file!", true);
-            const res = await files.addUsingPath(testFileNamePercentPound, "Test file!", { Overwrite: true });            testFileNamePercentPoundServerRelPath = res.data.ServerRelativeUrl; oDataId = res.data['__metadata']['id'];
+            const res = await files.addUsingPath(testFileNamePercentPound, "Test file!", { Overwrite: true });            testFileNamePercentPoundServerRelPath = res.data.ServerRelativeUrl;
         });
 
         it("getByName", async function () {
@@ -149,8 +148,8 @@ describe("files", () => {
             return expect(fileList).to.be.an.instanceOf(Array).and.to.have.lengthOf(1);
         });
 
-        it("getUsingAbsoluteUrl", async function () {
-            return expect(files.getUsingAbsoluteUrl(oDataId)()).to.eventually.be.fulfilled;
+        it("getByServerRelativeUrl", async function () {
+            return expect(files.getByServerRelativeUrl(testFileNamePercentPoundServerRelPath)()).to.eventually.be.fulfilled;
         });
 
         it("add stream file and get item fails with ECONNRESET", (done) => {
@@ -167,12 +166,12 @@ describe("files", () => {
             })();
         }).timeout(600000).retries(0);
 
-        it("add stream file and get item succeeds with getUsingAbsoluteUrl", async function () {
+        it("add stream file and get item succeeds with getByServerRelativeUrl", async function () {
             const contents = Readable.from("2131");
             const name = `${getRandomString(4)}-upload-stream.txt`;
             let response = await files.configure({ headers: { "content-length": "4", } }).add(name, contents, true);
 
-            const item = await files.getUsingAbsoluteUrl(response.data['__metadata']['id']).getItem();
+            const item = await files.getByServerRelativeUrl(response.data['ServerRelativeUrl']).getItem();
             return expect(item()).to.eventually.be.fulfilled;
         });
     }


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #1914

#### What's in this Pull Request?

*This fixes the issue with calling file.getItem() in the ffg scenarios:*
- When the content uploaded is a stream using files.add rather than files.addChunked
- When the document library has over 5000 items which exceeds the SP online threshold limit.

The change made leverages the odata.id returned after an upload which is the absolute url of the file rather than use getFolderByServerRelativeUrl(*relativepath*)/files(*filename*)/listItemAllFields
