### PR TITLE
docs(getting started): fix example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ import { spfi, SPFx } from "@pnp/sp";
 protected async onInit(): Promise<void> {
 
     await super.onInit();
-    const sp = spfi().using(spSPFx(this.context));
+    const sp = spfi().using(SPFx(this.context));
     
 }
 


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?


#### What's in this Pull Request?

Fixes an issue in the getting started documentation where the standalone SP SPFx example incorrectly uses the aliased `spSPFx` function. 

