### PR TITLE
Further address getAllChildrenAsOrderedTree.

### DIFF
--- a/packages/sp/taxonomy/types.ts
+++ b/packages/sp/taxonomy/types.ts
@@ -149,7 +149,7 @@ export class _TermSet extends _SPInstance<ITermSetInfo> {
 
         const visitor = async (source: { children: IChildren }, parent: IOrderedTermInfo[]) => {
 
-            const children = await source.children.select("*", "customSortOrder")();
+            const children = await source.children.select(...selects)();
 
             for (let i = 0; i < children.length; i++) {
 

--- a/test/sp/taxonomy.ts
+++ b/test/sp/taxonomy.ts
@@ -69,7 +69,7 @@ describe("Taxonomy", function () {
     /**
      * Term Sets
      */
-    describe("TermSets", function () {
+    describe.only("TermSets", function () {
         let termset: ITermSet = null;
 
         before(async function () {
@@ -116,6 +116,18 @@ describe("Taxonomy", function () {
             }
             const termById = await termset.getTermById(terms[0].id)();
             return expect(termById).has.property("id");
+        });
+        it("getAllChildrenAsOrderedTree", async function(){
+            const tree = await termset.getAllChildrenAsOrderedTree();
+            return expect(tree).to.be.an("Array");
+        });
+        it("getAllChildrenAsOrderedTree-retreiveProperties", async function () {
+            const tree = await termset.getAllChildrenAsOrderedTree({retrieveProperties: true});
+            if (tree.length < 1) {
+                return;
+            }
+            const term = tree[0];
+            return expect(term).has.property("localProperties");
         });
     });
 
@@ -220,5 +232,6 @@ describe("Taxonomy", function () {
             const set = await relation.set();
             return expect(set).has.property("id");
         });
+
     });
 });

--- a/test/sp/taxonomy.ts
+++ b/test/sp/taxonomy.ts
@@ -69,7 +69,7 @@ describe("Taxonomy", function () {
     /**
      * Term Sets
      */
-    describe.only("TermSets", function () {
+    describe("TermSets", function () {
         let termset: ITermSet = null;
 
         before(async function () {


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues
Additional to PR #2144. 

#### What's in this Pull Request?

Another missed line from the getAllChildrenAsOrderedTree method. Admittedly, I missed the other select method within this function in the previous PR #2144. Also add tests to cover this method, with and without the additional prop _retreiveProperties_ .
- **getAllChildrenAsOrderedTree**: Tests that the method runs and returns an array.
- **getAllChildrenAsOrderedTree-retreiveProperties**: Tests that, if the method does return a term, the term has the localProperties key. This test would have caught the bug addressed by this PR and  #2144.
