### PR TITLE
update sp index and files docs to address [v3] changes

### DIFF
--- a/docs/sp/files.md
+++ b/docs/sp/files.md
@@ -132,7 +132,7 @@ const sp = spfi("{tenant url}").using(SPDefault({
     }
 })).using(ThrowErrors());
 
-const fr = await sp.web.lists.getByTitle("Documents").rootFolder.files.addChunked( "new.txt", stream, undefined, true, stream.bytesRead );
+const fr = await sp.web.lists.getByTitle("Documents").rootFolder.files.addChunked( "new.txt", stream, undefined, true );
 ```
 
 ### Setting Associated Item Values

--- a/docs/sp/files.md
+++ b/docs/sp/files.md
@@ -7,21 +7,23 @@ One of the more challenging tasks on the client side is working with SharePoint 
 Reading files from the client using REST is covered in the below examples. The important thing to remember is choosing which format you want the file in so you can appropriately process it. You can retrieve a file as Blob, Buffer, JSON, or Text. If you have a special requirement you could also write your [own parser](../odata/parsers.md).
 
 ```typescript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 import "@pnp/sp/folders";
 
-const blob: Blob = await sp.web.getFileByServerRelativeUrl("/sites/dev/documents/file.avi").getBlob();
+const sp = spfi("{tenant url}").using(SPFx(this.context));
 
-const buffer: ArrayBuffer = await sp.web.getFileByServerRelativeUrl("/sites/dev/documents/file.avi").getBuffer();
+const blob: Blob = await sp.web.getFileByServerRelativePath("/sites/dev/documents/file.avi").getBlob();
 
-const json: any = await sp.web.getFileByServerRelativeUrl("/sites/dev/documents/file.json").getJSON();
+const buffer: ArrayBuffer = await sp.web.getFileByServerRelativePath("/sites/dev/documents/file.avi").getBuffer();
 
-const text: string = await sp.web.getFileByServerRelativeUrl("/sites/dev/documents/file.txt").getText();
+const json: any = await sp.web.getFileByServerRelativePath("/sites/dev/documents/file.json").getJSON();
+
+const text: string = await sp.web.getFileByServerRelativePath("/sites/dev/documents/file.txt").getText();
 
 // all of these also work from a file object no matter how you access it
-const text2: string = await sp.web.getFolderByServerRelativeUrl("/sites/dev/documents").files.getByName("file.txt").getText();
+const text2: string = await sp.web.getFolderByServerRelativePath("/sites/dev/documents").files.getByUrl("file.txt").getText();
 ```
 
 ### getFileByUrl
@@ -29,9 +31,11 @@ const text2: string = await sp.web.getFolderByServerRelativeUrl("/sites/dev/docu
 This method supports opening files from sharing links or absolute urls. The file must reside in the site from which you are trying to open the file.
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files/web";
+
+const sp = spfi("{tenant url}").using(SPFx(this.context));
 
 const url = "{absolute file url OR sharing url}";
 
@@ -44,13 +48,15 @@ const fileContent = await file.getText();
 
 ## Adding Files
 
-Likewise you can add files using one of two methods, add or addChunked. AddChunked is appropriate for larger files, generally larger than 10 MB but this may differ based on your bandwidth/latency so you can adjust the code to use the chunked method. The below example shows getting the file object from an input and uploading it to SharePoint, choosing the upload method based on file size.
+Likewise you can add files using one of two methods, addUsingPath or addChunked. AddChunked is appropriate for larger files, generally larger than 10 MB but this may differ based on your bandwidth/latency so you can adjust the code to use the chunked method. The below example shows getting the file object from an input and uploading it to SharePoint, choosing the upload method based on file size.
+
+The addUsingPath method, supports the percent or pound characters in file names.
 
 ```typescript
 declare var require: (s: string) => any;
 
 import { ConsoleListener, Logger, LogLevel } from "@pnp/logging";
-import { sp } from "@pnp/sp";
+import { spfi } from "@pnp/sp";
 import { Web } from "@pnp/sp/webs";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
@@ -68,6 +74,7 @@ Logger.activeLogLevel = LogLevel.Verbose;
 
 let web = Web(siteUrl);
 
