### PR TITLE
Pass object of type ISPFXContext to SPFx function.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -148,14 +148,12 @@ export class SampleService {
 
         //Option 1 - with AADTokenProvider
         this._sp = spfi().using(SPFx({
-            spfxContext: {
             aadTokenProviderFactory: tokenProviderFactory,
             pageContext: pageContext,
-            }
         }));
 
         //Option 2 - without AADTokenProvider
-        this._sp = spfi().using(SPFx(pageContext));
+        this._sp = spfi().using(SPFx({ pageContext }));
 
         });
     }


### PR DESCRIPTION
The code example showing how to establish a context for an SPFx service passes
an object of the wrong type. The argument must match the type
ISPFXContext.

#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### Related Issues

fixes #2182

#### What's in this Pull Request?

Updated documentation for "Establish context within an SPFx service"



