### PR TITLE
fix issue with folder copyTo for no root site collection permissions

### DIFF
--- a/packages/sp/folders/types.ts
+++ b/packages/sp/folders/types.ts
@@ -219,7 +219,7 @@ export class _Folder extends _SharePointQueryableInstance<IFolderInfo> {
 
         const uri = new URL(urlInfo.ParentWeb.Url);
 
-        await spPost(Folder(uri.origin, "/_api/SP.MoveCopyUtil.CopyFolder()").configureFrom(this),
+        await spPost(Folder(urlInfo.ParentWeb.Url, "/_api/SP.MoveCopyUtil.CopyFolder()").configureFrom(this),
             body({
                 destUrl: isUrlAbsolute(destUrl) ? destUrl : combine(uri.origin, destUrl),
                 srcUrl: combine(uri.origin, urlInfo.Folder.ServerRelativeUrl),


### PR DESCRIPTION
This PR is for addressing #2096.
- #2096 

#### Category
- [x] Bug fix?
- [ ] New feature
- [ ] New sample
- [ ] Documentation update


#### Related Issues
The same result occurs as in #1686, where a permissions error response is sent in response when attempting to copy a folder.

- related to issue :: #1686
- similar to PR :: #1692


#### What's in this Pull Request?

References `urlInfo.ParentWeb.url` instead of the `uri.origin` — directly reflecting the way `moveTo` is set up for folders.

