### PR TITLE
Sp app catalog default path

### DIFF
--- a/packages/sp/appcatalog/web.ts
+++ b/packages/sp/appcatalog/web.ts
@@ -1,4 +1,4 @@
-import { addProp } from "@pnp/queryable";
+import { SPInit } from "../spqueryable.js";
 import { _Web } from "../webs/types.js";
 import { AppCatalog, IAppCatalog } from "./types.js";
 
@@ -14,4 +14,10 @@ declare module "../webs/types" {
     }
 }
 
-addProp(_Web, "appcatalog", AppCatalog);
+Reflect.defineProperty(_Web.prototype, "appcatalog", {
+    configurable: true,
+    enumerable: true,
+    get: function (this: SPInit) {
+        return AppCatalog(this);
+    },
+});


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #2208

#### What's in this Pull Request?

Contains fix for app catalog module.

Changed prototype property initialization similar to addProp but without path override.
