### PR TITLE
3.3.0 Updates and Fixes

### DIFF
--- a/docs/queryable/queryable.md
+++ b/docs/queryable/queryable.md
@@ -68,6 +68,12 @@ The Queryable lifecycle is:
 
 As well `log` and `error` can emit at any point during the lifecycle.
 
+## No observers registered for this request
+
+If you see an error thrown with the message `No observers registered for this request.` it means at the time of execution the given object has no actions to take. Because all the request logic is defined within observers, an absence of observers is _likely_ an error condition. If the object was created by a method within the library please report an issue as it is likely a bug. If you created the object through direct use of one of the factory functions, please be sure you have registered observers with `using` or `on` as appropriate. [More information on observers is available in this article](../core/observers.md).
+
+If you for some reason want to execute a queryable with no registred observers, you can simply register a noop observer to any of the moments.
+
 ## Queryable Observers
 
 This section outlines how to write observers for the Queryable lifecycle, and the expectations of each moment's observer behaviors.

--- a/docs/sp/items.md
+++ b/docs/sp/items.md
@@ -246,7 +246,7 @@ await sp.web.lists.getById("4D5A36EA-6E84-4160-8458-65C436DB765C").items.add({
 
 There are two types of user fields, those that allow a single value and those that allow multiple. For both types, you first need to determine the Id field name, which you can do by doing a GET REST request on an existing item. Typically the value will be the user field internal name with "Id" appended. So in our example, we have two fields User1 and User2 so the Id fields are User1Id and User2Id.
 
-Next, you need to remember there are two types of user fields, those that take a single value and those that allow multiple - these are updated in different ways. For single value user fields you supply just the user's id. For multiple value fields, you need to supply an object with a "results" property and an array. Examples for both are shown below.
+Next, you need to remember there are two types of user fields, those that take a single value and those that allow multiple - these are updated in different ways. For single value user fields you supply just the user's id. For multiple value fields, you need to supply an array. Examples for both are shown below.
 
 ```TypeScript
 import { spfi } from "@pnp/sp";

--- a/docs/sp/search.md
+++ b/docs/sp/search.md
@@ -45,20 +45,17 @@ console.log(results3.PrimarySearchResults);
 
 ## Search Result Caching
 
-You can use the searchWithCaching method to enable cache support for your search results this option works with any of the options for providing a query, just replace "search" with "searchWithCaching" in your method chain and gain all the benefits of caching. The second parameter is optional and allows you to specify the cache options
+Starting with v3 you can use any of the caching behaviors with search and the results will be cached. Please see here [for more details on caching options](https://pnp.github.io/pnpjs/queryable/behaviors/#caching).
 
 ```TypeScript
 import { spfi } from "@pnp/sp";
 import "@pnp/sp/search";
 import { ISearchQuery, SearchResults, SearchQueryBuilder } from "@pnp/sp/search";
+import { Caching } from "@pnp/queryable";
 
-const sp = spfi(...);
+const sp = spfi(...).using(Caching());
 
-sp.searchWithCaching({
-    Querytext: "test",
-    RowLimit: 10,
-    EnableInterleaving: true,
-} as ISearchQuery).then((r: SearchResults) => {
+sp.search({/* ... query */}).then((r: SearchResults) => {
 
     console.log(r.ElapsedTime);
     console.log(r.RowCount);
@@ -69,7 +66,7 @@ sp.searchWithCaching({
 const builder = SearchQueryBuilder("test").rowLimit(3);
 
 // supply a search query builder and caching options
-const results2 = await sp.searchWithCaching(builder, { key: "mykey", expiration: dateAdd(new Date(), "month", 1) });
+const results2 = await sp.search(builder);
 
 console.log(results2.TotalRows);
 ```

--- a/packages/queryable/queryable.ts
+++ b/packages/queryable/queryable.ts
@@ -115,6 +115,10 @@ export class Queryable<R> extends Timeline<typeof DefaultMoments> implements IQu
 
     protected execute(userInit: RequestInit): Promise<void> {
 
+        if (Reflect.ownKeys(this.observers).length < 1) {
+            throw Error("No observers registered for this request. (https://pnp.github.io/pnpjs/queryable/queryable#No-observers-registered-for-this-request)");
+        }
+
         setTimeout(async () => {
 
             const requestId = getGUID();

--- a/packages/queryable/request-builders.ts
+++ b/packages/queryable/request-builders.ts
@@ -1,10 +1,33 @@
 import { jsS } from "@pnp/core";
 
-export function body<T = unknown, U = any>(o: U, previous?: T): T & { body: string } {
+/**
+ * takes the supplied object of type U, JSON.stringify's it, and sets it as the value of a "body" property
+ */
+export function body<T extends Partial<RequestInit>, U = any>(o: U, previous?: T): T & { body: string } {
     return Object.assign({ body: jsS(o) }, previous);
 }
 
+/**
+ * Adds headers to an new/existing RequestInit
+ *
+ * @param o Headers to add
+ * @param previous Any previous partial RequestInit
+ * @returns RequestInit combining previous and specified headers
+ */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function headers<T = unknown, U extends Record<string, string> = {}>(o: U, previous?: T): T & { headers: U } {
-    return Object.assign({ headers: o }, previous);
+export function headers<T extends Partial<RequestInit>, U extends Record<string, string> = {}>(o: U, previous?: T): T & { headers: U } {
+    return Object.assign({}, previous, { headers: { ...previous?.headers, ...o } });
+}
+
+/**
+ * Adds the X-PnP-CacheAlways header to a request indicating to any caching observers this request should be cached. If
+ * no caching observers are registered this has no effect.
+ *
+ * @param previous Any previous RequestInit to extend
+ * @returns A RequestInit combining the caching header and any previous RequestInit
+ */
+export function cacheAlways<T extends Partial<RequestInit>>(previous?: T) {
+    return headers({
+        "X-PnP-CacheAlways": "1",
+    }, previous);
 }

--- a/packages/sp/appcatalog/types.ts
+++ b/packages/sp/appcatalog/types.ts
@@ -85,7 +85,7 @@ export class _AppCatalog extends _SPCollection {
 
         return {
             data: r,
-            file: File(odataUrlFrom(r)),
+            file: File([this, odataUrlFrom(r)]),
         };
     }
 }

--- a/packages/sp/comments/types.ts
+++ b/packages/sp/comments/types.ts
@@ -95,7 +95,7 @@ export class _Replies extends _SPCollection<ICommentInfo[]> {
 
         const d = await spPost(Replies(this, null), body(info));
 
-        return Object.assign(Comment(odataUrlFrom(d)), d);
+        return Object.assign(Comment([this, odataUrlFrom(d)]), d);
     }
 }
 export interface IReplies extends _Replies { }

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -482,7 +482,7 @@ export const File = spInvokableFactory<IFile>(_File);
  */
 export function fileFromServerRelativePath(base: ISPQueryable, serverRelativePath: string): IFile {
 
-    return File([base, extractWebUrl(base.toUrl())], `_api/web/getFileByServerRelativePath(decodedUrl='!@file::${escapeQueryStrValue(serverRelativePath)}')`);
+    return File([base, extractWebUrl(base.toUrl())], `_api/web/getFileByServerRelativePath(decodedUrl='${escapeQueryStrValue(serverRelativePath)}')`);
 }
 
 /**

--- a/packages/sp/folders/types.ts
+++ b/packages/sp/folders/types.ts
@@ -42,7 +42,7 @@ export class _Folders extends _SPCollection<IFolderInfo[]> {
 
         return {
             data,
-            folder: folderFromServerRelativePath(this, data.ServerRelativePath.DecodedUrl),
+            folder: folderFromServerRelativePath(this, data.ServerRelativeUrl),
         };
     }
 }
@@ -251,7 +251,7 @@ export const Folder = spInvokableFactory<IFolder>(_Folder);
  */
 export function folderFromServerRelativePath(base: ISPQueryable, serverRelativePath: string): IFolder {
 
-    return Folder([base, extractWebUrl(base.toUrl())], `_api/web/getFolderByServerRelativePath(decodedUrl='!@folder::${escapeQueryStrValue(serverRelativePath)}')`);
+    return Folder([base, extractWebUrl(base.toUrl())], `_api/web/getFolderByServerRelativePath(decodedUrl='${escapeQueryStrValue(serverRelativePath)}')`);
 }
 
 /**

--- a/packages/sp/lists/types.ts
+++ b/packages/sp/lists/types.ts
@@ -110,7 +110,7 @@ export class _Lists extends _SPCollection<IListInfo[]> {
      */
     public async ensureSiteAssetsLibrary(): Promise<IList> {
         const json = await spPost(Lists(this, "ensuresiteassetslibrary"));
-        return List(odataUrlFrom(json));
+        return List([this, odataUrlFrom(json)]);
     }
 
     /**
@@ -118,7 +118,7 @@ export class _Lists extends _SPCollection<IListInfo[]> {
      */
     public async ensureSitePagesLibrary(): Promise<IList> {
         const json = await spPost(Lists(this, "ensuresitepageslibrary"));
-        return List(odataUrlFrom(json));
+        return List([this, odataUrlFrom(json)]);
     }
 }
 export interface ILists extends _Lists { }

--- a/packages/sp/lists/web.ts
+++ b/packages/sp/lists/web.ts
@@ -64,5 +64,5 @@ _Web.prototype.getList = function (this: _Web, listRelativeUrl: string): IList {
 
 _Web.prototype.getCatalog = async function (this: _Web, type: number): Promise<IList> {
     const data = await Web(this, `getcatalog(${type})`).select("Id")();
-    return List(odataUrlFrom(data));
+    return List([this, odataUrlFrom(data)]);
 };

--- a/packages/sp/search/query.ts
+++ b/packages/sp/search/query.ts
@@ -1,6 +1,6 @@
 import { _SPInstance, ISPQueryable } from "../spqueryable.js";
 import { hOP, isArray } from "@pnp/core";
-import { body } from "@pnp/queryable";
+import { body, cacheAlways } from "@pnp/queryable";
 import { ISearchQuery, ISearchResponse, ISearchResult, ISearchBuilder, SearchQueryInit } from "./types.js";
 import { spPost } from "../operations.js";
 import { defaultPath } from "../decorators.js";
@@ -93,8 +93,8 @@ export class _Search extends _SPInstance {
 
         const query = this.parseQuery(queryInit);
 
-        const postBody: RequestInit = body({
-            request:{
+        const postBody: RequestInit = cacheAlways(body({
+            request: {
                 ...query,
                 HitHighlightedProperties: this.fixArrProp(query.HitHighlightedProperties),
                 Properties: this.fixArrProp(query.Properties),
@@ -103,7 +103,7 @@ export class _Search extends _SPInstance {
                 SelectProperties: this.fixArrProp(query.SelectProperties),
                 SortList: this.fixArrProp(query.SortList),
             },
-        });
+        }));
 
         const data = await spPost(this, postBody);
 
@@ -118,11 +118,7 @@ export class _Search extends _SPInstance {
      * @param prop property to fix for container struct
      */
     private fixArrProp(prop: any): any[] {
-        if (typeof prop === "undefined") {
-            return [];
-        }
-
-        return isArray(prop) ? prop : [prop];
+        return typeof prop === "undefined" ? [] : isArray(prop) ? prop : [prop];
     }
 
     /**

--- a/packages/sp/site-users/web.ts
+++ b/packages/sp/site-users/web.ts
@@ -47,7 +47,7 @@ _Web.prototype.ensureUser = async function (this: _Web, logonName: string): Prom
     const data = await spPost(Web(this, "ensureuser"), body({ logonName }));
     return {
         data,
-        user: SiteUser(odataUrlFrom(data)),
+        user: SiteUser([this, odataUrlFrom(data)]),
     };
 };
 

--- a/packages/sp/views/types.ts
+++ b/packages/sp/views/types.ts
@@ -100,7 +100,7 @@ export interface IView extends _View, IDeleteable { }
 export const View = spInvokableFactory<IView>(_View);
 
 @defaultPath("viewfields")
-export class _ViewFields extends _SPCollection<{ SchemaXml: string }> {
+export class _ViewFields extends _SPCollection<{ Items: string[]; SchemaXml: string }> {
 
     /**
      * Gets a value that specifies the XML schema that represents the collection.


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [X] New feature?
- [ ] New sample?
- [X] Documentation update?

#### Related Issues

fixes #2226
fixes #2229
fixes #2231
fixes #2232

#### What's in this Pull Request?

- Addresses issue where created object in library was not getting observer refs supplied (#2226)
- Fixed issue with search not caching results (#2229)
- Added support for "X-PnP-CacheAlways" header to allow non-get requests to be cached correctly
- Added `Items` property to IViewFilesInfo (#2231)
- Fixed issue where some objects created from urls were not getting observer refs (#2232)
- Added an exception if a queryable it executed with no registered observers and a docs entry to explain it
- Small docs updates and cleanup