### PR TITLE
Add post install script to test if SPFx version 1.12 - 1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
         "serve": "tsc -p ./debug/serve/tsconfig.json && node ./build/server/debug/serve/plumbing/run.js",
         "start": "npm run serve",
         "test": "tsc -p ./test/tsconfig.json && mocha --verbose --logging",
-        "test-build": "tsc -p ./test/tsconfig.json"
+        "test-build": "tsc -p ./test/tsconfig.json",
+        "postinstall": "node tools/postinstall/script.cjs"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
         "serve": "tsc -p ./debug/serve/tsconfig.json && node ./build/server/debug/serve/plumbing/run.js",
         "start": "npm run serve",
         "test": "tsc -p ./test/tsconfig.json && mocha --verbose --logging",
-        "test-build": "tsc -p ./test/tsconfig.json",
-        "postinstall": "node tools/postinstall/script.cjs"
+        "test-build": "tsc -p ./test/tsconfig.json"
     },
     "repository": {
         "type": "git",

--- a/packages/sp/package.json
+++ b/packages/sp/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "@pnp/sp",
-  "version": "0.0.0-PLACEHOLDER",
-  "description": "pnp - provides a fluent api for working with SharePoint REST",
-  "main": "./index.js",
-  "typings": "./index",
-  "dependencies": {
-    "tslib": "2.3.1",
-    "@pnp/core": "0.0.0-PLACEHOLDER",
-    "@pnp/queryable": "0.0.0-PLACEHOLDER"
-  }
+    "name": "@pnp/sp",
+    "version": "0.0.0-PLACEHOLDER",
+    "description": "pnp - provides a fluent api for working with SharePoint REST",
+    "main": "./index.js",
+    "typings": "./index",
+    "scripts": {
+        "postinstall": "node ../../tools/postinstall/script.cjs"
+    },
+    "dependencies": {
+        "tslib": "2.3.1",
+        "@pnp/core": "0.0.0-PLACEHOLDER",
+        "@pnp/queryable": "0.0.0-PLACEHOLDER"
+    }
 }

--- a/tools/postinstall/script.cjs
+++ b/tools/postinstall/script.cjs
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const projectRoot = process.env.INIT_CWD;
+const packageLoc = `${projectRoot}\\package.json`;
+const packageFile = fs.readFileSync(packageLoc, "utf8");
+const packageJSON = JSON.parse(packageFile);
+if (packageJSON.dependencies != null) {
+    const spfxVersion = packageJSON.dependencies["@microsoft/sp-core-library"];
+    if (spfxVersion != null) {
+        const spfxVersionFloat = parseFloat(spfxVersion);
+        if (spfxVersionFloat > 1.11 && spfxVersionFloat < 1.15) {
+            console.log("");
+            console.log("\x1b[43m%s\x1b[0m", " PnPjs WARNING ");
+            console.log("\x1b[33m%s\x1b[0m", "  The version of SPFx you are using requires an update to work with PnPjs. Please make sure to follow the getting started instructions to make the appropriate changes. ➡ https://pnp.github.io/pnpjs/getting-started/#spfx-version-1121-later");
+            console.log("");
+        }
+    }
+} else {
+    console.log("Package has no dependencies");
+}


### PR DESCRIPTION
Show's message that updates are needed & instructions are in the getting started guide

#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

Addresses #2184 with original PR done by @M365Bass

#### What's in this Pull Request?

Creates a postinstall step that checks if solution is SPFx version 1.12 - 1.14 and show a message that the user needs to make updates following instructions in getting started docs.