+
 $(() => {
     $("#testingdiv").append("<button id='thebuttontodoit'>Do It</button>");
 
@@ -82,12 +89,12 @@ $(() => {
         if (file.size <= 10485760) {
 
             // small upload
-            await web.getFolderByServerRelativeUrl("/sites/dev/Shared%20Documents/test/").files.add(file.name, file, true);
+            await web.getFolderByServerRelativePath("Shared Documents").files.addUsingPath(file.name, file, {Overwrite: true});
             Logger.write("done");
         } else {
 
             // large upload
-            await web.getFolderByServerRelativeUrl("/sites/dev/Shared%20Documents/test/").files.addChunked(file.name, file, data => {
+            await web.getFolderByServerRelativePath("Shared Documents").files.addChunked("filename%#%.txt", file, data => {
 
                 Logger.log({ data: data, level: LogLevel.Verbose, message: "progress" });
 
@@ -104,17 +111,28 @@ If you are working in nodejs you can also add a file using a stream. This exampl
 
 ```TypeScript
 // triggers auto-application of extensions, in this case to add getStream
+import { spfi } from "@pnp/sp";
 import "@pnp/nodejs";
+import "@pnp/sp/webs";
+import "@pnp/sp/lists";
+import "@pnp/sp/files";
+import { createReadStream } from 'fs';
+import { SPDefault } from "@pnp/nodejs";
+import { ThrowErrors } from "@pnp/queryable";
 
 // get a stream of an existing file
-const sr = await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/old.md").getStream();
+const stream = createReadStream("c:/temp/file.txt");
 
 // now add the stream as a new file, remember to set the content-length header
-const fr = await sp.web.lists.getByTitle("Documents").rootFolder.files.configure({
-    headers: {
-        "content-length": `${sr.knownLength}`,
-    },
-}).add("new.md", sr.body);
+const sp = spfi("{tenant url}").using(SPDefault({
+    baseUrl: 'https://{tenant}.sharepoint.com/sites/dev',
+    msal: {
+        config: config,
+        scopes: [ 'https://{tenant}.sharepoint.com/.default' ]
+    }
+})).using(ThrowErrors());
+
+const fr = await sp.web.lists.getByTitle("Documents").rootFolder.files.addChunked( "new.txt", stream, undefined, true, stream.bytesRead );
 ```
 
 ### Setting Associated Item Values
@@ -122,12 +140,13 @@ const fr = await sp.web.lists.getByTitle("Documents").rootFolder.files.configure
 You can also update the file properties of a newly uploaded file using code similar to the below snippet:
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 import "@pnp/sp/folders";
 
-const file = await sp.web.getFolderByServerRelativeUrl("/sites/dev/Shared%20Documents/test/").files.add("file.name", "file", true);
+const sp = spfi("{tenant url}").using(SPFx(this.context));
+const file = await sp.web.getFolderByServerRelativePath("/sites/dev/Shared%20Documents/test/").files.addUsingPath("file.name", "content", {Overwrite: true});
 const item = await file.file.getItem();
 await item.update({
   Title: "A Title",
@@ -135,32 +154,20 @@ await item.update({
 });
 ```
 
-## AddUsingPath
-
-If you need to support the percent or pound characters you can use the addUsingPath method of IFiles
-
-```TypeScript
-import { sp } from "@pnp/sp";
-import "@pnp/sp/webs";
-import "@pnp/sp/files";
-import "@pnp/sp/folders";
-
-const file = await sp.web.getFolderByServerRelativeUrl("/sites/dev/Shared%20Documents/test/").files.addUsingPath("file%#%.name", "content");
-```
-
 ## Update File Content
 
 You can of course use similar methods to update existing files as shown below. This overwrites the existing content in the file.
 
 ```typescript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 import "@pnp/sp/folders";
 
-await sp.web.getFileByServerRelativeUrl("/sites/dev/documents/test.txt").setContent("New string content for the file.");
+const sp = spfi("{tenant url}").using(SPFx(this.context));
+await sp.web.getFileByServerRelativePath("/sites/dev/documents/test.txt").setContent("New string content for the file.");
 
-await sp.web.getFileByServerRelativeUrl("/sites/dev/documents/test.mp4").setContentChunked(file);
+await sp.web.getFileByServerRelativePath("/sites/dev/documents/test.mp4").setContentChunked(file);
 ```
 
 ## Check in, Check out, and Approve & Deny
@@ -172,21 +179,23 @@ The library provides helper methods for checking in, checking out, and approving
 Check in takes two optional arguments, comment and check in type.
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import { CheckinType } from "@pnp/sp/files";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 
+const sp = spfi("{tenant url}").using(SPFx(this.context));
+
 // default options with empty comment and CheckinType.Major
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").checkin();
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").checkin();
 console.log("File checked in!");
 
 // supply a comment (< 1024 chars) and using default check in type CheckinType.Major
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").checkin("A comment");
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").checkin("A comment");
 console.log("File checked in!");
 
 // Supply both comment and check in type
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").checkin("A comment", CheckinType.Overwrite);
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").checkin("A comment", CheckinType.Overwrite);
 console.log("File checked in!");
 ```
 
@@ -195,11 +204,13 @@ console.log("File checked in!");
 Check out takes no arguments.
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 
-sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").checkout();
+const sp = spfi("{tenant url}").using(SPFx(this.context));
+
+sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").checkout();
 console.log("File checked out!");
 ```
 
@@ -208,19 +219,21 @@ console.log("File checked out!");
 You can also approve or deny files in libraries that use approval. Approve takes a single required argument of comment, the comment is optional for deny.
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").approve("Approval Comment");
+const sp = spfi("{tenant url}").using(SPFx(this.context));
+
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").approve("Approval Comment");
 console.log("File approved!");
 
 // deny with no comment
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").deny();
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").deny();
 console.log("File denied!");
 
 // deny with a supplied comment.
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").deny("Deny comment");
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").deny("Deny comment");
 console.log("File denied!");
 ```
 
@@ -229,24 +242,26 @@ console.log("File denied!");
 You can both publish and unpublish a file using the library. Both methods take an optional comment argument.
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 
+const sp = spfi("{tenant url}").using(SPFx(this.context));
+
 // publish with no comment
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").publish();
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").publish();
 console.log("File published!");
 
 // publish with a supplied comment.
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").publish("Publish comment");
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").publish("Publish comment");
 console.log("File published!");
 
 // unpublish with no comment
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").unpublish();
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").unpublish();
 console.log("File unpublished!");
 
 // unpublish with a supplied comment.
-await sp.web.getFileByServerRelativeUrl("/sites/dev/shared documents/file.txt").unpublish("Unpublish comment");
+await sp.web.getFileByServerRelativePath("/sites/dev/shared documents/file.txt").unpublish("Unpublish comment");
 console.log("File unpublished!");
 ```
 
@@ -282,11 +297,13 @@ This property controls the size of the individual chunks and is defaulted to 104
 This method allows you to get the item associated with this file. You can optionally specify one or more select fields. The result will be merged with a new Item instance so you will have both the returned property values and chaining ability in a single object.
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spFI, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 import "@pnp/sp/folders";
 import "@pnp/sp/security";
+
+const sp = spfi("{tenant url}").using(SPFx(this.context));
 
 const item = await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.txt").getItem();
 console.log(item);
@@ -302,12 +319,14 @@ console.log(perms);
 You can also supply a generic typing parameter and the resulting type will be a union type of Item and the generic type parameter. This allows you to have proper intellisense and type checking.
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spFI, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 import "@pnp/sp/folders";
 import "@pnp/sp/items";
 import "@pnp/sp/security";
+
+const sp = spfi("{tenant url}").using(SPFx(this.context));
 
 // also supports typing the objects so your type will be a union type
 const item = await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.txt").getItem<{ Id: number, Title: string }>("Id", "Title");
@@ -325,14 +344,16 @@ console.log(perms);
 It's possible to move a file to a new destination within a site collection  
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
+
+const sp = spfi("{tenant url}").using(SPFx(this.context));
 
 // destination is a server-relative url of a new file
 const destinationUrl = `/sites/dev/SiteAssets/new-file.docx`;
 
-await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx").moveTo(destinationUrl);
+await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx").moveByPath(destinationUrl, false, true);
 ```  
 
 ### copy
@@ -340,39 +361,28 @@ await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx"
 It's possible to copy a file to a new destination within a site collection  
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
+
+const sp = spfi("{tenant url}").using(SPFx(this.context));
 
 // destination is a server-relative url of a new file
 const destinationUrl = `/sites/dev/SiteAssets/new-file.docx`;
 
 await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx").copyTo(destinationUrl, false);
-```  
-
-### move by path
-
-It's possible to move a file to a new destination within the same or a different site collection  
-
-```TypeScript
-import { sp } from "@pnp/sp";
-import "@pnp/sp/webs";
-import "@pnp/sp/files";
-
-// destination is a server-relative url of a new file
-const destinationUrl = `/sites/dev2/SiteAssets/new-file.docx`;
-
-await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx").moveByPath(destinationUrl, false, true);
-```  
+```
 
 ### copy by path
 
 It's possible to copy a file to a new destination within the same or a different site collection  
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
+
+const sp = spfi("{tenant url}").using(SPFx(this.context));
 
 // destination is a server-relative url of a new file
 const destinationUrl = `/sites/dev2/SiteAssets/new-file.docx`;
@@ -385,10 +395,12 @@ await sp.web.getFileByServerRelativePath("/sites/dev/Shared Documents/test.docx"
 You can get a file by Id from a web.
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 import { IFile } from "@pnp/sp/files";
+
+const sp = spfi("{tenant url}").using(SPFx(this.context));
 
 const file: IFile = sp.web.getFileById("2b281c7b-ece9-4b76-82f9-f5cf5e152ba0");
 ```
@@ -398,11 +410,12 @@ const file: IFile = sp.web.getFileById("2b281c7b-ece9-4b76-82f9-f5cf5e152ba0");
 Deletes a file
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 
-await sp.web.rootFolder.files.getByName("name.txt").delete();
+const sp = spfi("{tenant url}").using(SPFx(this.context));
+await sp.web.getFolderByServerRelativePath("{folder relative path}").files.getByUrl("filename.txt").delete();
 ```
 
 ### delete with params
@@ -410,11 +423,12 @@ await sp.web.rootFolder.files.getByName("name.txt").delete();
 Deletes a file with options
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 
-await sp.web.rootFolder.files.getByName("name.txt").deleteWithParams({
+const sp = spfi("{tenant url}").using(SPFx(this.context));
+await sp.web.getFolderByServerRelativePath("{folder relative path}").files.getByUrl("filename.txt").deleteWithParams({
     BypassSharedLock: true,
 });
 ```
@@ -424,9 +438,10 @@ await sp.web.rootFolder.files.getByName("name.txt").deleteWithParams({
 Checks to see if a file exists
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/files";
 
-const exists = await sp.web.rootFolder.files.getByName("name.txt").exists();
+const sp = spfi("{tenant url}").using(SPFx(this.context));
+const exists = await sp.web.getFolderByServerRelativePath("{folder relative path}").files.getByUrl("name.txt").exists();
 ```

--- a/docs/sp/index.md
+++ b/docs/sp/index.md
@@ -13,12 +13,12 @@ Install the library and required dependencies
 Import the library into your application and access the root sp object
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 
 (function main() {
-
-    // here we will load the current web's title
+    // here we setup the root sp object with the sharepoint context which will be used to load the current web's title
+    const sp = spfi("{tenant url}").using(SPFx(this.context));
     const w = await sp.web.select("Title")();
     console.log(`Web Title: ${w.Title}`);
 )()
@@ -71,22 +71,21 @@ Install the library and required dependencies
 Import the library into your application, setup the node client, make a request
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
+import { GraphDefault, SPDefault } from "@pnp/nodejs";
+import {ThrowErrors} from "@pnp/queryable";
 import "@pnp/sp/webs";
-import { SPFetchClient } from "@pnp/nodejs";
 
 // do this once per page load
-sp.setup({
-    sp: {
-        fetchClientFactory: () => {
-            return new SPFetchClient("{your site url}", "{your client id}", "{your client secret}");
-        },
-    },
-});
+const sp = spfi().using(SPDefault({
+  baseUrl: siteUrl,
+  msal: {
+    config: config,
+    scopes: [ 'https://{tenant}.sharepoint.com/.default' ]
+  }
+})).using(ThrowErrors());
 
 // now make any calls you need using the configured client
-
 const w = await sp.web.select("Title")();
 console.log(`Web Title: ${w.Title}`);
-
 ```


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### What's in this Pull Request?

Updates to the sp/index and  sp/files documentation, showcasing the various ways to use the library based on changes made to the library in the v3 version

#### Notable Changes
- removed the AddUsingPath section and moved the content for that section to the "adding files" section to include a note about file names with % or # characters
- removed the moveByPath section, since only one move function exists. 
