### PR TITLE
sp/views/types: add missing query escaping

### DIFF
--- a/packages/sp/views/types.ts
+++ b/packages/sp/views/types.ts
@@ -8,6 +8,7 @@ import {
 } from "../spqueryable.js";
 import { defaultPath } from "../decorators.js";
 import { spPost, spPostMerge } from "../operations.js";
+import { escapeQueryStrValue } from "../utils/escape-query-str.js";
 
 @defaultPath("views")
 export class _Views extends _SPCollection<IViewInfo[]> {
@@ -48,7 +49,7 @@ export class _Views extends _SPCollection<IViewInfo[]> {
      * @param title The case-sensitive title of the view
      */
     public getByTitle(title: string): IView {
-        return View(this, `getByTitle('${title}')`);
+        return View(this, `getByTitle('${escapeQueryStrValue(title)}')`);
     }
 }
 export interface IViews extends _Views { }
@@ -115,7 +116,7 @@ export class _ViewFields extends _SPCollection<{ Items: string[]; SchemaXml: str
      * @param fieldTitleOrInternalName The case-sensitive internal name or display name of the field to add.
      */
     public add(fieldTitleOrInternalName: string): Promise<void> {
-        return spPost(ViewFields(this, `addviewfield('${fieldTitleOrInternalName}')`));
+        return spPost(ViewFields(this, `addviewfield('${escapeQueryStrValue(fieldTitleOrInternalName)}')`));
     }
 
     /**
@@ -141,7 +142,7 @@ export class _ViewFields extends _SPCollection<{ Items: string[]; SchemaXml: str
      * @param fieldInternalName The case-sensitive internal name of the field to remove from the view.
      */
     public remove(fieldInternalName: string): Promise<void> {
-        return spPost(ViewFields(this, `removeviewfield('${fieldInternalName}')`));
+        return spPost(ViewFields(this, `removeviewfield('${escapeQueryStrValue(fieldInternalName)}')`));
     }
 }
 export interface IViewFields extends _ViewFields { }


### PR DESCRIPTION
#### Category

- [x] Bug fix?

#### What's in this Pull Request?

Escape URL-embedded values in this particular file. Perhaps the better option would be to use aliases as well so that URL lengths are never an issue.

No effort has been done to check other files for this same issue.

This change is semi-breaking: If anybody was doing manual escapes, this will double-escape and break the code; others that didn't escape and didn't notice issues weren't embedding problematic characters and therefore won't notice issues.

IMHO, when one abstracts away the URL-based nature of the SP API, this also means abstracting away the details of its encoding, and making sure it works correctly for all inputs.