### PR TITLE
Add Bookings to Graph

### DIFF
--- a/docs/graph/bookings.md
+++ b/docs/graph/bookings.md
@@ -1,0 +1,179 @@
+# @pnp/graph/bookings
+
+Represents the Bookings services available to a user.
+
+You can learn more  by reading the [Official Microsoft Graph Documentation](https://docs.microsoft.com/en-us/graph/api/resources/booking-api-overview?view=graph-rest-1.0).
+
+## IUsers, IUser, IPeople
+
+[![Invokable Banner](https://img.shields.io/badge/Invokable-informational.svg)](../concepts/invokable.md) [![Selective Imports Banner](https://img.shields.io/badge/Selective%20Imports-informational.svg)](../concepts/selective-imports.md)
+
+## Get Booking Currencies
+
+Get the supported currencies
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/bookings";
+
+const graph = graphfi(...);
+
+// Get all the currencies
+const currencies = await graph.bookingCurrencies();
+// get the details of the first currency
+const currency = await graph.bookingCurrencies.getById(currencies[0].id);
+```
+
+## Work with Booking Businesses
+
+Get the bookings businesses
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/bookings";
+
+const graph = graphfi(...);
+
+// Get all the businesses
+const businesses = await graph.bookingBusinesses();
+// get the details of the first business
+const business = await graph.bookingBusinesses.getById(businesses[0].id);
+// get the business calendar
+const calView = await business.calendarView("2022-06-01", "2022-08-01");
+// publish the business
+await business.publish();
+// unpublish the business
+await business.unpublish();
+```
+
+## Work with Booking Services
+
+Get the bookings business services
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/bookings";
+import { BookingService } from "@microsoft/microsoft-graph-types";
+
+const graph = graphfi(...);
+
+const business = await graph.bookingBusinesses.getById({Booking Business Id});
+// get the business services
+const services = await business.services();
+// add a service
+const newServiceDesc: BookingService = {booking service details -- see Microsoft Graph documentation};
+const newService = services.add(newServiceDesc);
+// get service by id
+const service = await business.services.getById({service id});
+// update service
+const updateServiceDesc: BookingService = {booking service details -- see Microsoft Graph documentation};
+const update = await business.services.getById({service id}).update(updateServiceDesc);
+// delete service
+await business.services.getById({service id}).delete();
+```
+
+## Work with Booking Customers
+
+Get the bookings business customers
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/bookings";
+import { BookingCustomer } from "@microsoft/microsoft-graph-types";
+
+const graph = graphfi(...);
+
+const business = await graph.bookingBusinesses.getById({Booking Business Id});
+// get the business customers
+const customers = await business.customers();
+// add a customer
+const newCustomerDesc: BookingCustomer = {booking customer details -- see Microsoft Graph documentation};
+const newCustomer = customers.add(newCustomerDesc);
+// get customer by id
+const customer = await business.customers.getById({customer id});
+// update customer
+const updateCustomerDesc: BookingCustomer = {booking customer details -- see Microsoft Graph documentation};
+const update = await business.customers.getById({customer id}).update(updateCustomerDesc);
+// delete customer
+await business.customers.getById({customer id}).delete();
+```
+
+## Work with Booking StaffMembers
+
+Get the bookings business staffmembers
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/bookings";
+import { BookingStaffMember } from "@microsoft/microsoft-graph-types";
+
+const graph = graphfi(...);
+
+const business = await graph.bookingBusinesses.getById({Booking Business Id});
+// get the business staff members
+const staffmembers = await business.staffMembers();
+// add a staff member
+const newStaffMemberDesc: BookingStaffMember = {booking staff member details -- see Microsoft Graph documentation};
+const newStaffMember = staffmembers.add(newStaffMemberDesc);
+// get staff member by id
+const staffmember = await business.staffMembers.getById({staff member id});
+// update staff member
+const updateStaffMemberDesc: BookingStaffMember = {booking staff member details -- see Microsoft Graph documentation};
+const update = await business.staffMembers.getById({staff member id}).update(updateStaffMemberDesc);
+// delete staffmember
+await business.staffMembers.getById({staff member id}).delete();
+```
+
+## Work with Booking Appointments
+
+Get the bookings business appointments
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/bookings";
+import { BookingAppointment } from "@microsoft/microsoft-graph-types";
+
+const graph = graphfi(...);
+
+const business = await graph.bookingBusinesses.getById({Booking Business Id});
+// get the business appointments
+const appointments = await business.appointments();
+// add a appointment
+const newAppointmentDesc: BookingAppointment = {booking appointment details -- see Microsoft Graph documentation};
+const newAppointment = appointments.add(newAppointmentDesc);
+// get appointment by id
+const appointment = await business.appointments.getById({appointment id});
+// cancel the appointment
+await appointment.cancel();
+// update appointment
+const updateAppointmentDesc: BookingAppointment = {booking appointment details -- see Microsoft Graph documentation};
+const update = await business.appointments.getById({appointment id}).update(updateAppointmentDesc);
+// delete appointment
+await business.appointments.getById({appointment id}).delete();
+```
+
+## Work with Booking Custom Questions
+
+Get the bookings business custom questions
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/bookings";
+import { BookingCustomQuestion } from "@microsoft/microsoft-graph-types";
+
+const graph = graphfi(...);
+
+const business = await graph.bookingBusinesses.getById({Booking Business Id});
+// get the business custom questions
+const customQuestions = await business.customQuestions();
+// add a custom question
+const newCustomQuestionDesc: BookingCustomQuestion = {booking custom question details -- see Microsoft Graph documentation};
+const newCustomQuestion = customQuestions.add(newCustomQuestionDesc);
+// get custom question by id
+const customquestion = await business.customQuestions.getById({customquestion id});
+// update custom question
+const updateCustomQuestionDesc: BookingCustomQuestion = {booking custom question details -- see Microsoft Graph documentation};
+const update = await business.customQuestions.getById({custom question id}).update(updateCustomQuestionDesc);
+// delete custom question
+await business.customQuestions.getById({customquestion id}).delete();
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
     - graph: 
       - graph: 'packages/#graph'
       - Behaviors: 'graph/behaviors.md'
+      - bookings: 'graph/bookings.md'
       - groups: 'graph/groups.md'
       - groups: 'graph/groups.md'
       - insights: 'graph/insights.md'
@@ -84,6 +85,7 @@ nav:
       - 'Navigation': 'sp/navigation.md'
       - Permissions: 'sp/permissions.md'
       - Profiles: 'sp/profiles.md'
+      - 'Recycle Bin': 'sp/recycle-bin.md'
       - 'Regional Settings': 'sp/regional-settings.md'
       - 'Related Items': 'sp/related-items.md'
       - Search: 'sp/search.md'

--- a/packages/graph/bookings/funcs.ts
+++ b/packages/graph/bookings/funcs.ts
@@ -1,0 +1,18 @@
+
+import { IGraphQueryable, GraphQueryableCollection, IGraphQueryableCollection } from "../graphqueryable.js";
+import { BookingAppointment as IBookingAppointmentEntity } from "@microsoft/microsoft-graph-types";
+
+/**
+ * Get the collection of bookingAppointment objects for a bookingBusiness, that occurs in the specified date range.
+ *
+ * @param this IGraphQueryable instance
+ * @param start start time
+ * @param end end time
+ */
+export function calendarView(this: IGraphQueryable, start: string, end: string): IGraphQueryableCollection<IBookingAppointmentEntity[]> {
+
+    const query = GraphQueryableCollection(this, "calendarView");
+    query.query.set("startDateTime", start);
+    query.query.set("endDateTime", end);
+    return query;
+}

--- a/packages/graph/bookings/index.ts
+++ b/packages/graph/bookings/index.ts
@@ -1,0 +1,45 @@
+import { BookingBusinesses, BookingCurrencies, IBookingBusinesses, IBookingCurrencies } from "./types.js";
+import { GraphFI } from "../fi.js";
+
+export {
+    BookingCurrencies,
+    BookingCurrency,
+    BookingBusinesses,
+    BookingBusiness,
+    BookingAppointments,
+    BookingAppointment,
+    BookingCustomers,
+    BookingCustomer,
+    BookingServices,
+    BookingService,
+    BookingStaffMembers,
+    BookingStaffMember,
+    IBookingBusinessAddResult,
+    IBookingAppointmentAddResult,
+    IBookingCustomerAddResult,
+    IBookingServiceAddResult,
+    IBookingStaffMemberAddResult,
+} from "./types.js";
+
+declare module "../fi" {
+    interface GraphFI {
+        readonly bookingBusinesses: IBookingBusinesses;
+        readonly bookingCurrencies: IBookingCurrencies;
+    }
+}
+
+Reflect.defineProperty(GraphFI.prototype, "bookingBusinesses", {
+    configurable: true,
+    enumerable: true,
+    get: function (this: GraphFI) {
+        return this.create(BookingBusinesses);
+    },
+});
+
+Reflect.defineProperty(GraphFI.prototype, "bookingCurrencies", {
+    configurable: true,
+    enumerable: true,
+    get: function (this: GraphFI) {
+        return this.create(BookingCurrencies);
+    },
+});

--- a/packages/graph/bookings/types.ts
+++ b/packages/graph/bookings/types.ts
@@ -1,0 +1,353 @@
+import {
+    BookingBusiness as IBookingBusinessEntity,
+    BookingAppointment as IBookingAppointmentEntity,
+    BookingCustomer as IBookingCustomerEntity,
+    BookingService as IBookingServiceEntity,
+    BookingStaffMember as IBookingStaffMemberEntity,
+    BookingCurrency as IBookingCurrencyEntity,
+    BookingCustomQuestion as IBookingCustomQuestionEntity,
+} from "@microsoft/microsoft-graph-types";
+import { _DirectoryObject } from "../directory-objects/types.js";
+import { _GraphQueryableCollection, graphInvokableFactory } from "../graphqueryable.js";
+import { defaultPath, deleteable, IDeleteable, updateable, IUpdateable, getById, IGetById } from "../decorators.js";
+import { graphPost } from "../operations.js";
+import { body } from "@pnp/queryable";
+import { calendarView } from "./funcs.js";
+
+/**
+ * Describes a Booking Currency entity
+ *
+ */
+export class _BookingCurrency extends _DirectoryObject<IBookingCurrencyEntity> { }
+export interface IBookingCurrency extends _BookingCurrency { }
+export const BookingCurrency = graphInvokableFactory<IBookingCurrency>(_BookingCurrency);
+
+/**
+ * Describes a collection of Booking Currency objects
+ *
+ */
+@defaultPath("solutions/bookingCurrencies")
+@getById(BookingCurrency)
+export class _BookingCurrencies extends _GraphQueryableCollection<IBookingCurrencyEntity[]>{ }
+export interface IBookingCurrencies extends _BookingCurrencies, IGetById<IBookingCurrency> { }
+export const BookingCurrencies = graphInvokableFactory<IBookingCurrencies>(_BookingCurrencies);
+
+/**
+ * Represents a booking business entity
+ */
+@deleteable()
+@updateable()
+export class _BookingBusiness extends _DirectoryObject<IBookingBusinessEntity> {
+    /**
+     * Get the calendar view for the booking business.
+     */
+    public calendarView = calendarView;
+
+    /**
+     * Make the scheduling page of a business available to external customers.
+     */
+    public publish(): Promise<void> {
+        return graphPost(BookingBusiness(this, "publish"));
+    }
+    /**
+     * Make the scheduling page of this business not available to external customers.
+     */
+    public unpublish(): Promise<void> {
+        return graphPost(BookingBusiness(this, "unpublish"));
+    }
+
+    /**
+     * Get the appointments for the booking business.
+     */
+    public get appointments(): IBookingAppointments {
+        return BookingAppointments(this);
+    }
+
+    /**
+     * Get the customers for the booking business.
+     */
+    public get customers(): IBookingCustomers {
+        return BookingCustomers(this);
+    }
+
+    /**
+     * Get the services for the booking business.
+     */
+    public get services(): IBookingServices {
+        return BookingServices(this);
+    }
+
+    /**
+     * Get the staff members for the booking business.
+     */
+    public get staffMembers(): IBookingStaffMembers {
+        return BookingStaffMembers(this);
+    }
+
+    /**
+     * Get the staff members for the booking business.
+     */
+    public get customQuestions(): IBookingCustomQuestions {
+        return BookingCustomQuestions(this);
+    }
+}
+export interface IBookingBusiness extends _BookingBusiness, IDeleteable, IUpdateable { }
+export const BookingBusiness = graphInvokableFactory<IBookingBusiness>(_BookingBusiness);
+
+/**
+ * Describes a collection of Booking Business objects
+ *
+ */
+@defaultPath("solutions/bookingBusinesses")
+@getById(BookingBusiness)
+export class _BookingBusinesses extends _GraphQueryableCollection<IBookingBusinessEntity[]>{
+    /**
+         * Create a new booking business as specified in the request body.
+         *
+         * @param name The name of the business, which interfaces with customers. This name appears at the top of the business scheduling page.
+         * @param additionalProperties A plain object collection of additional properties you want to set on the new group of type IBookingBusiness
+         */
+    public async add(name: string, additionalProperties: Record<string, any> = {}): Promise<IBookingBusinessAddResult> {
+
+        const postBody = {
+            displayName: name,
+            ...additionalProperties,
+        };
+
+        const data = await graphPost(this, body(postBody));
+
+        return {
+            data,
+            bookingBusiness: (<any>this).getById(data.id),
+        };
+    }
+}
+
+export interface IBookingBusinesses extends _BookingBusinesses, IGetById<IBookingBusiness> { }
+export const BookingBusinesses = graphInvokableFactory<IBookingBusinesses>(_BookingBusinesses);
+
+/**
+ * Represents a booking appointment entity
+ */
+@deleteable()
+@updateable()
+export class _BookingApointment extends _DirectoryObject<IBookingAppointmentEntity> {
+    /**
+     * Cancel the specified bookingAppointment in the specified bookingBusiness and send a message to the involved customer and staff members.
+     */
+    public cancel(cancellationMessage: string): Promise<void> {
+        const postBody = { cancellationMessage };
+        return graphPost(BookingAppointment(this, "cancel"), body(postBody));
+    }
+}
+export interface IBookingAppointment extends _BookingApointment, IDeleteable, IUpdateable { }
+export const BookingAppointment = graphInvokableFactory<IBookingAppointment>(_BookingApointment);
+
+/**
+ * Describes a collection of booking appointment objects
+ *
+ */
+@defaultPath("appointments")
+@getById(BookingAppointment)
+export class _BookingAppointments extends _GraphQueryableCollection<IBookingAppointmentEntity[]>{
+    /**
+     * Create a new booking appointment as specified in the request body.
+     *
+     * @param bookingAppointment  a JSON representation of a BookingAppointment object.
+     */
+    public async add(bookingAppointment: IBookingAppointmentEntity): Promise<IBookingAppointmentAddResult> {
+        const data = await graphPost(this, body(bookingAppointment));
+
+        return {
+            data,
+            bookingAppointment: (<any>this).getById(data.id),
+        };
+    }
+}
+
+export interface IBookingAppointments extends _BookingAppointments, IGetById<IBookingAppointment> { }
+export const BookingAppointments = graphInvokableFactory<IBookingAppointments>(_BookingAppointments);
+
+/**
+ * Represents a booking customer entity
+ */
+@deleteable()
+@updateable()
+export class _BookingCustomer extends _DirectoryObject<IBookingCustomerEntity> { }
+export interface IBookingCustomer extends _BookingCustomer, IDeleteable, IUpdateable { }
+export const BookingCustomer = graphInvokableFactory<IBookingCustomer>(_BookingCustomer);
+
+/**
+ * Describes a collection of booking customer objects
+ *
+ */
+@defaultPath("customers")
+@getById(BookingCustomer)
+export class _BookingCustomers extends _GraphQueryableCollection<IBookingCustomerEntity[]>{
+    /**
+     * Create a new booking customer as specified in the request body.
+     *
+     * @param bookingCustomer  a JSON representation of a BookingCustomer object.
+     */
+    public async add(bookingCustomer: IBookingCustomerEntity): Promise<IBookingCustomerAddResult> {
+        const data = await graphPost(this, body(bookingCustomer));
+
+        return {
+            data,
+            bookingCustomer: (<any>this).getById(data.id),
+        };
+    }
+}
+
+export interface IBookingCustomers extends _BookingCustomers, IGetById<IBookingCustomer> { }
+export const BookingCustomers = graphInvokableFactory<IBookingCustomers>(_BookingCustomers);
+
+/**
+ * Represents a booking service entity
+ */
+@deleteable()
+@updateable()
+export class _BookingService extends _DirectoryObject<IBookingServiceEntity> { }
+export interface IBookingService extends _BookingService, IDeleteable, IUpdateable { }
+export const BookingService = graphInvokableFactory<IBookingService>(_BookingService);
+
+/**
+ * Describes a collection of booking service objects
+ *
+ */
+@defaultPath("services")
+@getById(BookingService)
+export class _BookingServices extends _GraphQueryableCollection<IBookingServiceEntity[]>{
+    /**
+     * Create a new booking service as specified in the request body.
+     *
+     * @param bookingService  a JSON representation of a BookingService object.
+     */
+    public async add(bookingService: IBookingServiceEntity): Promise<IBookingServiceAddResult> {
+        const data = await graphPost(this, body(bookingService));
+
+        return {
+            data,
+            bookingService: (<any>this).getById(data.id),
+        };
+    }
+}
+
+export interface IBookingServices extends _BookingServices, IGetById<IBookingService> { }
+export const BookingServices = graphInvokableFactory<IBookingServices>(_BookingServices);
+
+/**
+ * Represents a booking staffmember entity
+ */
+@deleteable()
+@updateable()
+export class _BookingStaffMember extends _DirectoryObject<IBookingStaffMemberEntity> { }
+export interface IBookingStaffMember extends _BookingStaffMember, IDeleteable, IUpdateable { }
+export const BookingStaffMember = graphInvokableFactory<IBookingStaffMember>(_BookingStaffMember);
+
+/**
+ * Describes a collection of booking staffmember objects
+ *
+ */
+@defaultPath("staffMembers")
+@getById(BookingStaffMember)
+export class _BookingStaffMembers extends _GraphQueryableCollection<IBookingStaffMemberEntity[]>{
+    /**
+     * Create a new booking staffmember as specified in the request body.
+     *
+     * @param bookingStaffMember  a JSON representation of a BookingStaffMember object.
+     */
+    public async add(bookingStaffMember: IBookingStaffMemberEntity): Promise<IBookingStaffMemberAddResult> {
+        const data = await graphPost(this, body(bookingStaffMember));
+
+        return {
+            data,
+            bookingStaffMember: (<any>this).getById(data.id),
+        };
+    }
+}
+
+export interface IBookingStaffMembers extends _BookingStaffMembers, IGetById<IBookingStaffMember> { }
+export const BookingStaffMembers = graphInvokableFactory<IBookingStaffMembers>(_BookingStaffMembers);
+
+/**
+ * Represents a booking custom questions entity
+ */
+@deleteable()
+@updateable()
+export class _BookingCustomQuestion extends _DirectoryObject<IBookingCustomQuestionEntity> { }
+export interface IBookingCustomQuestion extends _BookingCustomQuestion, IDeleteable, IUpdateable { }
+export const BookingCustomQuestion = graphInvokableFactory<IBookingCustomQuestion>(_BookingCustomQuestion);
+
+/**
+ * Describes a collection of booking custom questions objects
+ *
+ */
+@defaultPath("customquestions")
+@getById(BookingCustomQuestion)
+export class _BookingCustomQuestions extends _GraphQueryableCollection<IBookingCustomQuestionEntity[]>{
+    /**
+     * Create a new booking customquestions as specified in the request body.
+     *
+     * @param bookingCustomQuestion  a JSON representation of a BookingCustomQuestion object.
+     */
+    public async add(bookingCustomQuestion: IBookingCustomQuestionEntity): Promise<IBookingCustomQuestionAddResult> {
+        const data = await graphPost(this, body(bookingCustomQuestion));
+
+        return {
+            data,
+            bookingCustomQuestion: (<any>this).getById(data.id),
+        };
+    }
+}
+
+export interface IBookingCustomQuestions extends _BookingCustomQuestions, IGetById<IBookingCustomQuestion> { }
+export const BookingCustomQuestions = graphInvokableFactory<IBookingCustomQuestions>(_BookingCustomQuestions);
+
+/**
+ * IBookingBusinessAddResult
+ */
+export interface IBookingBusinessAddResult {
+    bookingBusiness: IBookingBusinessEntity;
+    data: any;
+}
+
+/**
+ * IBookingAppointmentAddResult
+ */
+export interface IBookingAppointmentAddResult {
+    bookingAppointment: IBookingAppointmentEntity;
+    data: any;
+}
+
+/**
+ * IBookingCustomerAddResult
+ */
+export interface IBookingCustomerAddResult {
+    bookingCustomer: IBookingCustomerEntity;
+    data: any;
+}
+
+/**
+ * IBookingServiceAddResult
+ */
+export interface IBookingServiceAddResult {
+    bookingService: IBookingServiceEntity;
+    data: any;
+}
+
+/**
+ * IBookingStaffMemberAddResult
+ */
+export interface IBookingStaffMemberAddResult {
+    bookingStaffMember: IBookingStaffMemberEntity;
+    data: any;
+}
+
+/**
+ * IBookingCustomQuestionAddResult
+ */
+export interface IBookingCustomQuestionAddResult {
+    bookingCustomQuestion: IBookingCustomQuestionEntity;
+    data: any;
+}

--- a/packages/graph/groups/types.ts
+++ b/packages/graph/groups/types.ts
@@ -76,7 +76,7 @@ export interface IGroup extends _Group, IDeleteable, IUpdateable { }
 export const Group = graphInvokableFactory<IGroup>(_Group);
 
 /**
- * Describes a collection of Field objects
+ * Describes a collection of Group objects
  *
  */
 @defaultPath("groups")


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

addresses #1814

#### What's in this Pull Request?

Added all the version 1.0 Bookings api's to the graph as a new importable object.
Booking Businesses, Customers, Services, Staff Members, Appointments, Custom Questions, and Currencies.

Cannot be tested with app permissions, requires manual testing.