### PR TITLE
Delete comment should be DELETE verb

### DIFF
--- a/packages/sp/comments/types.ts
+++ b/packages/sp/comments/types.ts
@@ -82,7 +82,7 @@ export class _Comment extends _SharePointQueryableInstance<ICommentInfo> {
      */
     @tag("com.delete")
     public delete(): Promise<void> {
-        return spPost(this.clone(Comment, "DeleteComment"));
+        return spDelete(this);
     }
 }
 export interface IComment extends _Comment {}


### PR DESCRIPTION
Delete comment should be DELETE verb instead of POST to DeleteComment.
Now delete comment is broken in SharePoint Online.

#### Category
- [ x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #X, mentioned in #Y

#### What's in this Pull Request?

Now method comment.delete() makes post request to /Comments(@id)/DeleteComment enpdoint, wich doesn't exists in SharePoint Online. Instead of this DELETE request to /Comments(@id) should be used.

