### PR TITLE
Documentation update for config/services setup

### DIFF
--- a/docs/concepts/project-preset.md
+++ b/docs/concepts/project-preset.md
@@ -1,18 +1,14 @@
-# Project Presets
+# Project Config/Services Setup
 
-Due to the introduction of [selective imports](./selective-imports.md) it can be somewhat frustrating to import all of the needed dependencies every time you need them across many files. Instead the preferred approach, especially for SPFx, is to create a project preset file. This centralizes the imports, configuration, and optionally extensions to PnPjs in a single place.
+Due to the introduction of [selective imports](./selective-imports.md) it can be somewhat frustrating to import all of the needed dependencies every time you need them across many files. Instead the preferred approach, especially for SPFx, is to create a project config file or establish a service to manage your PnPjs interfaces. Doing so centralizes the imports, configuration, and optionally extensions to PnPjs in a single place.
 
 > If you have multiple projects that share dependencies on PnPjs you can benefit from creating a [custom bundle](./custom-bundle.md) and using them across your projects.
 
 These steps reference an [SPFx](https://docs.microsoft.com/sharepoint/dev/spfx/sharepoint-framework-overview) solution, but apply to any solution.
 
-## Install the library
+## Using a config file
 
-`npm install @pnp/sp --save`
-
-## Create a Preset File
-
-Within the src directory create a new file named `pnpjs-presets.ts` and copy in the below content.
+Within the src directory create a new file named `pnpjs-config.ts` and copy in the below content.
 
 ```TypeScript
 import { WebPartContext } from "@microsoft/sp-webpart-base";
@@ -54,7 +50,7 @@ protected async onInit(): Promise<void> {
 Now you can consume your configured `_sp` object from anywhere else in your code by simply referencing the `pnpjs-presets.ts` file via an import statement and then getting a local instance of the `_sp` object using the `getSP()` method without passing any context.
 
 ```TypeScript
-import { getSP } from './pnpjs-resets.ts';
+import { getSP } from './pnpjs-config.ts';
 ...
 export default class PnPjsExample extends React.Component<IPnPjsExampleProps, IIPnPjsExampleState> {
   
@@ -73,6 +69,56 @@ export default class PnPjsExample extends React.Component<IPnPjsExampleProps, II
   ...
 
 }
+```
+
+### Use a service class
+
+Because you do not have full access to the context object within a service you need to setup things a little differently. If you do not need AAD tokens you can leave that part out and specify just the pageContext (Option 2).
+
+```TypeScript
+import { ServiceKey, ServiceScope } from "@microsoft/sp-core-library";
+import { PageContext } from "@microsoft/sp-page-context";
+import { AadTokenProviderFactory } from "@microsoft/sp-http";
+import { spfi, SPFx } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/lists/web";
+
+export interface ISampleService {
+    getLists(): Promise<any[]>;
+}
+
+export class SampleService {
+
+    public static readonly serviceKey: ServiceKey<ISampleService> = ServiceKey.create<ISampleService>('SPFx:SampleService', SampleService);
+    private _sp: SPFI;
+
+    constructor(serviceScope: ServiceScope) {
+
+        serviceScope.whenFinished(() => {
+
+        const pageContext = serviceScope.consume(PageContext.serviceKey);
+        const tokenProviderFactory = serviceScope.consume(AadTokenProviderFactory.serviceKey);
+
+        //Option 1 - with AADTokenProvider
+        this._sp = spfi().using(SPFx({
+            aadTokenProviderFactory: tokenProviderFactory,
+            pageContext: pageContext,
+        }));
+
+        //Option 2 - without AADTokenProvider
+        this._sp = spfi().using(SPFx({ pageContext }));
+    }
+
+    public getLists(): Promise<any[]> {
+        return this._sp.web.lists();
+    }
+}
+```
+
+Depending on the architecture of your solution you can also opt to export the service as a global. If you choose this route you would need to modify the service to create an Init function where you would pass the service scope instead of doing so in the constructor. You would then export a constant that creates a global instance of the service.
+
+```ts
+export const mySampleService = new SampleService();
 ```
 
 For a full sample, please see our [PnPjs Version 3 Sample Project](https://github.com/pnp/sp-dev-fx-webparts/tree/main/samples/react-pnp-js-sample)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,49 +146,9 @@ protected async onInit(): Promise<void> {
 
 ```
 
-### Establish context within an SPFx service
+## Project Config/Services Setup
 
-Because you do not have full access to the context object within a service you need to setup things a little differently. If you do not need AAD tokens you can leave that part out and specify just the pageContext (Option 2).
-
-```TypeScript
-import { ServiceKey, ServiceScope } from "@microsoft/sp-core-library";
-import { PageContext } from "@microsoft/sp-page-context";
-import { AadTokenProviderFactory } from "@microsoft/sp-http";
-import { spfi, SPFx } from "@pnp/sp";
-import "@pnp/sp/webs";
-import "@pnp/sp/lists/web";
-
-export interface ISampleService {
-    getLists(): Promise<any[]>;
-}
-
-export class SampleService {
-
-    public static readonly serviceKey: ServiceKey<ISampleService> = ServiceKey.create<ISampleService>('SPFx:SampleService', SampleService);
-    private _sp: SPFI;
-
-    constructor(serviceScope: ServiceScope) {
-
-        serviceScope.whenFinished(() => {
-
-        const pageContext = serviceScope.consume(PageContext.serviceKey);
-        const tokenProviderFactory = serviceScope.consume(AadTokenProviderFactory.serviceKey);
-
-        //Option 1 - with AADTokenProvider
-        this._sp = spfi().using(SPFx({
-            aadTokenProviderFactory: tokenProviderFactory,
-            pageContext: pageContext,
-        }));
-
-        //Option 2 - without AADTokenProvider
-        this._sp = spfi().using(SPFx({ pageContext }));
-    }
-
-    public getLists(): Promise<any[]> {
-        return this._sp.web.lists();
-    }
-}
-```
+Please see the [documentation](./concepts/project-preset.md) on setting up a config file or a services for more information about establishing and instance of the spfi or graphfi interfaces that can be reused. It is a common mistake with users of V3 that they try and create the interface in event handlers which causes issues.
 
 ## Getting started with NodeJS
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ nav:
     - 'Batching & Caching': 'concepts/batching-caching.md'
     - 'Custom Bundling': 'concepts/custom-bundle.md'
     - 'Error-Handling': 'concepts/error-handling.md'
-    - 'Project Presets': 'concepts/project-preset.md'
+    - 'Project Config/Services Setup': 'concepts/project-preset.md'
     - 'Selective Imports': 'concepts/selective-imports.md'
     - 'Typings': 'concepts/typings.md'
     - 'Using Behaviors': 'core/behaviors.md'


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### Related Issues

N/A

#### What's in this Pull Request?

Slightly reorganizes documentation on creating preset config files and services for V3 project implementation. Now both the config file and services samples are in the same file and link had been made from the getting started page.

