### PR TITLE
WIP: Adding sp-admin library to support tenant admin APIs [Don't Merge]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
         "coverage": true,
         ".nyc_output": true,
         "build": true,
-        "dist": true,
+        "dist": false,
         "site": true,
         "buildsystem-config.js": true
     },

--- a/debug/launch/main.ts
+++ b/debug/launch/main.ts
@@ -8,8 +8,9 @@ import { ITestingSettings } from "../../test/load-settings.js";
 // add your debugging imports here and prior to submitting a PR git checkout debug/debug.ts
 // will allow you to keep all your debugging files locally
 // comment out the example
-import { Example } from "./files.js";
+// import { Example } from "./files.js";
 // import { Example } from "./sp.js";
+import { Example } from "./admin.js";
 // import { Example } from "./graph.js";
 
 // setup the connection to SharePoint using the settings file, you can

--- a/docs/sp-admin/index.md
+++ b/docs/sp-admin/index.md
@@ -1,0 +1,70 @@
+# sp-admin
+
+The `@pnp/sp-admin` library enables you to call the static SharePoint admin API's located at `_api/Microsoft.Online.SharePoint.TenantManagement.Office365Tenant`, `_api/Microsoft.Online.SharePoint.TenantAdministration.SiteProperties`, and `_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant`. These APIs typically require an elevated level of permissions and should not be relied upon in general user facing solutions. Before using this library please understand the impact of what you are doing as you are updating settings at the tenant level for all users.
+
+## Use
+
+To use the library you first need to install the package:
+
+```CMD
+npm install @pnp/sp-admin --save
+```
+
+Then import the package into your solution, it will attach a node to the existing sp fluent interface.
+
+```TS
+import "@pnp/sp-admin";
+```
+
+## Basic Example
+
+In this example we get all of the web templates' information.
+
+```TS
+import { spfi } from "@pnp/sp";
+import "@pnp/sp-admin";
+
+const sp = spfi(...);
+
+// note the "admin" node now available
+const templates = await spTenant.admin.tenant.getSPOTenantAllWebTemplates();
+```
+
+## tenant
+
+The `tenant` node represents calls to the `_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant` api.
+
+When calling the `tenant` endpoint you must target the -admin site as shown here. If you do not you will get only errors back.
+
+```TS
+import { spfi } from "@pnp/sp";
+import "@pnp/sp-admin";
+
+const sp = spfi("https://{tenant}-admin.sharepoint.com");
+
+// The MSAL scope will be: "https://{tenant}-admin.sharepoint.com/.default"
+
+// get props
+const allProps = await spTenant.admin.tenant();
+
+// select specific props to return
+const selectedProps = await spTenant.admin.tenant.select("AllowEditing", "DefaultContentCenterSite")();
+
+// call a method
+const templates = await spTenant.admin.tenant.getSPOTenantAllWebTemplates();
+```
+
+## office365Tenant
+
+The `office365Tenant` node represents calls to the `_api/Microsoft.Online.SharePoint.TenantManagement.Office365Tenant` end point and is accessible from any site url.
+
+```TS
+import { spfi } from "@pnp/sp";
+import "@pnp/sp-admin";
+
+const sp = spfi(...);
+
+const allProps = await spTenant.admin.office365Tenant();
+```
+
+

--- a/packages/graph/tsconfig.json
+++ b/packages/graph/tsconfig.json
@@ -11,9 +11,6 @@
             "path": "../core/tsconfig.json"
         },
         {
-            "path": "../logging/tsconfig.json"
-        },
-        {
             "path": "../queryable/tsconfig.json"
         }
     ]

--- a/packages/graph/tsconfig.json
+++ b/packages/graph/tsconfig.json
@@ -3,7 +3,6 @@
     "include": [
         "./**/*.ts",
         "../core/**/*.ts",
-        "../logging/**/*.ts",
         "../queryable/**/*.ts"
     ],
     "references": [

--- a/packages/queryable/tsconfig.json
+++ b/packages/queryable/tsconfig.json
@@ -6,9 +6,6 @@
     "references": [
         {
             "path": "../core/tsconfig.json"
-        },
-        {
-            "path": "../logging/tsconfig.json"
         }
     ]
 }

--- a/packages/sp-admin/Office365Tenant.ts
+++ b/packages/sp-admin/Office365Tenant.ts
@@ -16,7 +16,7 @@ import {
 } from "./types.js";
 
 @defaultPath("_api/Microsoft.Online.SharePoint.TenantManagement.Office365Tenant")
-export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
+class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
     /**
     * Choose which fields to return
@@ -389,8 +389,8 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
      *GetExternalUsersResults.UserCollectionPosition value returned from the previous call.  If GetExternalUsersResults.ExternalUserCollection.Count is less than pageSize,
      *all available users have been returned (it is the last page of results.)
      */
-    public getExternalUsers(position: number, pageSize: number, filter: string = null, sortOrder = SortOrder.Ascending): Promise<IGetExternalUsersResults> {
-        return spPost(Office365Tenant(this, "GetExternalUsers"), body({
+    public getExternalUsers(position = 0, pageSize = 50, filter: string = null, sortOrder = SortOrder.Ascending): Promise<IGetExternalUsersResults> {
+        return spPost(Office365Tenant(this, "GetExternalUsers").select(<any>"ExternalUserCollection").expand("ExternalUserCollection"), body({
             position,
             pageSize,
             filter,
@@ -413,8 +413,8 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
      *all available users have been returned (it is the last page of results.)
      */
     // eslint-disable-next-line max-len
-    public getExternalUsersWithSortBy(position: number, pageSize: number, filter: string = null, sortPropertyName = "OtherMail", sortOrder = SortOrder.Ascending): Promise<IGetExternalUsersResults> {
-        return spPost(Office365Tenant(this, "GetExternalUsersWithSortBy"), body({
+    public getExternalUsersWithSortBy(position = 0, pageSize = 50, filter: string = null, sortPropertyName = "OtherMail", sortOrder = SortOrder.Ascending): Promise<IGetExternalUsersResults> {
+        return spPost(Office365Tenant(this, "GetExternalUsersWithSortBy").select(<any>"ExternalUserCollection").expand("ExternalUserCollection"), body({
             position,
             pageSize,
             filter,
@@ -437,8 +437,8 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
      * value returned from the previous call.  If GetExternalUsersResults.ExternalUserCollection.Count is less than pageSize,
      * all available users have been returned (it is the last page of results.)
      */
-    public getExternalUsersForSite(siteUrl: string, position: number, pageSize: number, filter: string = null, sortOrder = SortOrder.Ascending): Promise<IGetExternalUsersResults> {
-        return spPost(Office365Tenant(this, "GetExternalUsersForSite"), body({
+    public getExternalUsersForSite(siteUrl: string, position = 0, pageSize = 50, filter: string = null, sortOrder = SortOrder.Ascending): Promise<IGetExternalUsersResults> {
+        return spPost(Office365Tenant(this, "GetExternalUsersForSite").select(<any>"ExternalUserCollection").expand("ExternalUserCollection"), body({
             siteUrl,
             position,
             pageSize,

--- a/packages/sp-admin/Office365Tenant.ts
+++ b/packages/sp-admin/Office365Tenant.ts
@@ -1,0 +1,555 @@
+import { body } from "@pnp/queryable";
+import { _SPInstance, defaultPath, spPost, IResourcePath } from "@pnp/sp";
+import { boolean } from "yargs";
+import { IOffice365TenantInfo, SPOrgAssetType, SPOTenantCdnType } from "./types.js";
+
+@defaultPath("_api/Microsoft.Online.SharePoint.TenantManagement.Office365Tenant")
+export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
+
+    // TODO::test
+    /**
+     * Sets the configuration values for Idle session sign out for unmanaged devices
+     * 
+     * @param enabled Boolean indicating if the policy should be enabled
+     * @param warnAfter TimeSpan containing the time before warning the user
+     * @param signOutAfter TimeSpan containing the time before signing out the user
+     * @returns True if the operation succeeds, false otherwise
+     */
+    public setIdleSessionSignOutForUnmanagedDevices(enabled: boolean, warnAfter: any, signOutAfter: any): Promise<boolean> {
+        return spPost(Office365Tenant(this, "SetIdleSessionSignOutForUnmanagedDevices"), body({
+            enabled,
+            warnAfter,
+            signOutAfter,
+        }));
+    }
+
+    // TODO::test
+    /**
+     * Gets the configuration values, as a string, for Idle session sign out for unmanaged devices
+     * The return string is a comma delineated list of the three policy settings.  The policy settings consist of
+     * 1. Enabled: true or false
+     * 2. Warn after: Time until user should be warned in seconds.
+     * 3. Sign out after: Time until user should be signed out in seconds.
+     * 
+     * @returns A string indicating the current policy settings
+     */
+    public getIdleSessionSignOutForUnmanagedDevices(): Promise<string> {
+        return spPost(Office365Tenant(this, "GetIdleSessionSignOutForUnmanagedDevices"));
+    }
+
+    // TODO::test
+    /**
+     * Adds a SharePoint document library to the list of Organization Assets libraries
+     * 
+     * @param cdnType 
+     * @param libUrl Url of a SharePoint document library to be added to the list of Organization Assets libraries
+     * @param thumbnailUrl 
+     * @param orgAssetType 
+     * @param defaultOriginAdded 
+     */
+    public addToOrgAssetsLibAndCdn(cdnType: SPOTenantCdnType, libUrl: IResourcePath, thumbnailUrl: IResourcePath, orgAssetType: SPOrgAssetType, defaultOriginAdded: boolean): Promise<void> {
+        return spPost(Office365Tenant(this, "AddToOrgAssetsLibAndCdn"), body({
+            cdnType,
+            libUrl,
+            thumbnailUrl,
+            orgAssetType,
+            defaultOriginAdded,
+        }));
+    }
+
+    // TODO::test
+    public removeFromOrgAssetsAndCdn(remove: boolean, cdnType: SPOTenantCdnType, libUrl: IResourcePath): Promise<void> {
+        return spPost(Office365Tenant(this, "RemoveFromOrgAssetsAndCdn"), body({
+            remove,
+            cdnType,
+            libUrl,
+        }));
+    }
+
+    // TODO::test
+    /**
+     * Removes an entry from the list of Organization Assets libraries
+     */
+    public removeFromOrgAssets(libUrl: IResourcePath, listId: string): Promise<void> {
+        return spPost(Office365Tenant(this, "RemoveFromOrgAssets"), body({
+            libUrl,
+            listId,
+        }));
+    }
+
+    // TODO::test
+    /**
+     * Sets a SharePoint library thumbnail in Organization Assets libraries
+     * 
+     * @param libUrl Url of a SharePoint library to be set in Organization Assets
+     * @param thumbnailUrl Url to an image used as the thumbnail for this library in the FilePicker
+     * @param orgAssetType Type of Organization Assets Document Library
+     * @returns 
+     */
+    public setOrgAssetsLib(libUrl: IResourcePath, thumbnailUrl: IResourcePath, orgAssetType: SPOrgAssetType): Promise<void> {
+        return spPost(Office365Tenant(this, "SetOrgAssetsLib"), body({
+            libUrl,
+            thumbnailUrl,
+            orgAssetType,
+        }));
+    }
+
+    // TODO::test
+    /**
+     * Gets the minor version that should be used to generate the next iteration of the custom font catalog for the
+     * font org asset library specified by libUrl
+     * 
+     * @param libUrl 
+     * @returns 
+     */
+    public getCustomFontsMinorVersion(libUrl: IResourcePath): Promise<number> {
+        return spPost(Office365Tenant(this, "GetCustomFontsMinorVersion"), body({
+            libUrl,
+        }));
+    }
+
+    // TODO::test
+    /**
+     * Uploads fonts and font catalogs to a font asset library
+     */
+    public uploadCustomFontsAndCatalogLib(customFontFiles: any, libUrl: IResourcePath): Promise<boolean> {
+        return spPost(Office365Tenant(this, "UploadCustomFontsAndCatalogLib"), body({
+            customFontFiles,
+            libUrl,
+        }));
+    }
+
+    // TODO::test
+    /**
+     * Removes old Custom Fonts files
+     */
+    public removePreviousCustomFontUpload(majVersions: string[], libUrl: IResourcePath): Promise<void> {
+        return spPost(Office365Tenant(this, "RemovePreviousCustomFontUpload"), body({
+            majVersions,
+            libUrl,
+        }));
+    }
+
+    // TODO::test
+    /**
+     * Increments the minor version for libUrl
+     */
+    public incrementCustomFontsMinorVersion(libUrl: IResourcePath): Promise<void> {
+        return spPost(Office365Tenant(this, "IncrementCustomFontsMinorVersion"), body({
+            libUrl,
+        }));
+    }
+
+    // TODO::test
+    /**
+     * Gets a list of tenant CDN origins
+     * 
+     * @param cdnType Type of CDN: private or public
+     */
+    public getTenantCdnOrigins(cdnType: SPOTenantCdnType): Promise<string[]> {
+        return spPost(Office365Tenant(this, "GetTenantCdnOrigins"), body({
+            cdnType,
+        }));
+    }
+
+    /// <summary>
+    /// Adds a tenant cdn origin.
+    /// </summary>
+    /// <param name="cdnType">Type of CDN: private or public</param>
+    /// <param name="originUrl">origin Url to add</param>
+
+    public void AddTenantCdnOrigin(SPOTenantCdnType cdnType, string originUrl) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Create);
+        this.DataAccess.AddTenantCdnOrigin(cdnType, originUrl);
+    }
+
+    /// <summary>
+    /// Removes a tenant cdn origin.
+    /// </summary>
+    /// <param name="cdnType">Type of CDN: private or public</param>
+    /// <param name="originUrl">origin Url to add</param>
+
+    public void RemoveTenantCdnOrigin(SPOTenantCdnType cdnType, string originUrl) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Delete);
+        this.DataAccess.RemoveTenantCdnOrigin(cdnType, originUrl);
+    }
+
+    /// <summary>
+    /// Enables or disabled tenant CDN feature.
+    /// </summary>
+    /// <param name="cdnType">Type of CDN: private or public</param>
+    /// <param name="isEnabled">value to set</param>
+
+    public void SetTenantCdnEnabled(SPOTenantCdnType cdnType, bool isEnabled) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
+        this.DataAccess.SetTenantCdnEnabled(cdnType, isEnabled);
+    }
+
+    /// <summary>
+    /// Gets whether tenant CDN feature is enabled.
+    /// </summary>
+    /// <param name="cdnType">Type of CDN: private or public</param>
+    /// <returns>True if CDN is enabled; false otherwise</returns>
+
+    public bool GetTenantCdnEnabled(SPOTenantCdnType cdnType) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
+        return this.DataAccess.GetTenantCdnEnabled(cdnType);
+    }
+
+    /// <summary>
+    /// Sets policy for the tenant CDN.
+    /// </summary>
+    /// <param name="cdnType">CDN type</param>
+    /// <param name="policy">Policy type</param>
+    /// <param name="policyValue">Policy value</param>
+
+    public void SetTenantCdnPolicy(SPOTenantCdnType cdnType, SPOTenantCdnPolicyType policy, string policyValue) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
+        this.DataAccess.SetTenantCdnPolicy(cdnType, policy, policyValue);
+    }
+
+    /// <summary>
+    /// Gets list of policies for the tenant CDN.
+    /// </summary>
+    /// <param name="cdnType">CDN type</param>
+    /// <returns>List of policies</returns>
+
+    public IList<string> GetTenantCdnPolicies(SPOTenantCdnType cdnType) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
+        return this.DataAccess.GetTenantCdnPolicies(cdnType);
+    }
+
+    /// <summary>
+    /// Creates default origins for requested CDN type.
+    /// </summary>
+    /// <returns></returns>
+
+    public void CreateTenantCdnDefaultOrigins(SPOTenantCdnType cdnType) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Create);
+        this.DataAccess.CreateTenantCdnDefaultOrigins(cdnType);
+    }
+
+    #endregion
+
+    #region Theming
+
+    /// <summary>
+    /// Add a custom theme to the tenant so that it will be available when selecting a site theme.
+    /// </summary>
+    /// <param name="name">The name of the theme.</param>
+    /// <param name="themeJson">A JSON representation of the theme information.</param>
+    /// <returns>True, if the theme is added successfully.</returns>
+
+    public bool AddTenantTheme(string name, string themeJson) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Create);
+        return this.DataAccess.AddTenantTheme(name, themeJson);
+    }
+
+    /// <summary>
+    /// Update the properties of a custom theme.
+    /// </summary>
+    /// <param name="name">The name of the theme to update.</param>
+    /// <param name="themeJson">A JSON representation of the new theme information.</param>
+    /// <returns>True, if the theme is updated successfully.</returns>
+
+    public bool UpdateTenantTheme(string name, string themeJson) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
+        return this.DataAccess.UpdateTenantTheme(name, themeJson);
+    }
+
+    /// <summary>
+    /// Remove a custom theme from the tenant.
+    /// </summary>
+    /// <param name="name">The name of the theme to delete.</param>
+
+    public void DeleteTenantTheme(string name) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Delete);
+        this.DataAccess.DeleteTenantTheme(name);
+    }
+
+    /// <summary>
+    /// Retrieves a custom theme previously added to the tenant.
+    /// </summary>
+    /// <param name="name">The name of the theme to retrieve.</param>
+    /// <returns>A ThemeProperties object representing the theme.</returns>
+
+    public ThemeProperties GetTenantTheme(string name) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
+        return this.DataAccess.GetTenantTheme(name);
+    }
+
+    /// <summary>
+    /// Retrieves all custom themes added to the tenant.
+    /// </summary>
+    /// <returns>ThemeProperties objects representing all of the custom themes added to the tenant.</returns>
+
+    public IList<ThemeProperties> GetAllTenantThemes() {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
+        return this.DataAccess.GetAllTenantThemes();
+    }
+
+    /// <summary>
+    /// Retrieves a setting specifying whether default SharePoint themes should be hidden from the web UI.
+    /// </summary>
+    /// <returns>True, if default SharePoint themes should be hidden from the web UI</returns>
+
+    public bool GetHideDefaultThemes() {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
+        return this.DataAccess.GetHideDefaultThemes();
+    }
+
+    /// <summary>
+    /// Updates a setting specifying whether default SharePoint themes should be hidden from the web UI.
+    /// </summary>
+    /// <returns>True, if the setting is updated successfully.</returns>
+
+    public bool SetHideDefaultThemes(bool hideDefaultThemes) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
+        return this.DataAccess.SetHideDefaultThemes(hideDefaultThemes);
+    }
+
+    /// <summary>
+    /// Adds an SDN provider to the tenant.
+    /// </summary>
+    /// <param name="identifier">id of an SDN provider to be added</param>
+    /// <param name="license">license number provided by SDN provider</param>
+
+    public void AddSdnProvider(string identifier, string license) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Create);
+        this.DataAccess.AddSdnProvider(identifier, license);
+    }
+
+    /// <summary>
+    /// Removes an entry from the list of supported SDN providers.
+    /// </summary>
+
+    public void RemoveSdnProvider() {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Delete);
+        this.DataAccess.RemoveSdnProvider();
+    }
+    #endregion
+    /// <summary>
+    /// Returns a collection of User objects corresponding to external users in the tenancy.
+    /// </summary>
+    /// <param name="position">Zero-based index of the position in the sorted collection of the first result to be returned.</param>
+    /// <param name="pageSize">The maximum number of ExternalUsers to be returned in the collection.  Must be less than or equal to 50.</param>
+    /// <param name="filter">Limits the results to only those ExternalUers whose display name or invitedAs email address
+    /// begins with the text in the string, using a case-insensitive comparison.</param>
+    /// <param name="sortOrder">Specifies whether a call to GetExternalUsers should sort results in Ascending or
+    /// Descending order on the ExternalUser.invitedAs property</param>
+    /// <returns>
+    /// A GetExternalUsersResults object containing up to pageSize users that match the filter criteria, in the order
+    /// specified, starting from the specified position.  Further pages can be fetched by calling again with
+    /// the same filter and sortOrder parameters but specifying for position the
+    /// GetExternalUsersResults.UserCollectionPosition value returned from the previous call.  If
+    /// GetExternalUsersResults.ExternalUserCollection.Count is less than pageSize, all available users have been returned
+    /// (it is the last page of results.)
+    /// </returns>
+    /// <remarks>This method is unaffected by the value of the SharingCapability property.</remarks>
+    /// <id guid="EC4771AB-489F-4164-89A7-52E9DBA3DF0B" />
+
+    public GetExternalUsersResults GetExternalUsers(int position, int pageSize, string filter = null, SortOrder sortOrder = SortOrder.Ascending) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
+        return GetExternalUsersInternal(null /*no site url*/, position, pageSize, filter, sortOrder, null /*no sort by*/);
+    }
+
+    /// <summary>
+    /// Returns a collection of external users with sort property name.
+    /// </summary>
+    /// <param name="position">Zero-based index of the position in the sorted collection of the first result to be returned.</param>
+    /// <param name="pageSize">The maximum number of ExternalUsers to be returned in the collection.  Must be less than or equal to 500.</param>
+    /// <param name="filter">Limits the results to only those ExternalUers whose display name or AcceptedAs email address
+    /// begins with the text in the string, using a case-insensitive comparison.</param>
+    /// <param name="sortPropertyName">Name of the property to sort by. Support ExternalUser.acceptedAs and ExternalUser.whenCreated property.</param>
+    /// <param name="sortOrder">Specifies whether a call to GetExternalUsers should sort results in Ascending or Descending order.</param>
+    /// <returns>Return a collection of ExternalUsers.</returns>
+
+    public GetExternalUsersResults GetExternalUsersWithSortBy(int position, int pageSize, string filter = null, string sortPropertyName = MsoAdAttributeNames.OtherMail, SortOrder sortOrder = SortOrder.Ascending) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
+        return GetExternalUsersInternal(null /*no site url*/, position, pageSize, filter, sortOrder, sortPropertyName);
+    }
+
+    /// <summary>
+    /// Returns a collection of User objects corresponding to external users who have accessed this site collection.
+    /// </summary>
+    /// <param name="siteUrl">The site url whose external users are required.</param>
+    /// <param name="position">Zero-based index of the position in the sorted collection of the first result to be returned.</param>
+    /// <param name="pageSize">The maximum number of ExternalUsers to be returned in the collection.  Must be less than or equal to 50.</param>
+    /// <param name="filter">Limits the results to only those ExternalUers whose display name or invitedAs email address
+    /// begins with the text in the string, using a case-insensitive comparison.</param>
+    /// <param name="sortOrder">Specifies whether a call to GetExternalUsers should sort results in Ascending or
+    /// Descending order on the ExternalUser.invitedAs property</param>
+    /// <returns>
+    /// A GetExternalUsersResults object containing up to pageSize users that match the filter criteria, in the order
+    /// specified, starting from the specified position.  Further pages can be fetched by calling again with
+    /// the same filter and sortOrder parameters but specifying for position the
+    /// GetExternalUsersResults.UserCollectionPosition value returned from the previous call.  If
+    /// GetExternalUsersResults.ExternalUserCollection.Count is less than pageSize, all available users have been returned
+    /// (it is the last page of results.)
+    /// </returns>
+    /// <remarks>This method is unaffected by the value of the SharingCapability property.</remarks>
+    /// <id guid="("F0FD624B-BF88-4BA5-A636-19F573112327")" />
+    [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+
+    public GetExternalUsersResults GetExternalUsersForSite(string siteUrl, int position, int pageSize, string filter = null, SortOrder sortOrder = SortOrder.Ascending) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
+        if (string.IsNullOrEmpty(siteUrl)) {
+            throw new ArgumentException("siteUrl");
+        }
+        return GetExternalUsersInternal(siteUrl, position, pageSize, filter, sortOrder);
+    }
+
+
+    /// <summary>
+    /// Removes from the directory external users whose full ExternalUser.UniqueId property belongs in (case insensitive) the
+    /// array of strings.  This method is unaffected by the value of the SharingCapability property.
+    /// </summary>
+    /// <param name="emailNames">An array of strings, where each string is the UniqueId of an external user to delete</param>
+    /// <returns>A RemoveExternalUsersResults object with the RemoveSucceeded and RemoveFailed arrays populated
+    /// based on the results of attempting to remove the specified users.</returns>
+    /// <id guid="0E26ABE4-F8AF-4314-A6DB-24A009575BB6" />
+
+    public RemoveExternalUsersResults RemoveExternalUsers(string[] uniqueIds) {
+        this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Delete);
+        SpoCommonHelper.ValidateNotNull(Office365Tenant.UniqueIdsParameterName, uniqueIds);
+        return this.DataAccess.RemoveExternalUsers(uniqueIds);
+    }
+
+    /// <summary>
+    /// Queues an import of custom properties into user profiles from an external data source. This is a mostly asynchronous call in that it doesn't download the source data or do the import, it simply
+    /// adds it to a queue to do later.
+    ///
+    /// The overall process for this import is as follows:
+    /// 1) Create users in the User Profile Service. The custom property import process does not import users, only properties.
+    /// 2) Create the custom properties in the User Profile Service. The custom property import process does not create the properties, just imports the values.
+    /// 3) Create an external data source, the uri of which is passed to this method as the sourceUri parameter. The Uri must point to a resource that is accessible from within the SharePoint Online data center. It must have a record for each user with properties to import. Users are identified in the source data using the property passed to sourceDataIdProperty.
+    /// 4) Call this method. This mehod queues the import. The data pointed to by sourceUri will be downloaded to the server and later imported into the User Profile Service. Data will be downloaded roughly once an hour and then queued for actual import.
+    ///
+    /// </summary>
+    /// <param name="idType">The type of id to use when looking up the user profile. See docs for ImportProfilePropertiesUserIdType for details. Note that regardless of the type the user must already exist in the User Profile Service for import to work.</param>
+    /// <param name="sourceDataIdProperty">The name of the id property in the source data. The value of the property from the source data will be used to look up the user. The User Profile Service property used for the lookup depends on the value of idType.</param>
+    /// <param name="propertyMap">A map from source property name to User Profile Service property name. Note that the User Profile Service properties must already exist.</param>
+    /// <param name="sourceUri">The URI of the source data to import. This must not be transient as it may not be downloaded for some time.</param>
+    /// <returns>Guid identifying the import job that has been queued.</returns>
+    [ClientCallable]
+    public Guid QueueImportProfileProperties(ImportProfilePropertiesUserIdType idType, string sourceDataIdProperty, IDictionary<string, string> propertyMap, Uri sourceUri)
+{
+    this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Update);
+    return UPImport.ImportProfilePropertiesImpl.QueueImportProfileProperties(SPContext.Current, idType.ToDirectoryObjectIdentityAttributeTemp(), sourceDataIdProperty, propertyMap, sourceUri);
+}
+
+/// <summary>
+/// Deletes a previously queued job to import of custom properties into user profiles. Only certain jobs can be deleted:
+///  -Only jobs that haven't been started yet (have been queued but not imported) can be deleted.
+///  -Only top-level jobs can be cancelled. The job id returned by QueueImportProfileProperties will be a top-level job.
+/// </summary>
+/// <param name="jobId">The job id returned by QueueImportProfileProperties to delete.</param>
+/// <returns>True if the job is deleted, false otherwise.</returns>
+/// <exception cref="System.ArgumentException">Thrown when a job is not found or is invalid in some other way.</exception>
+[ClientCallable]
+        public bool DeleteImportProfilePropertiesJob(Guid jobId)
+{
+    this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Delete);
+    return UPImport.ImportProfilePropertiesImpl.DeleteImportProfilePropertiesJob(SPContext.Current, jobId);
+}
+
+/// <summary>
+/// Gets high-level status for all the import profile properties jobs for the current tenant.
+/// </summary>
+/// <returns>A collection of ImportProfilePropertiesJobStatus objects with high-level status information for the jobs.</returns>
+[ClientCallable]
+        public ImportProfilePropertiesJobStatusCollection GetImportProfilePropertyJobs()
+{
+    this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
+    return new ImportProfilePropertiesJobStatusCollection(UPImport.ImportProfilePropertiesImpl.GetWorkItems(SPContext.Current, wi => new ImportProfilePropertiesJobInfo(wi)));
+}
+
+/// <summary>
+/// Gets high-level status for the import profile properties job specified by jobId. This jobId would have been returned by the original call to QueueImportProfileProperties.
+/// </summary>
+/// <param name="jobId">The id of the job for which to get high-level status.</param>
+/// <returns>An ImportProfilePropertiesJobStatus obect with high level status information about the specified job.</returns>
+[ClientCallable]
+        public ImportProfilePropertiesJobInfo GetImportProfilePropertyJob(Guid jobId)
+{
+    this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
+    return new ImportProfilePropertiesJobInfo(UPImport.ImportProfilePropertiesImpl.GetWorkItem(SPContext.Current, jobId));
+}
+
+/// <summary>
+/// Disables non-owners of a site to share content to users that are not members of the site collection.
+/// </summary>
+/// <param name="siteUrl">The siteUrl of the site collection.</param>
+[ClientCallable]
+        public void DisableSharingForNonOwnersOfSite(string siteUrl)
+{
+    this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
+    this.DataAccess.DisableSharingForNonOwnersOfSite(siteUrl);
+}
+
+/// <summary>
+/// Gets whether non-owners of a site can share content to users that are not members of the site collection.
+/// </summary>
+/// <param name="siteUrl">The siteUrl of the site collection to check if restrict sharing is enabled.</param>
+/// <returns>A Boolean indicating if sharing is disabled for site members in the site collection.</returns>
+[ClientCallable]
+        public bool IsSharingDisabledForNonOwnersOfSite(string siteUrl)
+{
+    this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
+    return this.DataAccess.IsSharingDisabledForNonOwnersOfSite(siteUrl);
+}
+
+/// <summary>
+/// Revokes all user sessions for a given username.
+/// </summary>
+/// <param name="userName">
+/// The home tenant user name, which is being used at authentication time.
+/// <example>user@contoso.com</example>
+/// </param>
+/// <returns>An SPOUserSessionRevocationResult enum value which represents the state of the operation.</returns>
+[ClientCallable]
+        public SPOUserSessionRevocationResult RevokeAllUserSessions(string userName)
+{
+    this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
+    SpoCommonHelper.ValidateString("userName", userName);
+    return this.DataAccess.RevokeAllUserSessions(userName);
+}
+
+/// <summary>
+/// Revokes all user sessions for a given user's puid.
+/// </summary>
+/// <param name="puidList">
+/// A list of puids to be revoked.
+/// Each value should look like this:
+/// <example>10037ffe8000008d</example>
+/// </param>
+/// <returns>An SPOUserSessionRevocationResult enum value which represents the state of the operation.</returns>
+[ClientCallable]
+        public IList < SPOUserSessionRevocationResult > RevokeAllUserSessionsByPuid(IList < string > puidList)
+{
+    this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
+    return this.DataAccess.RevokeAllUserSessionsByPuid(puidList);
+}
+
+        /// <summary>
+        /// Create a new Office 365 Group and connect it to an existing site.  After this succeeds for a given site, calling it again with the same site will throw an Exception.
+        /// </summary>
+        /// <param name="siteUrl">The full URL of the site to connect to.</param>
+        /// <param name="displayName">The desired display name of the new group</param>
+        /// <param name="alias">The desired email alias for the new group</param>
+        /// <param name="isPublic">Whether the new group should be public or private</param>
+        /// <param name="optionalParams">An optional set of creation parameters for the group</param>
+        
+        public void CreateGroupForSite(string siteUrl, string displayName, string alias, bool isPublic, GroupCreationParams optionalParams)
+{
+    this.rbacManager.AssertAccess(TenantAdminResources.UnifiedGroups, Permissions.Create);
+    this.DataAccess.CreateGroupForSite(siteUrl, displayName, alias, isPublic, optionalParams);
+}
+}
+export interface IOffice365Tenant extends _Office365Tenant { }
+export const Office365Tenant = spInvokableFactory<IOffice365Tenant>(_Office365Tenant);
+
+
+
+
+

--- a/packages/sp-admin/Office365Tenant.ts
+++ b/packages/sp-admin/Office365Tenant.ts
@@ -1,19 +1,42 @@
 import { body } from "@pnp/queryable";
-import { _SPInstance, defaultPath, spPost, IResourcePath } from "@pnp/sp";
-import { boolean } from "yargs";
-import { IOffice365TenantInfo, SPOrgAssetType, SPOTenantCdnType } from "./types.js";
+import { _SPInstance, defaultPath, spPost, IResourcePath, spInvokableFactory } from "@pnp/sp";
+import {
+    IGetExternalUsersResults,
+    IGroupCreationParams,
+    IImportProfilePropertiesJobInfo,
+    ImportProfilePropertiesUserIdTypes,
+    IOffice365TenantInfo,
+    IRemoveExternalUsersResults,
+    ISPOUserSessionRevocationResult,
+    IThemeProperties,
+    SortOrder,
+    SPOrgAssetType,
+    SPOTenantCdnPolicyType,
+    SPOTenantCdnType,
+} from "./types.js";
 
 @defaultPath("_api/Microsoft.Online.SharePoint.TenantManagement.Office365Tenant")
 export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
+    /**
+    * Choose which fields to return
+    *
+    * @param selects One or more fields to return
+    * @description we limit the selects here because there are so many values possible and it improves discoverability.
+    * Unfortunately this doesn't work as a general solution due to expands
+    */
+    public select(...selects: (keyof IOffice365TenantInfo)[]): this {
+        return super.select(...selects);
+    }
+
     // TODO::test
     /**
-     * Sets the configuration values for Idle session sign out for unmanaged devices
-     * 
-     * @param enabled Boolean indicating if the policy should be enabled
-     * @param warnAfter TimeSpan containing the time before warning the user
-     * @param signOutAfter TimeSpan containing the time before signing out the user
-     * @returns True if the operation succeeds, false otherwise
+     *Sets the configuration values for Idle session sign out for unmanaged devices
+     *
+     *@param enabled Boolean indicating if the policy should be enabled
+     *@param warnAfter TimeSpan containing the time before warning the user
+     *@param signOutAfter TimeSpan containing the time before signing out the user
+     *@returns True if the operation succeeds, false otherwise
      */
     public setIdleSessionSignOutForUnmanagedDevices(enabled: boolean, warnAfter: any, signOutAfter: any): Promise<boolean> {
         return spPost(Office365Tenant(this, "SetIdleSessionSignOutForUnmanagedDevices"), body({
@@ -25,13 +48,13 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
     // TODO::test
     /**
-     * Gets the configuration values, as a string, for Idle session sign out for unmanaged devices
-     * The return string is a comma delineated list of the three policy settings.  The policy settings consist of
-     * 1. Enabled: true or false
-     * 2. Warn after: Time until user should be warned in seconds.
-     * 3. Sign out after: Time until user should be signed out in seconds.
-     * 
-     * @returns A string indicating the current policy settings
+     *Gets the configuration values, as a string, for Idle session sign out for unmanaged devices
+     *The return string is a comma delineated list of the three policy settings.  The policy settings consist of
+     *1. Enabled: true or false
+     *2. Warn after: Time until user should be warned in seconds.
+     *3. Sign out after: Time until user should be signed out in seconds.
+     *
+     *@returns A string indicating the current policy settings
      */
     public getIdleSessionSignOutForUnmanagedDevices(): Promise<string> {
         return spPost(Office365Tenant(this, "GetIdleSessionSignOutForUnmanagedDevices"));
@@ -39,14 +62,15 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
     // TODO::test
     /**
-     * Adds a SharePoint document library to the list of Organization Assets libraries
-     * 
-     * @param cdnType 
-     * @param libUrl Url of a SharePoint document library to be added to the list of Organization Assets libraries
-     * @param thumbnailUrl 
-     * @param orgAssetType 
-     * @param defaultOriginAdded 
+     *Adds a SharePoint document library to the list of Organization Assets libraries
+     *
+     *@param cdnType
+     *@param libUrl Url of a SharePoint document library to be added to the list of Organization Assets libraries
+     *@param thumbnailUrl
+     *@param orgAssetType
+     *@param defaultOriginAdded
      */
+    // eslint-disable-next-line max-len
     public addToOrgAssetsLibAndCdn(cdnType: SPOTenantCdnType, libUrl: IResourcePath, thumbnailUrl: IResourcePath, orgAssetType: SPOrgAssetType, defaultOriginAdded: boolean): Promise<void> {
         return spPost(Office365Tenant(this, "AddToOrgAssetsLibAndCdn"), body({
             cdnType,
@@ -68,7 +92,7 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
     // TODO::test
     /**
-     * Removes an entry from the list of Organization Assets libraries
+     *Removes an entry from the list of Organization Assets libraries
      */
     public removeFromOrgAssets(libUrl: IResourcePath, listId: string): Promise<void> {
         return spPost(Office365Tenant(this, "RemoveFromOrgAssets"), body({
@@ -79,12 +103,11 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
     // TODO::test
     /**
-     * Sets a SharePoint library thumbnail in Organization Assets libraries
-     * 
-     * @param libUrl Url of a SharePoint library to be set in Organization Assets
-     * @param thumbnailUrl Url to an image used as the thumbnail for this library in the FilePicker
-     * @param orgAssetType Type of Organization Assets Document Library
-     * @returns 
+     *Sets a SharePoint library thumbnail in Organization Assets libraries
+     *
+     *@param libUrl Url of a SharePoint library to be set in Organization Assets
+     *@param thumbnailUrl Url to an image used as the thumbnail for this library in the FilePicker
+     *@param orgAssetType Type of Organization Assets Document Library
      */
     public setOrgAssetsLib(libUrl: IResourcePath, thumbnailUrl: IResourcePath, orgAssetType: SPOrgAssetType): Promise<void> {
         return spPost(Office365Tenant(this, "SetOrgAssetsLib"), body({
@@ -98,9 +121,6 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
     /**
      * Gets the minor version that should be used to generate the next iteration of the custom font catalog for the
      * font org asset library specified by libUrl
-     * 
-     * @param libUrl 
-     * @returns 
      */
     public getCustomFontsMinorVersion(libUrl: IResourcePath): Promise<number> {
         return spPost(Office365Tenant(this, "GetCustomFontsMinorVersion"), body({
@@ -110,7 +130,7 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
     // TODO::test
     /**
-     * Uploads fonts and font catalogs to a font asset library
+     *Uploads fonts and font catalogs to a font asset library
      */
     public uploadCustomFontsAndCatalogLib(customFontFiles: any, libUrl: IResourcePath): Promise<boolean> {
         return spPost(Office365Tenant(this, "UploadCustomFontsAndCatalogLib"), body({
@@ -121,7 +141,7 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
     // TODO::test
     /**
-     * Removes old Custom Fonts files
+     *Removes old Custom Fonts files
      */
     public removePreviousCustomFontUpload(majVersions: string[], libUrl: IResourcePath): Promise<void> {
         return spPost(Office365Tenant(this, "RemovePreviousCustomFontUpload"), body({
@@ -132,7 +152,7 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
     // TODO::test
     /**
-     * Increments the minor version for libUrl
+     *Increments the minor version for libUrl
      */
     public incrementCustomFontsMinorVersion(libUrl: IResourcePath): Promise<void> {
         return spPost(Office365Tenant(this, "IncrementCustomFontsMinorVersion"), body({
@@ -142,9 +162,9 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
 
     // TODO::test
     /**
-     * Gets a list of tenant CDN origins
-     * 
-     * @param cdnType Type of CDN: private or public
+     *Gets a list of tenant CDN origins
+     *
+     *@param cdnType Type of CDN: private or public
      */
     public getTenantCdnOrigins(cdnType: SPOTenantCdnType): Promise<string[]> {
         return spPost(Office365Tenant(this, "GetTenantCdnOrigins"), body({
@@ -152,399 +172,433 @@ export class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
         }));
     }
 
-    /// <summary>
-    /// Adds a tenant cdn origin.
-    /// </summary>
-    /// <param name="cdnType">Type of CDN: private or public</param>
-    /// <param name="originUrl">origin Url to add</param>
-
-    public void AddTenantCdnOrigin(SPOTenantCdnType cdnType, string originUrl) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Create);
-        this.DataAccess.AddTenantCdnOrigin(cdnType, originUrl);
+    // TODO::test
+    /**
+     *Adds a tenant cdn origin
+     *
+     *@param cdnType Type of CDN: private or public
+     *@param originUrl origin Url to add
+     */
+    public addTenantCdnOrigin(cdnType: SPOTenantCdnType, originUrl: string): Promise<void> {
+        return spPost(Office365Tenant(this, "AddTenantCdnOrigin"), body({
+            cdnType,
+            originUrl,
+        }));
     }
 
-    /// <summary>
-    /// Removes a tenant cdn origin.
-    /// </summary>
-    /// <param name="cdnType">Type of CDN: private or public</param>
-    /// <param name="originUrl">origin Url to add</param>
-
-    public void RemoveTenantCdnOrigin(SPOTenantCdnType cdnType, string originUrl) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Delete);
-        this.DataAccess.RemoveTenantCdnOrigin(cdnType, originUrl);
+    // TODO::test
+    /**
+     *Removes a tenant cdn origin
+     *
+     *@param cdnType Type of CDN: private or public
+     *@param originUrl origin Url to remove
+     */
+    public removeTenantCdnOrigin(cdnType: SPOTenantCdnType, originUrl: string): Promise<void> {
+        return spPost(Office365Tenant(this, "RemoveTenantCdnOrigin"), body({
+            cdnType,
+            originUrl,
+        }));
     }
 
-    /// <summary>
-    /// Enables or disabled tenant CDN feature.
-    /// </summary>
-    /// <param name="cdnType">Type of CDN: private or public</param>
-    /// <param name="isEnabled">value to set</param>
-
-    public void SetTenantCdnEnabled(SPOTenantCdnType cdnType, bool isEnabled) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
-        this.DataAccess.SetTenantCdnEnabled(cdnType, isEnabled);
+    // TODO::test
+    /**
+     *Enables or disabled tenant CDN feature
+     *
+     *@param cdnType Type of CDN: private or public
+     *@param isEnabled value to set
+     */
+    public SetTenantCdnEnabled(cdnType: SPOTenantCdnType, isEnabled: boolean): Promise<void> {
+        return spPost(Office365Tenant(this, "setTenantCdnEnabled"), body({
+            cdnType,
+            isEnabled,
+        }));
     }
 
-    /// <summary>
-    /// Gets whether tenant CDN feature is enabled.
-    /// </summary>
-    /// <param name="cdnType">Type of CDN: private or public</param>
-    /// <returns>True if CDN is enabled; false otherwise</returns>
-
-    public bool GetTenantCdnEnabled(SPOTenantCdnType cdnType) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
-        return this.DataAccess.GetTenantCdnEnabled(cdnType);
+    // TODO::test
+    /**
+     *Gets whether tenant CDN feature is enabled
+     *
+     *@param cdnType Type of CDN: private or public
+     *@returns True if CDN is enabled; false otherwise
+     */
+    public getTenantCdnEnabled(cdnType: SPOTenantCdnType): Promise<boolean> {
+        return spPost(Office365Tenant(this, "GetTenantCdnEnabled"), body({
+            cdnType,
+        }));
     }
 
-    /// <summary>
-    /// Sets policy for the tenant CDN.
-    /// </summary>
-    /// <param name="cdnType">CDN type</param>
-    /// <param name="policy">Policy type</param>
-    /// <param name="policyValue">Policy value</param>
-
-    public void SetTenantCdnPolicy(SPOTenantCdnType cdnType, SPOTenantCdnPolicyType policy, string policyValue) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
-        this.DataAccess.SetTenantCdnPolicy(cdnType, policy, policyValue);
+    // TODO::test
+    /**
+     *Sets policy for the tenant CDN
+     *
+     *@param cdnType CDN type
+     *@param policy Policy type
+     *@param policyValue Policy value
+     */
+    public setTenantCdnPolicy(cdnType: SPOTenantCdnType, policy: SPOTenantCdnPolicyType, policyValue: string): Promise<void> {
+        return spPost(Office365Tenant(this, "SetTenantCdnPolicy"), body({
+            cdnType,
+            policy,
+            policyValue,
+        }));
     }
 
-    /// <summary>
-    /// Gets list of policies for the tenant CDN.
-    /// </summary>
-    /// <param name="cdnType">CDN type</param>
-    /// <returns>List of policies</returns>
-
-    public IList<string> GetTenantCdnPolicies(SPOTenantCdnType cdnType) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
-        return this.DataAccess.GetTenantCdnPolicies(cdnType);
+    // TODO::test
+    /**
+     *Gets list of policies for the tenant CDN
+     *
+     *@param cdnType CDN type
+     *@returns List of policies
+     */
+    public getTenantCdnPolicies(cdnType: SPOTenantCdnType): Promise<string[]> {
+        return spPost(Office365Tenant(this, "GetTenantCdnPolicies"), body({
+            cdnType,
+        }));
     }
 
-    /// <summary>
-    /// Creates default origins for requested CDN type.
-    /// </summary>
-    /// <returns></returns>
-
-    public void CreateTenantCdnDefaultOrigins(SPOTenantCdnType cdnType) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Create);
-        this.DataAccess.CreateTenantCdnDefaultOrigins(cdnType);
+    // TODO::test
+    /**
+     *Creates default origins for requested CDN type
+     */
+    public createTenantCdnDefaultOrigins(cdnType: SPOTenantCdnType): Promise<void> {
+        return spPost(Office365Tenant(this, "CreateTenantCdnDefaultOrigins"), body({
+            cdnType,
+        }));
     }
 
-    #endregion
-
-    #region Theming
-
-    /// <summary>
-    /// Add a custom theme to the tenant so that it will be available when selecting a site theme.
-    /// </summary>
-    /// <param name="name">The name of the theme.</param>
-    /// <param name="themeJson">A JSON representation of the theme information.</param>
-    /// <returns>True, if the theme is added successfully.</returns>
-
-    public bool AddTenantTheme(string name, string themeJson) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Create);
-        return this.DataAccess.AddTenantTheme(name, themeJson);
+    // TODO::test
+    /**
+     *Add a custom theme to the tenant so that it will be available when selecting a site theme
+     *
+     *@param name The name of the theme
+     *@param themeJson A JSON representation of the theme information
+     *@returns True, if the theme is added successfully
+     */
+    public addTenantTheme(name: string, themeJson: string): Promise<boolean> {
+        return spPost(Office365Tenant(this, "AddTenantTheme"), body({
+            name,
+            themeJson,
+        }));
     }
 
-    /// <summary>
-    /// Update the properties of a custom theme.
-    /// </summary>
-    /// <param name="name">The name of the theme to update.</param>
-    /// <param name="themeJson">A JSON representation of the new theme information.</param>
-    /// <returns>True, if the theme is updated successfully.</returns>
-
-    public bool UpdateTenantTheme(string name, string themeJson) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
-        return this.DataAccess.UpdateTenantTheme(name, themeJson);
+    // TODO::test
+    /**
+     *Update the properties of a custom theme
+     *
+     *@param name The name of the theme to update
+     *@param themeJson A JSON representation of the new theme information
+     *@returns True, if the theme is updated successfully
+     */
+    public updateTenantTheme(name: string, themeJson: string): Promise<boolean> {
+        return spPost(Office365Tenant(this, "UpdateTenantTheme"), body({
+            name,
+            themeJson,
+        }));
     }
 
-    /// <summary>
-    /// Remove a custom theme from the tenant.
-    /// </summary>
-    /// <param name="name">The name of the theme to delete.</param>
-
-    public void DeleteTenantTheme(string name) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Delete);
-        this.DataAccess.DeleteTenantTheme(name);
+    // TODO::test
+    /**
+     *Remove a custom theme from the tenant
+     *
+     *@param name The name of the theme to delete
+     */
+    public deleteTenantTheme(name: string): Promise<void> {
+        return spPost(Office365Tenant(this, "DeleteTenantTheme"), body({
+            name,
+        }));
     }
 
-    /// <summary>
-    /// Retrieves a custom theme previously added to the tenant.
-    /// </summary>
-    /// <param name="name">The name of the theme to retrieve.</param>
-    /// <returns>A ThemeProperties object representing the theme.</returns>
-
-    public ThemeProperties GetTenantTheme(string name) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
-        return this.DataAccess.GetTenantTheme(name);
+    // TODO::test
+    /**
+     *Retrieves a custom theme previously added to the tenant
+     *
+     *@param name The name of the theme to retrieve
+     *@returns A ThemeProperties object representing the theme
+     */
+    public getTenantTheme(name: string): Promise<IThemeProperties> {
+        return spPost(Office365Tenant(this, "GetTenantTheme"), body({
+            name,
+        }));
     }
 
-    /// <summary>
-    /// Retrieves all custom themes added to the tenant.
-    /// </summary>
-    /// <returns>ThemeProperties objects representing all of the custom themes added to the tenant.</returns>
-
-    public IList<ThemeProperties> GetAllTenantThemes() {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
-        return this.DataAccess.GetAllTenantThemes();
+    // TODO::test
+    /**
+     *Retrieves all custom themes added to the tenant
+     *
+     *@returns ThemeProperties objects representing all of the custom themes added to the tenant
+     */
+    public getAllTenantThemes(): Promise<IThemeProperties[]> {
+        return spPost(Office365Tenant(this, "GetAllTenantThemes"));
     }
 
-    /// <summary>
-    /// Retrieves a setting specifying whether default SharePoint themes should be hidden from the web UI.
-    /// </summary>
-    /// <returns>True, if default SharePoint themes should be hidden from the web UI</returns>
-
-    public bool GetHideDefaultThemes() {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
-        return this.DataAccess.GetHideDefaultThemes();
+    // TODO::test
+    /**
+     *Retrieves a setting specifying whether default SharePoint themes should be hidden from the web UI
+     *
+     *@return True, if default SharePoint themes should be hidden from the web UI
+     */
+    public getHideDefaultThemes(): Promise<boolean> {
+        return spPost(Office365Tenant(this, "GetHideDefaultThemes"));
     }
 
-    /// <summary>
-    /// Updates a setting specifying whether default SharePoint themes should be hidden from the web UI.
-    /// </summary>
-    /// <returns>True, if the setting is updated successfully.</returns>
-
-    public bool SetHideDefaultThemes(bool hideDefaultThemes) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
-        return this.DataAccess.SetHideDefaultThemes(hideDefaultThemes);
+    // TODO::test
+    /**
+     *Updates a setting specifying whether default SharePoint themes should be hidden from the web UI
+     *
+     *@param hideDefaultThemes
+     *@returns True, if the setting is updated successfully
+     */
+    public setHideDefaultThemes(hideDefaultThemes: boolean): Promise<boolean> {
+        return spPost(Office365Tenant(this, "SetHideDefaultThemes"), body({
+            hideDefaultThemes,
+        }));
     }
 
-    /// <summary>
-    /// Adds an SDN provider to the tenant.
-    /// </summary>
-    /// <param name="identifier">id of an SDN provider to be added</param>
-    /// <param name="license">license number provided by SDN provider</param>
-
-    public void AddSdnProvider(string identifier, string license) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Create);
-        this.DataAccess.AddSdnProvider(identifier, license);
+    // TODO::test
+    /**
+     *Adds an SDN provider to the tenant
+     *
+     *@param identifier id of an SDN provider to be added
+     *@param license license number provided by SDN provider
+     */
+    public addSdnProvider(identifier: string, license: string): Promise<void> {
+        return spPost(Office365Tenant(this, "AddSdnProvider"), body({
+            identifier,
+            license,
+        }));
     }
 
-    /// <summary>
-    /// Removes an entry from the list of supported SDN providers.
-    /// </summary>
-
-    public void RemoveSdnProvider() {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Delete);
-        this.DataAccess.RemoveSdnProvider();
-    }
-    #endregion
-    /// <summary>
-    /// Returns a collection of User objects corresponding to external users in the tenancy.
-    /// </summary>
-    /// <param name="position">Zero-based index of the position in the sorted collection of the first result to be returned.</param>
-    /// <param name="pageSize">The maximum number of ExternalUsers to be returned in the collection.  Must be less than or equal to 50.</param>
-    /// <param name="filter">Limits the results to only those ExternalUers whose display name or invitedAs email address
-    /// begins with the text in the string, using a case-insensitive comparison.</param>
-    /// <param name="sortOrder">Specifies whether a call to GetExternalUsers should sort results in Ascending or
-    /// Descending order on the ExternalUser.invitedAs property</param>
-    /// <returns>
-    /// A GetExternalUsersResults object containing up to pageSize users that match the filter criteria, in the order
-    /// specified, starting from the specified position.  Further pages can be fetched by calling again with
-    /// the same filter and sortOrder parameters but specifying for position the
-    /// GetExternalUsersResults.UserCollectionPosition value returned from the previous call.  If
-    /// GetExternalUsersResults.ExternalUserCollection.Count is less than pageSize, all available users have been returned
-    /// (it is the last page of results.)
-    /// </returns>
-    /// <remarks>This method is unaffected by the value of the SharingCapability property.</remarks>
-    /// <id guid="EC4771AB-489F-4164-89A7-52E9DBA3DF0B" />
-
-    public GetExternalUsersResults GetExternalUsers(int position, int pageSize, string filter = null, SortOrder sortOrder = SortOrder.Ascending) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
-        return GetExternalUsersInternal(null /*no site url*/, position, pageSize, filter, sortOrder, null /*no sort by*/);
+    // TODO::test
+    /**
+     *Removes an entry from the list of supported SDN providers
+     */
+    public removeSdnProvider(): Promise<void> {
+        return spPost(Office365Tenant(this, "RemoveSdnProvider"));
     }
 
-    /// <summary>
-    /// Returns a collection of external users with sort property name.
-    /// </summary>
-    /// <param name="position">Zero-based index of the position in the sorted collection of the first result to be returned.</param>
-    /// <param name="pageSize">The maximum number of ExternalUsers to be returned in the collection.  Must be less than or equal to 500.</param>
-    /// <param name="filter">Limits the results to only those ExternalUers whose display name or AcceptedAs email address
-    /// begins with the text in the string, using a case-insensitive comparison.</param>
-    /// <param name="sortPropertyName">Name of the property to sort by. Support ExternalUser.acceptedAs and ExternalUser.whenCreated property.</param>
-    /// <param name="sortOrder">Specifies whether a call to GetExternalUsers should sort results in Ascending or Descending order.</param>
-    /// <returns>Return a collection of ExternalUsers.</returns>
-
-    public GetExternalUsersResults GetExternalUsersWithSortBy(int position, int pageSize, string filter = null, string sortPropertyName = MsoAdAttributeNames.OtherMail, SortOrder sortOrder = SortOrder.Ascending) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
-        return GetExternalUsersInternal(null /*no site url*/, position, pageSize, filter, sortOrder, sortPropertyName);
+    // TODO::test
+    /**
+     *Returns a collection of User objects corresponding to external users in the tenancy
+     *
+     *@param position Zero-based index of the position in the sorted collection of the first result to be returned
+     *@param pageSize The maximum number of ExternalUsers to be returned in the collection.  Must be less than or equal to 50
+     *@param filter Limits the results to only those ExternalUers whose display name or invitedAs email address begins with the text in the string, using case-insensitive
+     *@param sortOrder Specifies whether a call to GetExternalUsers should sort results in Ascending or Descending order on the ExternalUser.invitedAs property
+     *@returns A GetExternalUsersResults object containing up to pageSize users that match the filter criteria, in the order specified, starting from the specified position.
+     *Further pages can be fetched by calling again with the same filter and sortOrder parameters but specifying for position the
+     *GetExternalUsersResults.UserCollectionPosition value returned from the previous call.  If GetExternalUsersResults.ExternalUserCollection.Count is less than pageSize,
+     *all available users have been returned (it is the last page of results.)
+     */
+    public getExternalUsers(position: number, pageSize: number, filter: string = null, sortOrder = SortOrder.Ascending): Promise<IGetExternalUsersResults> {
+        return spPost(Office365Tenant(this, "GetExternalUsers"), body({
+            position,
+            pageSize,
+            filter,
+            sortOrder,
+        }));
     }
 
-    /// <summary>
-    /// Returns a collection of User objects corresponding to external users who have accessed this site collection.
-    /// </summary>
-    /// <param name="siteUrl">The site url whose external users are required.</param>
-    /// <param name="position">Zero-based index of the position in the sorted collection of the first result to be returned.</param>
-    /// <param name="pageSize">The maximum number of ExternalUsers to be returned in the collection.  Must be less than or equal to 50.</param>
-    /// <param name="filter">Limits the results to only those ExternalUers whose display name or invitedAs email address
-    /// begins with the text in the string, using a case-insensitive comparison.</param>
-    /// <param name="sortOrder">Specifies whether a call to GetExternalUsers should sort results in Ascending or
-    /// Descending order on the ExternalUser.invitedAs property</param>
-    /// <returns>
-    /// A GetExternalUsersResults object containing up to pageSize users that match the filter criteria, in the order
-    /// specified, starting from the specified position.  Further pages can be fetched by calling again with
-    /// the same filter and sortOrder parameters but specifying for position the
-    /// GetExternalUsersResults.UserCollectionPosition value returned from the previous call.  If
-    /// GetExternalUsersResults.ExternalUserCollection.Count is less than pageSize, all available users have been returned
-    /// (it is the last page of results.)
-    /// </returns>
-    /// <remarks>This method is unaffected by the value of the SharingCapability property.</remarks>
-    /// <id guid="("F0FD624B-BF88-4BA5-A636-19F573112327")" />
-    [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
-
-    public GetExternalUsersResults GetExternalUsersForSite(string siteUrl, int position, int pageSize, string filter = null, SortOrder sortOrder = SortOrder.Ascending) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
-        if (string.IsNullOrEmpty(siteUrl)) {
-            throw new ArgumentException("siteUrl");
-        }
-        return GetExternalUsersInternal(siteUrl, position, pageSize, filter, sortOrder);
+    // TODO::test
+    /**
+     *Returns a collection of User objects corresponding to external users in the tenancy
+     *
+     *@param position Zero-based index of the position in the sorted collection of the first result to be returned
+     *@param pageSize The maximum number of ExternalUsers to be returned in the collection.  Must be less than or equal to 50
+     *@param filter Limits the results to only those ExternalUers whose display name or invitedAs email address begins with the text in the string, case-insensitive
+     *@param sortPropertyName Name of the property to sort by. Support ExternalUser.acceptedAs and ExternalUser.whenCreated property
+     *@param sortOrder Specifies whether a call to GetExternalUsers should sort results in Ascending or Descending order on the ExternalUser.invitedAs property
+     *@returns A GetExternalUsersResults object containing up to pageSize users that match the filter criteria, in the order specified, starting from the specified position.
+     *Further pages can be fetched by calling again with the same filter and sortOrder parameters but specifying for position the
+     *GetExternalUsersResults.UserCollectionPosition value returned from the previous call.  If GetExternalUsersResults.ExternalUserCollection.Count is less than pageSize,
+     *all available users have been returned (it is the last page of results.)
+     */
+    // eslint-disable-next-line max-len
+    public getExternalUsersWithSortBy(position: number, pageSize: number, filter: string = null, sortPropertyName = "OtherMail", sortOrder = SortOrder.Ascending): Promise<IGetExternalUsersResults> {
+        return spPost(Office365Tenant(this, "GetExternalUsersWithSortBy"), body({
+            position,
+            pageSize,
+            filter,
+            sortPropertyName,
+            sortOrder,
+        }));
     }
 
-
-    /// <summary>
-    /// Removes from the directory external users whose full ExternalUser.UniqueId property belongs in (case insensitive) the
-    /// array of strings.  This method is unaffected by the value of the SharingCapability property.
-    /// </summary>
-    /// <param name="emailNames">An array of strings, where each string is the UniqueId of an external user to delete</param>
-    /// <returns>A RemoveExternalUsersResults object with the RemoveSucceeded and RemoveFailed arrays populated
-    /// based on the results of attempting to remove the specified users.</returns>
-    /// <id guid="0E26ABE4-F8AF-4314-A6DB-24A009575BB6" />
-
-    public RemoveExternalUsersResults RemoveExternalUsers(string[] uniqueIds) {
-        this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Delete);
-        SpoCommonHelper.ValidateNotNull(Office365Tenant.UniqueIdsParameterName, uniqueIds);
-        return this.DataAccess.RemoveExternalUsers(uniqueIds);
+    // TODO::test
+    /**
+     *Returns a collection of User objects corresponding to external users who have accessed this site collection
+     *
+     *@param siteUrl The site url whose external users are required
+     *@param position Zero-based index of the position in the sorted collection of the first result to be returned
+     *@param pageSize The maximum number of ExternalUsers to be returned in the collection.  Must be less than or equal to 50
+     *@param filter Limits the results to only those ExternalUers whose display name or invitedAs email address begins with the text in the string, case-insensitive
+     *@param sortOrder Specifies whether a call to GetExternalUsers should sort results in Ascending or Descending order on the ExternalUser.invitedAs property
+     *@returns A GetExternalUsersResults object containing up to pageSize users that match the filter criteria, in the order specified, starting from the specified position.
+     * Further pages can be fetched by calling again with the same filter and sortOrder parameters but specifying for position the GetExternalUsersResults.UserCollectionPosition
+     * value returned from the previous call.  If GetExternalUsersResults.ExternalUserCollection.Count is less than pageSize,
+     * all available users have been returned (it is the last page of results.)
+     */
+    public getExternalUsersForSite(siteUrl: string, position: number, pageSize: number, filter: string = null, sortOrder = SortOrder.Ascending): Promise<IGetExternalUsersResults> {
+        return spPost(Office365Tenant(this, "GetExternalUsersForSite"), body({
+            siteUrl,
+            position,
+            pageSize,
+            filter,
+            sortOrder,
+        }));
     }
 
-    /// <summary>
-    /// Queues an import of custom properties into user profiles from an external data source. This is a mostly asynchronous call in that it doesn't download the source data or do the import, it simply
-    /// adds it to a queue to do later.
-    ///
-    /// The overall process for this import is as follows:
-    /// 1) Create users in the User Profile Service. The custom property import process does not import users, only properties.
-    /// 2) Create the custom properties in the User Profile Service. The custom property import process does not create the properties, just imports the values.
-    /// 3) Create an external data source, the uri of which is passed to this method as the sourceUri parameter. The Uri must point to a resource that is accessible from within the SharePoint Online data center. It must have a record for each user with properties to import. Users are identified in the source data using the property passed to sourceDataIdProperty.
-    /// 4) Call this method. This mehod queues the import. The data pointed to by sourceUri will be downloaded to the server and later imported into the User Profile Service. Data will be downloaded roughly once an hour and then queued for actual import.
-    ///
-    /// </summary>
-    /// <param name="idType">The type of id to use when looking up the user profile. See docs for ImportProfilePropertiesUserIdType for details. Note that regardless of the type the user must already exist in the User Profile Service for import to work.</param>
-    /// <param name="sourceDataIdProperty">The name of the id property in the source data. The value of the property from the source data will be used to look up the user. The User Profile Service property used for the lookup depends on the value of idType.</param>
-    /// <param name="propertyMap">A map from source property name to User Profile Service property name. Note that the User Profile Service properties must already exist.</param>
-    /// <param name="sourceUri">The URI of the source data to import. This must not be transient as it may not be downloaded for some time.</param>
-    /// <returns>Guid identifying the import job that has been queued.</returns>
-    [ClientCallable]
-    public Guid QueueImportProfileProperties(ImportProfilePropertiesUserIdType idType, string sourceDataIdProperty, IDictionary<string, string> propertyMap, Uri sourceUri)
-{
-    this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Update);
-    return UPImport.ImportProfilePropertiesImpl.QueueImportProfileProperties(SPContext.Current, idType.ToDirectoryObjectIdentityAttributeTemp(), sourceDataIdProperty, propertyMap, sourceUri);
-}
+    // TODO::test
+    /**
+     *Removes from the directory external users whose full ExternalUser.UniqueId property belongs in (case insensitive) the array of strings.
+     *This method is unaffected by the value of the SharingCapability property
+     *
+     *@param uniqueIds An array of strings, where each string is the UniqueId of an external user to delete
+     *@returns A RemoveExternalUsersResults object with the RemoveSucceeded and RemoveFailed arrays populated based on the results of attempting to remove the specified users.
+     */
+    public removeExternalUsers(uniqueIds: string[]): Promise<IRemoveExternalUsersResults> {
+        return spPost(Office365Tenant(this, "RemoveExternalUsers"), body({
+            uniqueIds,
+        }));
+    }
 
-/// <summary>
-/// Deletes a previously queued job to import of custom properties into user profiles. Only certain jobs can be deleted:
-///  -Only jobs that haven't been started yet (have been queued but not imported) can be deleted.
-///  -Only top-level jobs can be cancelled. The job id returned by QueueImportProfileProperties will be a top-level job.
-/// </summary>
-/// <param name="jobId">The job id returned by QueueImportProfileProperties to delete.</param>
-/// <returns>True if the job is deleted, false otherwise.</returns>
-/// <exception cref="System.ArgumentException">Thrown when a job is not found or is invalid in some other way.</exception>
-[ClientCallable]
-        public bool DeleteImportProfilePropertiesJob(Guid jobId)
-{
-    this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Delete);
-    return UPImport.ImportProfilePropertiesImpl.DeleteImportProfilePropertiesJob(SPContext.Current, jobId);
-}
+    // TODO::test
+    /**
+     * Queues an import of custom properties into user profiles from an external data source. This is a mostly asynchronous call in that it doesn't download
+     * the source data or do the import, it simply adds it to a queue to do later
+     *
+     *@description The overall process for this import is as follows:
+     *1) Create users in the User Profile Service. The custom property import process does not import users, only properties.
+     *2) Create the custom properties in the User Profile Service. The custom property import process does not create the properties, just imports the values.
+     *3) Create an external data source, the uri of which is passed to this method as the sourceUri parameter. The Uri must point to a resource that is accessible
+     *   from within the SharePoint Online data center. It must have a record for each user with properties to import. Users are identified in the source data using
+     *   the property passed to sourceDataIdProperty.
+     *4) Call this method. This mehod queues the import. The data pointed to by sourceUri will be downloaded to the server and later imported into the User
+     *   Profile Service. Data will be downloaded roughly once an hour and then queued for actual import.
+     *
+     *@param idType The type of id to use when looking up the user profile. See docs for ImportProfilePropertiesUserIdType for details.
+     * Note that regardless of the type the user must already exist in the User Profile Service for import to work.
+     *@param sourceDataIdProperty The name of the id property in the source data. The value of the property from the source data will be used to look up the user.
+     * The User Profile Service property used for the lookup depends on the value of idType.</param>
+     *@param propertyMap A map from source property name to User Profile Service property name. Note that the User Profile Service properties must already exist.
+     *@param sourceUri The URI of the source data to import. This must not be transient as it may not be downloaded for some time.
+     *@returns Guid identifying the import job that has been queued
+     */
+    // eslint-disable-next-line max-len
+    public QueueImportProfileProperties(idType: ImportProfilePropertiesUserIdTypes, sourceDataIdProperty: string, propertyMap: Record<string, string>, sourceUri: string): Promise<string> {
+        return spPost(Office365Tenant(this, "QueueImportProfileProperties"), body({
+            idType,
+            sourceDataIdProperty,
+            propertyMap,
+            sourceUri,
+        }));
+    }
 
-/// <summary>
-/// Gets high-level status for all the import profile properties jobs for the current tenant.
-/// </summary>
-/// <returns>A collection of ImportProfilePropertiesJobStatus objects with high-level status information for the jobs.</returns>
-[ClientCallable]
-        public ImportProfilePropertiesJobStatusCollection GetImportProfilePropertyJobs()
-{
-    this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
-    return new ImportProfilePropertiesJobStatusCollection(UPImport.ImportProfilePropertiesImpl.GetWorkItems(SPContext.Current, wi => new ImportProfilePropertiesJobInfo(wi)));
-}
+    // TODO::test
+    /**
+     *Deletes a previously queued job to import of custom properties into user profiles. Only certain jobs can be deleted:
+     *- Only jobs that haven't been started yet (have been queued but not imported) can be deleted.
+     *- Only top-level jobs can be cancelled. The job id returned by QueueImportProfileProperties will be a top-l
+     *
+     *@param jobId The job id returned by QueueImportProfileProperties to delete
+     *@returns True if the job is deleted, false otherwise
+     */
+    public deleteImportProfilePropertiesJob(jobId: string): Promise<boolean> {
+        return spPost(Office365Tenant(this, "DeleteImportProfilePropertiesJob"), body({
+            jobId,
+        }));
+    }
 
-/// <summary>
-/// Gets high-level status for the import profile properties job specified by jobId. This jobId would have been returned by the original call to QueueImportProfileProperties.
-/// </summary>
-/// <param name="jobId">The id of the job for which to get high-level status.</param>
-/// <returns>An ImportProfilePropertiesJobStatus obect with high level status information about the specified job.</returns>
-[ClientCallable]
-        public ImportProfilePropertiesJobInfo GetImportProfilePropertyJob(Guid jobId)
-{
-    this.rbacManager.AssertAccess(TenantAdminResources.TenantIdentities, Permissions.Read);
-    return new ImportProfilePropertiesJobInfo(UPImport.ImportProfilePropertiesImpl.GetWorkItem(SPContext.Current, jobId));
-}
+    // TODO::test
+    /**
+     *Gets high-level status for all the import profile properties jobs for the current tenant
+     *
+     *@returns A collection of ImportProfilePropertiesJobStatus objects with high-level status information for the jobs
+     */
+    public getImportProfilePropertyJobs(): Promise<IImportProfilePropertiesJobInfo[]> {
+        return spPost(Office365Tenant(this, "GetImportProfilePropertyJobs"));
+    }
 
-/// <summary>
-/// Disables non-owners of a site to share content to users that are not members of the site collection.
-/// </summary>
-/// <param name="siteUrl">The siteUrl of the site collection.</param>
-[ClientCallable]
-        public void DisableSharingForNonOwnersOfSite(string siteUrl)
-{
-    this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
-    this.DataAccess.DisableSharingForNonOwnersOfSite(siteUrl);
-}
+    // TODO::test
+    /**
+     *Gets high-level status for the import profile properties job specified by jobId. This jobId would have been returned by the original call to QueueImportProfileProperties
+     *
+     *@param jobId The id of the job for which to get high-level status
+     *@returns An ImportProfilePropertiesJobStatus obect with high level status information about the specified job
+     */
+    public getImportProfilePropertyJob(jobId: string): Promise<IImportProfilePropertiesJobInfo> {
+        return spPost(Office365Tenant(this, "GetImportProfilePropertyJob"), body({
+            jobId,
+        }));
+    }
 
-/// <summary>
-/// Gets whether non-owners of a site can share content to users that are not members of the site collection.
-/// </summary>
-/// <param name="siteUrl">The siteUrl of the site collection to check if restrict sharing is enabled.</param>
-/// <returns>A Boolean indicating if sharing is disabled for site members in the site collection.</returns>
-[ClientCallable]
-        public bool IsSharingDisabledForNonOwnersOfSite(string siteUrl)
-{
-    this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Read);
-    return this.DataAccess.IsSharingDisabledForNonOwnersOfSite(siteUrl);
-}
+    // TODO::test
+    /**
+     *Disables non-owners of a site to share content to users that are not members of the site collection
+     *
+     *@param siteUrl The siteUrl of the site collection
+     */
+    public disableSharingForNonOwnersOfSite(siteUrl: string): Promise<void> {
+        return spPost(Office365Tenant(this, "DisableSharingForNonOwnersOfSite"), body({
+            siteUrl,
+        }));
+    }
 
-/// <summary>
-/// Revokes all user sessions for a given username.
-/// </summary>
-/// <param name="userName">
-/// The home tenant user name, which is being used at authentication time.
-/// <example>user@contoso.com</example>
-/// </param>
-/// <returns>An SPOUserSessionRevocationResult enum value which represents the state of the operation.</returns>
-[ClientCallable]
-        public SPOUserSessionRevocationResult RevokeAllUserSessions(string userName)
-{
-    this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
-    SpoCommonHelper.ValidateString("userName", userName);
-    return this.DataAccess.RevokeAllUserSessions(userName);
-}
+    // TODO::test
+    /**
+     *Gets whether non-owners of a site can share content to users that are not members of the site collection
+     *
+     *@param siteUrl The siteUrl of the site collection to check if restrict sharing is enabled
+     *@returns A Boolean indicating if sharing is disabled for site members in the site collection
+     */
+    public isSharingDisabledForNonOwnersOfSite(siteUrl: string): Promise<boolean> {
+        return spPost(Office365Tenant(this, "IsSharingDisabledForNonOwnersOfSite"), body({
+            siteUrl,
+        }));
+    }
 
-/// <summary>
-/// Revokes all user sessions for a given user's puid.
-/// </summary>
-/// <param name="puidList">
-/// A list of puids to be revoked.
-/// Each value should look like this:
-/// <example>10037ffe8000008d</example>
-/// </param>
-/// <returns>An SPOUserSessionRevocationResult enum value which represents the state of the operation.</returns>
-[ClientCallable]
-        public IList < SPOUserSessionRevocationResult > RevokeAllUserSessionsByPuid(IList < string > puidList)
-{
-    this.rbacManager.AssertAccess(TenantAdminResources.TenantSettings, Permissions.Update);
-    return this.DataAccess.RevokeAllUserSessionsByPuid(puidList);
-}
+    // TODO::test
+    /**
+     *Revokes all user sessions for a given username
+     *
+     *@param userName The home tenant user name, which is being used at authentication time (user@contoso.com)
+     *@returns An value which represents the state of the operation
+     */
+    public revokeAllUserSessions(userName: string): Promise<ISPOUserSessionRevocationResult> {
+        return spPost(Office365Tenant(this, "RevokeAllUserSessions"), body({
+            userName,
+        }));
+    }
 
-        /// <summary>
-        /// Create a new Office 365 Group and connect it to an existing site.  After this succeeds for a given site, calling it again with the same site will throw an Exception.
-        /// </summary>
-        /// <param name="siteUrl">The full URL of the site to connect to.</param>
-        /// <param name="displayName">The desired display name of the new group</param>
-        /// <param name="alias">The desired email alias for the new group</param>
-        /// <param name="isPublic">Whether the new group should be public or private</param>
-        /// <param name="optionalParams">An optional set of creation parameters for the group</param>
-        
-        public void CreateGroupForSite(string siteUrl, string displayName, string alias, bool isPublic, GroupCreationParams optionalParams)
-{
-    this.rbacManager.AssertAccess(TenantAdminResources.UnifiedGroups, Permissions.Create);
-    this.DataAccess.CreateGroupForSite(siteUrl, displayName, alias, isPublic, optionalParams);
-}
+    /**
+     *Revokes all user sessions for a given user's puid
+     *
+     *@param puidList A list of puids to be revoked (ex: 10037ffe8000008d)
+     *@returns An SPOUserSessionRevocationResult enum value which represents the state of the operation
+     */
+    public revokeAllUserSessionsByPuid(puidList: string[]): Promise<ISPOUserSessionRevocationResult[]> {
+        return spPost(Office365Tenant(this, "RevokeAllUserSessionsByPuid"), body({
+            puidList,
+        }));
+    }
+
+    /**
+     *Create a new Office 365 Group and connect it to an existing site. After this succeeds for a given site, calling it again with the same site will throw an Exception
+     *
+     *@param siteUrl The full URL of the site to connect to
+     *@param displayName The desired display name of the new group
+     *@param alias The desired email alias for the new group
+     *@param isPublic Whether the new group should be public or private
+     *@param optionalParams An optional set of creation parameters for the group
+     */
+    public createGroupForSite(siteUrl: string, displayName: string, alias: string, isPublic: boolean, optionalParams: IGroupCreationParams): Promise<void> {
+        return spPost(Office365Tenant(this, "CreateGroupForSite"), body({
+            siteUrl,
+            displayName,
+            alias,
+            isPublic,
+            optionalParams,
+        }));
+    }
 }
 export interface IOffice365Tenant extends _Office365Tenant { }
 export const Office365Tenant = spInvokableFactory<IOffice365Tenant>(_Office365Tenant);

--- a/packages/sp-admin/index.ts
+++ b/packages/sp-admin/index.ts
@@ -1,15 +1,16 @@
 import { SPFI, _SPQueryable, spInvokableFactory } from "@pnp/sp";
-import { IOffice365Tenant, Office365Tenant } from "./Office365Tenant.js";
+import { IOffice365Tenant, Office365Tenant } from "./office-tenant.js";
+import { ITenantSiteProperties, TenantSiteProperties } from "./site-properties.js";
+import { ITenant, Tenant } from "./tenant.js";
 
 export * from "./types.js";
-export * from "./Office365Tenant.js";
-
+export * from "./office-tenant.js";
 
 declare module "@pnp/sp/fi" {
     interface SPFI {
 
         /**
-         * Access to the current web instance
+         * Access to the admin capabilities
          */
         readonly admin: IAdmin;
     }
@@ -29,22 +30,17 @@ class _Admin extends _SPQueryable {
         return Office365Tenant(this);
     }
 
+    public get siteProperties() {
+        return TenantSiteProperties(this);
+    }
+
+    public get tenant() {
+        return Tenant(this);
+    }
 }
 export interface IAdmin {
-    office365Tenant: IOffice365Tenant;
+    readonly office365Tenant: IOffice365Tenant;
+    readonly siteProperties: ITenantSiteProperties;
+    readonly tenant: ITenant;
 }
 export const Admin: IAdmin = <any>spInvokableFactory(_Admin);
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/sp-admin/index.ts
+++ b/packages/sp-admin/index.ts
@@ -1,0 +1,11 @@
+export * from "./types.js";
+
+// do we just auto attach to the sp stuff here?
+// yes so pattern is:
+// import "@pnp/sp-admin";
+
+
+
+
+
+

--- a/packages/sp-admin/index.ts
+++ b/packages/sp-admin/index.ts
@@ -1,8 +1,52 @@
+import { SPFI, _SPQueryable, spInvokableFactory } from "@pnp/sp";
+import { IOffice365Tenant, Office365Tenant } from "./Office365Tenant.js";
+
 export * from "./types.js";
 
 // do we just auto attach to the sp stuff here?
 // yes so pattern is:
 // import "@pnp/sp-admin";
+
+export * from "./Office365Tenant.js";
+
+
+declare module "@pnp/sp/fi" {
+    interface SPFI {
+
+        /**
+         * Access to the current web instance
+         */
+        readonly admin: IAdmin;
+    }
+}
+
+Reflect.defineProperty(SPFI.prototype, "admin", {
+    configurable: true,
+    enumerable: true,
+    get: function (this: SPFI) {
+        return this.create(<any>Admin);
+    },
+});
+
+class _Admin extends _SPQueryable {
+
+    public get office365Tenant() {
+        return Office365Tenant(this);
+    }
+
+}
+export interface IAdmin {
+    office365Tenant: IOffice365Tenant;
+}
+export const Admin: IAdmin = <any>spInvokableFactory(_Admin);
+
+
+
+
+
+
+
+
 
 
 

--- a/packages/sp-admin/index.ts
+++ b/packages/sp-admin/index.ts
@@ -2,11 +2,6 @@ import { SPFI, _SPQueryable, spInvokableFactory } from "@pnp/sp";
 import { IOffice365Tenant, Office365Tenant } from "./Office365Tenant.js";
 
 export * from "./types.js";
-
-// do we just auto attach to the sp stuff here?
-// yes so pattern is:
-// import "@pnp/sp-admin";
-
 export * from "./Office365Tenant.js";
 
 

--- a/packages/sp-admin/office-tenant.ts
+++ b/packages/sp-admin/office-tenant.ts
@@ -25,7 +25,7 @@ class _Office365Tenant extends _SPInstance<IOffice365TenantInfo> {
     * @description we limit the selects here because there are so many values possible and it improves discoverability.
     * Unfortunately this doesn't work as a general solution due to expands
     */
-    public select(...selects: (keyof IOffice365TenantInfo)[]): this {
+    public select(...selects: ("*" | keyof IOffice365TenantInfo)[]): this {
         return super.select(...selects);
     }
 

--- a/packages/sp-admin/package.json
+++ b/packages/sp-admin/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@pnp/sp-admin",
+    "version": "0.0.0-PLACEHOLDER",
+    "description": "pnp - provides a fluent api for working with SharePoint's Tenant Admin REST",
+    "main": "./index.js",
+    "typings": "./index",
+    "dependencies": {
+        "tslib": "2.4.0",
+        "@pnp/core": "0.0.0-PLACEHOLDER",
+        "@pnp/queryable": "0.0.0-PLACEHOLDER",
+        "@pnp/sp": "0.0.0-PLACEHOLDER"
+    }
+}

--- a/packages/sp-admin/site-properties.ts
+++ b/packages/sp-admin/site-properties.ts
@@ -1,0 +1,29 @@
+import { body } from "@pnp/queryable";
+import { _SPInstance, defaultPath, spPost, spInvokableFactory } from "@pnp/sp";
+import { ITenantSitePropertiesInfo } from "./types.js";
+
+@defaultPath("_api/Microsoft.Online.SharePoint.TenantAdministration.SiteProperties")
+class _TenantSiteProperties extends _SPInstance<ITenantSitePropertiesInfo> {
+
+    /**
+    * Choose which fields to return
+    *
+    * @param selects One or more fields to return
+    * @description we limit the selects here because there are so many values possible and it improves discoverability.
+    * Unfortunately this doesn't work as a general solution due to expands
+    */
+    public select(...selects: ("*" | keyof ITenantSitePropertiesInfo)[]): this {
+        return super.select(...selects);
+    }
+
+    /**
+     * Clears the Lockdown placed due to Sharing-Lockdown Policy
+     */
+    public clearSharingLockDown(siteUrl: string): Promise<void> {
+        return spPost(TenantSiteProperties(this, "ClearSharingLockDown"), body({
+            siteUrl,
+        }));
+    }
+}
+export interface ITenantSiteProperties extends _TenantSiteProperties { }
+export const TenantSiteProperties = spInvokableFactory<ITenantSiteProperties>(_TenantSiteProperties);

--- a/packages/sp-admin/tenant.ts
+++ b/packages/sp-admin/tenant.ts
@@ -1,0 +1,1149 @@
+// import { body } from "@pnp/queryable";
+import { body } from "@pnp/queryable";
+import { _SPInstance, defaultPath, spInvokableFactory, spPost } from "@pnp/sp";
+import { ITenantInfo } from "./types.js";
+
+@defaultPath("_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant")
+class _Tenant extends _SPInstance<ITenantInfo> {
+
+    /**
+    * Choose which fields to return
+    *
+    * @param selects One or more fields to return
+    * @description we limit the selects here because there are so many values possible and it improves discoverability.
+    * Unfortunately this doesn't work as a general solution due to expands
+    */
+    public select(...selects: ("*" | keyof ITenantInfo)[]): this {
+        return super.select(...selects);
+    }
+
+    /**
+     * Returns a site object for the given URL
+     *
+     * @param url URL of the requested site object
+     * @param includeDetail true to include details
+     * @returns Returns a site object for the given URL
+     */
+    public getSitePropertiesByUrl(url: string, includeDetail = false): Promise<any> {
+        return spPost(Tenant(this, "GetSitePropertiesByUrl"), body({
+            url,
+            includeDetail,
+        }));
+    }
+
+    /**
+*    #region Client Callable Methods
+
+
+
+   /// <summary>
+   /// Gets SPOSiteProperties objects for all sites from SharePoint in the tenancy that match the filter expression.
+   /// If the filter is null or empty string, then all the sites are returned.
+   /// </summary>
+   /// <returns>IEnumerable&lt;SPOSiteProperties&gt;</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public SitePropertiesEnumerable GetSitePropertiesFromSharePointByFilters(SitePropertiesEnumerableFilter speFilter)
+   {
+  
+   }
+
+
+
+
+
+   /// <summary>
+   /// Get whether this tenant has valid education license.
+   /// </summary>
+   /// <returns>bool;</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.RESTful, OperationType = OperationType.Read)]
+   public bool HasValidEducationLicense()
+   {
+  
+   }
+
+
+
+
+   /// <summary>
+   /// Queues a site collection for creation with the given properties
+   /// </summary>
+   /// <param name="SiteCreationProperties"> The initial properties for the site which is to be created. </param>
+   /// <returns>Queues a site collection for creation with the given properties</returns>
+   /// <id guid="3c1e5508-b720-4346-b9cb-d374736e613d" />
+   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
+   public SpoOperation CreateSite(SiteCreationProperties siteCreationProperties)
+   {
+  
+   }
+
+   /// <summary>
+   /// Gets all the SPWebTemplates on this Tenant.
+   /// </summary>
+   /// <returns>An SPOWebTemplateCollection containing a SPOWebTemplate information for each template</returns>
+   [ClientCallableMethod(OperationType = OperationType.Read, ClientLibraryTargets = ClientLibraryTargets.All)]
+   public SPOWebTemplateCollection GetSPOTenantAllWebTemplates()
+   {
+  
+   }
+
+   /// <summary>
+   /// Parameters required to be passed based on the <cref>UpdateGroupSitePropertiesType</cref>
+   /// </summary>
+   [ClientCallableType(Name = "UpdateGroupSitePropertiesParameters",
+  ServerTypeId = "{6d8cb9b8-0c8a-11ec-82a8-0242ac130003}",
+  ValueObject = true)]
+   public class UpdateGroupSitePropertiesParameters
+   {
+  [ClientCallableProperty(Name = "storageMaximumLevel")]
+  public Int64 StorageMaximumLevel { get; set; }
+
+  [ClientCallableProperty(Name = "storageWarningLevel")]
+  public Int64 StorageWarningLevel { get; set; }
+
+  public override string ToString()
+  {
+ return JsonConvert.SerializeObject(this);
+  }
+   }
+
+   /// <summary>
+   /// Handles updating the properties based on updateType <cref>UpdateGroupSitePropertiesType</cref> of all the sites which are part of the groupId
+   /// </summary>
+   /// <example>
+   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/UpdateGroupSiteProperties
+   ///RequestBody: {"groupId":"<Guid>","siteId":"<Guid>","updateType":"StorageQuota","parameters":{"storageMaximumLevel":<Int>,"storageWarningLevel":<Int>}}
+   /// </example>
+   /// <param name="groupId">Group Id</param>
+   /// <param name="siteId">Site Id</param>
+   /// <param name="updateType">Property which is required to be updated</param>
+   /// <param name="parameters">Params which are required to be passed based on the updateType</param>
+   /// <returns>string denoting the user storage key which can be used by client to pull the async workflow status</returns>
+   [ClientCallableMethod(Name = "UpdateGroupSiteProperties",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   public string UpdateGroupSiteProperties(Guid groupId, Guid siteId, string updateType, UpdateGroupSitePropertiesParameters parameters)
+   {
+ 
+   }
+
+   
+   /// <summary>
+   /// Gets all the site collection templates available in SPO for the given UI culture.
+   /// </summary>
+   /// <returns>An SPOWebTemplateCollection for all the site collection templates available in SPO for the given UI culture.</returns>
+   [ClientCallableMethod(
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.All,
+  AllowedReadRoles = new SecurityGroup[] { SecurityGroup.GlobalReader },
+  RequiredRight = ResourceRight.GlobalReader)]
+   public SPOWebTemplateCollection GetSPOAllWebTemplates(string cultureName, int compatibilityLevel)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Gets all the SPWebTemplates for site collections on this Tenant
+   /// </summary>
+   /// <returns>An SPOWebTemplateCollection containing a SPOWebTemplate information for each template</returns>
+   [ClientCallableMethod(OperationType = OperationType.Read, ClientLibraryTargets = ClientLibraryTargets.All)]
+   public SPOWebTemplateCollection GetSPOTenantWebTemplates(uint localeId, int compatibilityLevel)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Returns the site header logo by site URL.
+   /// </summary>
+   /// <param name="siteUrl"></param>
+   /// <returns>Stream containing the site logo data</returns>
+   [ClientCallableMethod(OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader,
+  IsBeta = true)]
+   public Stream GetSiteThumbnailLogo(string siteUrl)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Gets all the SPSiteCreationSources.
+   /// </summary>
+   /// <returns>A list of SPOSiteCreationSource objects, each object is mapped to a SPSiteCreationSource enum</returns>
+   [ClientCallableMethod(
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public IList<SPOSiteCreationSource> GetSPOSiteCreationSources()
+   {
+ 
+   }
+
+  
+
+  
+
+   /// <summary>
+   /// Deletes the site to the recycle bin
+   /// </summary>
+   /// <param name="url">URL of the site to be deleted</param>
+   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
+   public SpoOperation RemoveSite(string siteUrl)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Gets the health Status of the site from WEX api
+   /// https://constoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetSiteHealthStatus?sourceUrl='https://contoso.sharepoint.com/sites/pwa'
+   /// </summary>
+   [ClientCallableMethodAttribute(Name = "GetSiteHealthStatus",
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   public PortalHealthStatus GetSiteHealthStatus([ClientCallableParameter(Name = "sourceUrl")] String sourceUrl)
+   {
+  
+   }
+
+   /// <summary>
+   /// Performs the Swap operation on the provided sites
+   /// </summary>
+   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
+   public SpoOperation SwapSiteWithSmartGestureOptionForce(string sourceUrl, string targetUrl, string archiveUrl, bool includeSmartGestures, bool force)
+   {
+  
+   }
+
+   /// <summary>
+   /// Performs the Swap operation on the provided sites
+   /// </summary>
+   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
+   public SpoOperation SwapSiteWithSmartGestureOption(string sourceUrl, string targetUrl, string archiveUrl, bool includeSmartGestures)
+   {
+  
+   }
+
+   /// <summary>
+   /// Performs the Swap operation on the provided sites
+   /// </summary>
+   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
+   public SpoOperation SwapSite(string sourceUrl, string targetUrl, string archiveUrl)
+   {
+  
+   }
+
+   
+
+   /// <summary>
+   /// Permanently deletes the site from the recycle bin
+   /// </summary>
+   /// <param name="siteUrl">URL of the site to be deleted</param>
+   /// <returns>operation for the request</returns>
+   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
+   public SpoOperation RemoveDeletedSite(string siteUrl)
+   {
+  
+   }
+
+   /// <summary>
+   /// Permanently deletes the site from the recycle bin
+   /// </summary>
+   /// <param name="siteUrl">URL of the site to be deleted</param>
+   /// <param name="siteId">SiteID of the site to be deleted</param>
+   /// <returns>operation for the request</returns>
+   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
+   public SpoOperation RemoveDeletedSitePreferId(string siteUrl, Guid siteId)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Restores site from deleted state (recycle bin)
+   /// </summary>
+   /// <param name="siteUrl">URL of the site to be restored</param>
+   /// <returns>operation for the request</returns>
+   [ClientCallableMethod]
+   public SpoOperation RestoreDeletedSite(string siteUrl)
+   {
+  
+   }
+
+   /// <summary>
+   /// Restores site from deleted state (recycle bin)
+   /// </summary>
+   /// <param name="siteId">SiteID of the site to be deleted</param>
+   /// <returns>operation for the request</returns>
+   [ClientCallableMethod]
+   public SpoOperation RestoreDeletedSiteById(Guid siteId)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Restores site from deleted state (recycle bin)
+   /// </summary>
+   /// <param name="siteUrl">URL of the site to be restored</param>
+   /// <param name="siteId">SiteID of the site to be deleted</param>
+   /// <returns>operation for the request</returns>
+   [ClientCallableMethod]
+   public SpoOperation RestoreDeletedSitePreferId(string siteUrl, Guid siteId)
+   {
+ 
+   }
+
+
+   /// <summary>
+   /// A collection of PowerApps environments
+   /// </summary>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.RESTful, OperationType = OperationType.Read)]
+   public ReadOnlyCollection<PowerAppsEnvironment> GetPowerAppsEnvironments()
+   {
+  
+   }
+
+
+   /// <summary>
+   /// Sets the configuration values for the following policy:
+   ///  * Idle session sign out for unmanaged devices.
+   /// </summary>
+   /// <param name="enabled">Boolean indicating if the policy should be enabled.</param>
+   /// <param name="warnAfter">TimeSpan containing the time before warning the user</param>
+   /// <param name="signOutAfter">TimeSpan containing the time before signing out the user.</param>
+   /// <returns>True if the operation succeeds, false otherwise.</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public bool SetIdleSessionSignOutForUnmanagedDevices(Boolean enabled, TimeSpan warnAfter, TimeSpan signOutAfter)
+   {
+  
+   }
+
+   /// <summary>
+   /// Gets the configuration values, as a string, for the following policy:
+   ///  * Idle session sign out for unmanaged devices.
+   /// </summary>
+   /// <remarks>
+   /// The return string is a comma delineated list of the three policy settings.  The policy settings consist of:
+   /// 1. Enabled: true or false
+   /// 2. Warn after: Time until user should be warned in seconds.
+   /// 3. Sign out after: Time until user should be signed out in seconds.
+   /// </remarks>
+   /// <returns>A string indicating the current policy settings.</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All,
+  AllowedWriteRoles = new SecurityGroup[] { SecurityGroup.GlobalReader },
+  RequiredRight = ResourceRight.GlobalReader)]
+   public string GetIdleSessionSignOutForUnmanagedDevices()
+   {
+ 
+   }
+
+
+   /// <summary>
+   /// RESTful API to export SPList to CSV file and return file download link.
+   /// </summary>
+   /// <param name="viewXml">XML of the export view </param>
+   /// <example>
+   /// POST _api/SPO.Tenant/ExportToCSV
+   /// </example>
+   [ClientCallableMethodAttribute(Name = "ExportToCSV",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   public string ExportToCSV(string viewXml)
+   {
+ 
+   }
+
+   /// <summary>
+   /// RESTful API to export SPList to CSV file and return file download link.
+   /// </summary>
+   /// <param name="viewXml">XML of the export view </param>
+   /// <param name="listName">Name of Admin SPList to be exported</param>
+   /// <example>
+   /// POST _api/SPO.Tenant/ExportAdminListToCSV
+   /// </example>
+   [ClientCallableMethodAttribute(Name = "ExportAdminListToCSV",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   public string ExportAdminListToCSV(string viewXml, string listName)
+   {
+ 
+   }
+
+   /// <summary>
+   /// RESTful API to set site's user groups
+   /// </summary>
+   /// <param name="SiteUserGroupsData.siteId">The guid of site.</param>
+   /// <param name="SiteUserGroupsData.SiteUserGroups">The array of site's user groups that will replace the current user groups.</param>
+   /// <example>
+   /// POST https://prepspo-admin.spgrid.com/_api/SPO.Tenant/SetSiteUserGroups
+   /// </example>
+   [ClientCallableMethodAttribute(Name = "SetSiteUserGroups",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  IsBeta = true)]
+   public void SetSiteUserGroups(
+  [ClientCallableParameter(Name = "siteUserGroupsData")]
+  SiteUserGroupsData siteUserGroupsData)
+   {
+  
+   }
+
+   /// <summary>
+   /// RESTful API to set site administrators
+   /// </summary>
+   /// <param name="siteAdministratorsFieldsData.siteId">The guid of site.</param>
+   /// <param name="siteAdministratorsFieldsData.siteAdministrators">The array of site's administrators that will replace current administrators.</param>
+   /// <example>
+   /// POST https://prepspo-admin.spgrid.com/_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant/SetSiteAdministrators
+   /// with payload:
+   /// {
+   ///"siteAdministratorsFieldsData":
+   ///{
+   ///    "siteId":"1ae2d477-3e17-4dba-9f30-f1cc8bc594b9",
+   ///    "siteAdministrators":["User1@prepspo.msolctp-int.com","User2@prepspo.msolctp-int.com"]
+   ///}
+   /// }
+   /// </example>
+   [ClientCallableMethodAttribute(Name = "SetSiteAdministrators",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  IsBeta = true)]
+   public void SetSiteAdministrators(
+  [ClientCallableParameter(Name = "siteAdministratorsFieldsData")]
+  SiteAdministratorsFieldsData siteAdministratorsFieldsData)
+   {
+  
+   }
+
+   /// <summary>
+   /// RESTful API to check tenant licenses.
+   /// Full list of licenses are defined in TenantConstants class in %SRCROOT%\sporel\sts\stsom\Administration\SPOnlineProvisioning\SPTenantOMConstants.cs
+   /// </summary>
+   /// <param name="licenses">The licenses to check on tenant.</param>
+   /// <example>
+   /// GET https://prepspo-admin.spgrid.com/_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant/CheckTenantLicenses?licenses=["SPO_Standard","SPO_Project"]
+   ///It returns true for onebox.
+   /// </example>
+   /// <returns>True if and only if tenant has all licenses in parameter</returns>
+   [ClientCallableMethodAttribute(OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  IsBeta = true)]
+   public bool CheckTenantLicenses(
+  [ClientCallableParameter(Name = "licenses")]
+  string[] licenses)
+   {
+  
+   }
+
+   /// <summary>
+   /// RESTful API to check tenant intune license
+   /// </summary>
+   /// <example>
+   /// GET https://contoso-admin.sharepoint.com/_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant/CheckTenantIntuneLicense
+   /// </example>
+   /// <returns>True if and only if tenant has Intune license</returns>
+   [ClientCallableMethodAttribute(Name = "CheckTenantIntuneLicense",
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  IsBeta = true,
+  AllowedReadRoles = new SecurityGroup[] { SecurityGroup.GlobalReader },
+  RequiredRight = ResourceRight.GlobalReader)]
+   public bool CheckTenantIntuneLicense()
+   {
+ 
+   }
+
+  
+
+    /// <summary>
+   /// RESTful API to get site's administrators' names and emails
+   /// </summary>
+   /// <param name="siteId">The guid of site.</param>
+   /// <example>
+   /// GET https://prepspo-admin.spgrid.com/_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant/GetSiteAdministrators
+   /// with query param ?siteId=1ae2d477-3e17-4dba-9f30-f1cc8bc594b9   
+   /// </example>
+   [ClientCallableMethodAttribute(Name = "GetSiteAdministrators",
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  IsBeta = true,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public List<SiteAdministratorsInfo> GetSiteAdministrators(
+  Guid siteId)
+   {
+ 
+   }
+
+   /// <summary>
+   /// RESTful API for getting Compatible Information Barrier Segments.
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetTenantAllOrCompatibleIBSegments
+   /// Request Body : {"segments":["9049237F-BF11-4G6B-433A-7A44A9BDDE42"]}
+   /// If the input guids are null, we return all the IB Segments associated to a tenant.
+   /// </summary>
+   [ClientCallableMethod(Name = "GetTenantAllOrCompatibleIBSegments",
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public IBSegmentInfo[] GetTenantAllOrCompatibleIBSegments(Guid[] segments)
+   {
+  
+   }
+
+   /// <summary>
+   /// RESTful API for getting SiteStream for  Information Barrier Segments.
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderIBSegmentListDataAsStream
+   /// Request Body : {"parameters":{"ViewXml":"<View></View>","DatesInUtc":true},segments:{"998D8D85-9D92-40BC-BBBC-4B85F13E0FB5"},overrideParameters:""}
+   /// </summary>
+   [ClientCallableMethod(Name = "RenderIBSegmentListDataAsStream",
+   OperationType = OperationType.Read,
+   ClientLibraryTargets = ClientLibraryTargets.RESTful,
+   RequiredRight = ResourceRight.GlobalReader)]
+   public Stream RenderIBSegmentListDataAsStream(
+  SPRenderListDataParameters parameters, Guid[] segments,
+  [ClientCallableParameter(RESTfulParameterSource = RESTfulParameterSource.Path)] SPRenderListDataOverrideParameters overrideParameters)
+   {
+  
+   }
+
+   /// <summary>
+   /// RESTful API for getting Information Barrier Segments Filter Options.
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderIBSegmentListFilterData
+   /// Request Body : {"parameters":{"ViewXml":"<View></View>"}}
+   /// </summary>
+   [ClientCallableMethod(Name = "RenderIBSegmentListFilterData",
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public Stream RenderIBSegmentListFilterData(
+  SPRenderListFilterDataParameters parameters)
+   {
+  
+   }
+
+   
+
+   /// <summary>
+   /// Renders Tenant Admin SPList Data after filtering based on the groupId the site belongs to
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderFilteredAdminListDataByGroupId
+   /// <param name="groupId">Group Id the sites belong to</param>
+   /// <returns>Filtered Tenant Admin list Data as stream</returns>
+   /// Request Body : {"groupId": Guid value}
+   /// </summary>
+   [ClientCallableMethod(Name = "RenderFilteredAdminListDataByGroupId",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public Stream RenderFilteredAdminListDataByGroupId(Guid groupId)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Renders Tenant Admin SPList Data
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderAdminListData
+   /// <param name="parameters">parameters for list data rendering</param>
+   /// <param name="overrideParameters">overrideParameter for list data renderings</param>
+   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
+   /// <returns>Tenant Admin list Data as stream</returns>
+   /// Request Body : {"parameters": {"ViewXml":"<View></View>","DatesInUtc":true}}
+   /// </summary>
+   [ClientCallableMethod(Name = "RenderAdminListData",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public Stream RenderAdminListData(SPRenderListDataParameters parameters, SPRenderListDataOverrideParameters overrideParameters, string listName)
+   {
+
+   }
+
+   /// <summary>
+   /// Renders Tenant Admin SPList Data after filtering based on filter conditions
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderFilteredAdminListData
+   /// <param name="parameters">parameters for list data rendering</param>
+   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
+   /// <returns>Filtered Tenant Admin list Data as stream</returns>
+   /// Request Body : {"parameters": {"ViewXml":"<View></View>"}}
+   /// </summary>
+   [ClientCallableMethod(Name = "RenderFilteredAdminListData",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public Stream RenderFilteredAdminListData(SPRenderListFilterDataParameters parameters, string listName)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Gets SPList total item Count
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetSPListItemCount
+   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
+   /// <returns>List item count</returns>
+   /// </summary>
+   [ClientCallableMethod(Name = "GetSPListItemCount",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public int GetSPListItemCount(string listName)
+   {
+    
+   }
+
+   /// <summary>
+   /// Gets the SpList Root Folder Properties
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetSPListRootFolderProperties
+   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
+   /// <returns>List Root Fodler Properties</returns>
+   /// </summary>
+   [ClientCallableMethod(Name = "GetSPListRootFolderProperties",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   internal SPPropertyValues GetSPListRootFolderProperties(string listName)
+   {
+  
+   }
+
+   /// <summary>
+   /// Gets all the views from Tenant Admin Sites List
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetAdminListViews
+   /// <returns>All the avaiable Views from the List</returns>
+   /// </summary>
+   [ClientCallableMethod(Name = "GetAdminListViews",
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public SPViewCollection GetAdminListViews()
+   {
+
+   }
+
+   /// <summary>
+   /// Gets a view by DisplayName from SPList
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetViewByDisplayName
+   /// <param name="viewName">View Name</param>
+   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
+   /// <returns>Returns SPView for given View Name</returns>
+   /// Request Body : {"viewName": "ExportView"}}
+   /// </summary>
+   [ClientCallableMethod(Name = "GetViewByDisplayName",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public SPView GetViewByDisplayName(string viewName, string listName)
+   {
+
+
+   /// <summary>
+   /// Sets Default View in SPList
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/SetDefaultView
+   /// <param name="viewId">View Id</param>
+   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
+   /// Request Body : {"viewId" : "6450c68f-e2f6-461e-ac68-dc1f9f9400eb"}
+   /// </summary>
+   [ClientCallableMethod(Name = "SetDefaultView",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public void SetDefaultView(string viewId, string listName)
+   {
+   }
+
+   /// <summary>
+   /// Removes item from SPList
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RemoveSPListItem
+   /// <param name="listItemId">List Item Id</param>
+   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
+   /// Request Body : {"listItemId" : 1}
+   /// </summary>
+   [ClientCallableMethod(Name = "RemoveSPListItem",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public void RemoveSPListItem(int listItemId, string listName)
+   {
+  
+   }
+
+   /// <summary>
+   /// Add a new view in SPList
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/AddTenantAdminListView
+   /// <param name="parameters">Creation Information for the New View</param>
+   /// <returns>Returns SPView of the Newly Added View</returns>
+   /// Request Body : {"parameters": {"Title": "NewView"}}
+   /// </summary>
+   [ClientCallableMethod(Name = "AddTenantAdminListView",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   internal SPView AddTenantAdminListView(SPViewCreationInformation parameters)
+   {
+  this.rbacManager.AssertAccess(Resources.SharePointSites, Permissions.Update);
+  return SPOTenantAdminSPListUtilities<SPListAsAggregatedStore>.AddTenantAdminListView(siteSubscription, parameters);
+   }
+
+   /// <summary>
+   /// Deletes a view in SPList
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RemoveTenantAdminListView
+   /// <param name="viewId">View Id</param>
+   /// Request Body : {"viewId": "6450c68f-e2f6-461e-ac68-dc1f9f9400eb"}
+   /// </summary>
+   [ClientCallableMethod(Name = "RemoveTenantAdminListView",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   internal void RemoveTenantAdminListView(string viewId)
+   {
+
+   }
+
+   /// <summary>
+   /// Saves a view in SPList
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/UpdateTenantAdminListView
+   /// <param name="viewId">View Id</param>
+   /// <param name="viewXml">View XML</param>
+   /// Request Body : {"viewId" : "6450c68f-e2f6-461e-ac68-dc1f9f9400eb", "viewXml":"<View></View>"}
+   /// </summary>
+   [ClientCallableMethod(Name = "UpdateTenantAdminListView",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public void UpdateTenantAdminListView(string viewId, string viewXml)
+   {
+  
+   }
+
+   /// <summary>
+   /// Updates SPField Values in Tenant Admin Lists
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/UpdateTenantAdminListItem
+   /// <param name="listItemId">List Item Id</param>
+   /// <param name="columnValues">List of TenantAdminList Column Values</param>
+   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
+   /// Request Body : {"listItemId" : 1, "columnValues": [{columnName: "State", columnValue: "1"}]}
+   /// </summary>
+   [ClientCallableMethod(Name = "UpdateTenantAdminListItem",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   internal void UpdateTenantAdminListItem(int listItemId, List<TenantAdminListItemColumnValue> columnValues, string listName)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Renders Recent Admin Actions SPList data as Stream
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderRecentAdminActions
+   /// <param name="parameters">parameters for list data rendering</param>
+   /// <param name="overrideParameters">overrideParameter for list data renderings</param>
+   /// <returns>Recent Admin Actions SPList Data as stream</returns>
+   /// Request Body : {"parameters": {"ViewXml":"<View></View>","DatesInUtc":true}}
+   /// </summary>
+   [ClientCallableMethod(Name = "RenderRecentAdminActions",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   internal Stream RenderRecentAdminActions(SPRenderListDataParameters parameters, SPRenderListDataOverrideParameters overrideParameters)
+   {
+
+
+   /// <summary>
+   /// Adds Recent Admin Action in Tenant RecentActions Store
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/AddRecentAdminAction
+   /// <param name="payload">RecentAdminAction value object</param>
+   /// <returns>Recent Admin Actions SPListItem</returns>
+   /// Request Body : {"payload": {"adminActionSource": "SharePointAdminCenter", "adminActionStatus": "Success", "key": "123"}}
+   /// </summary>
+   [ClientCallableMethod(Name = "AddRecentAdminAction",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   internal SPListItem AddRecentAdminAction(TenantAdminRecentActionPayload payload)
+   
+   }
+
+   /// <summary>
+   /// Get list of Policy Automation executions from SPList
+   /// </summary>
+   /// <remarks>
+   /// Returns stream of execution history item list filtered based on ViewXML passed in "parameters" object in payload.
+   /// Single Policy Execution History can also be fetched by passing Policy Id in WHERE clause of ViewXML.
+   /// <example>
+   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderPolicyExecutionsHistory
+   ///Request Body : {"parameters":{"ViewXml":"<View></View>","DatesInUtc":true}
+   ///Response Body: {
+   ///  "Row": [
+   ///    {
+   ///  "ExecutionId": "{DC3F043E-FF25-4D29-B857-CC241190E7D6}",
+   ///  "PolicyId": "{1F4062E3-8D68-4CFE-8646-97978E7BD473}",
+   ///  "PolicyVersion": "1",
+   ///  "RetryCount": "0",
+   ///  "Status": "Scheduled",
+   ///  "WorkItemId": "{0E59F3CA-59AB-4C0D-80F3-257E314657C2}",
+   ///  "WorkItemType": "Parent"
+   ///    }
+   ///  ]
+   ///}
+   /// </example>
+   /// </remarks>
+   [ClientCallableMethod(Name = "RenderPolicyExecutionsHistory",
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public Stream RenderPolicyExecutionsHistory(SPRenderListDataParameters parameters, SPRenderListDataOverrideParameters overrideParameters)
+   {
+    }
+   }
+
+   /// <summary>
+   /// Get list of Policy Automation definitions from SPList
+   /// </summary>
+   /// <remarks>
+   /// <example>
+   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderPolicyDefinitionList
+   ///Request Body : {"parameters": {"ViewXml":"<View><ViewFields><FieldRef Name=\"PolicyId\"/><FieldRef Name=\"PolicyVersion\"/><FieldRef Name=\"PolicyState\"/><FieldRef Name=\"PolicyType\"/><FieldRef Name=\"PolicyTemplate\"/><FieldRef Name=\"CreatedBy\"/>
+   ///<FieldRef Name=\"PolicyCreatedTime\"/><FieldRef Name=\"UpdatedBy\"/><FieldRef Name=\"LastUpdatedTime\"/><FieldRef Name=\"EnabledTime\"/><FieldRef Name=\"DisabledTime\"/><FieldRef Name=\"PolicyDeletedTime\"/><FieldRef Name=\"PolicyFrequencyValue\"/>
+   ///<FieldRef Name=\"PolicyFrequencyUnit\"/><FieldRef Name=\"PolicyDefinition\"/></ViewFields><RowLimit Paged=\"TRUE\">30</RowLimit></View>","DatesInUtc":true}}
+   /// </example>
+   /// <param name="parameters">parameters for list data rendering</param>
+   /// <param name="overrideParameters">overrideParameter for list data renderings</param>
+   /// <returns>Policy definition SPList Data as stream</returns>
+   /// </remarks>
+   [ClientCallableMethod(Name = "RenderPolicyDefinitionList",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   internal Stream RenderPolicyDefinitionList(SPRenderListDataParameters parameters, SPRenderListDataOverrideParameters overrideParameters)
+   {
+  
+   /// <summary>
+   /// Creates Policy Automation definition record in SPList and create a work item
+   /// using Policy Automation Work item scheduler.
+   /// </summary>
+   /// <remarks>
+   /// <example>
+   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/CreatePolicyDefinition
+   ///Request Body : {
+   ///    "policyInputParameters": {
+   ///    "policyId": "4b986c69-1d8b-4c59-bf08-6310a687b35e",
+   ///    "policyCustomName": "inactivePolicy",
+   ///    "policyType": "OOTB",
+   ///    "policyTemplate": "Inactive",
+   ///    "policyFrequencyValue": "1",
+   ///    "policyFrequencyUnit": "WEEKLY"}
+   /// }
+   /// </example>
+   /// <param name="tenantAdminPolicyDefinition">TenantAdmin Policy Definition</param>
+   /// <returns>Policy Definition SPListItem</returns>
+   /// </remarks>
+   [ClientCallableMethod(Name = "CreatePolicyDefinition",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   internal SPListItem CreatePolicyDefinition(CreatePolicyRequest policyInputParameters)
+   {
+  
+   /// <summary>
+   /// Update Policy Automation definition instance in SPList.
+   /// In case of no change in schedule, only update definition SPList with a new version.
+   /// In case of schedule change, mark existing execution history as abandoned, and
+   /// create a new work item along with new execution history.
+   /// We can enable & disable any policy using this API.
+   /// </summary>
+   /// <remarks>
+   /// <example>
+   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/UpdatePolicyDefinition
+   ///Request Body : {"policyDefinition": {"policyId": "guid", "policyVersion": "1", "customPolicyName": "inactivePolicy"}, "updateType":"Enable"}
+   /// </example>
+   /// <param name="policyDefinition">Policy Definition</param>
+   /// </remarks>
+   [ClientCallableMethod(Name = "UpdatePolicyDefinition",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   internal void UpdatePolicyDefinition(int itemId, CreatePolicyRequest policyInputParameters)
+   {
+  
+   /// <summary>
+   /// Soft delete Policy by marking policy definition status as Deleted in SPList and mark existing
+   /// execution history as abandoned
+   /// </summary>
+   /// <remarks>
+   /// <example>
+   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/DeletePolicyDefinition
+   ///RequestBody: {"policyDefinition": {"policyId": "guid", "policyVersion": "1", "policyState": "Deleted","customPolicyName": "inactivePolicy"}, "updateType":"Deleted"}
+   /// </example>
+   /// <param name="policyDefinition">PolicyDefinition</param>
+   /// </remarks>
+   [ClientCallableMethod(Name = "DeletePolicyDefinition",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   internal void DeletePolicyDefinition(int itemId)
+   {
+
+
+   /// <summary>
+   /// Sends a sample mail to site owner for given site URL.
+   /// </summary>
+   /// <remarks>
+   /// Note: To be used only for testing PolicyAutomationEmailNotificationUtility class.
+   /// Should be removed after integration testing is successful.
+   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/SendEmail
+   /// </remarks>
+   [ClientCallableMethod(Name = "SendEmail",
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   public bool SendEmail(string siteUrl)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Adds an item in Tenant Admin List with given Column Values
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/AddTenantAdminListItem
+   /// <param name="columnValues">List of TenantAdminList Column Values to be added in the ListItem</param>
+   /// <param name="listName">TenantAdmin SPList on which the list item will be added</param>
+   /// Request Body :
+   /// {
+   ///"columnValues":
+   ///    [{
+   ///    columnName: "PUID_KEY",
+   ///    columnValue: "admin@contoso.com:SPONewAdminCenterVisited"
+   ///    }]
+   ///"listName": "DO_NOT_DELETE_SPLIST_TENANTADMIN_USERSTORAGE"
+   /// }
+   /// </summary>
+   /// <remarks>
+   /// This API is intended to update only SPLists other than below Sites Lists in Tenant Admin Site
+   /// 1. <see cref="AllSitesAggregatedStore"/>
+   /// 2. <see cref="SPListAsAggregatedStore"/>
+   /// Calls to Update to Sites Lists is not supported
+   /// </remarks>
+   [ClientCallableMethod(Name = "AddTenantAdminListItem",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   internal SPListItem AddTenantAdminListItem(List<TenantAdminListItemColumnValue> columnValues, string listName)
+   {
+  
+   }
+
+   /// <summary>
+   /// Gets sites based on States from Tenant Admin Sites List
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetSitesByState
+   /// <param name="states">State Values</param>
+   /// <returns>List Items Collection</returns>
+   /// Request Body : {"states" : [1,2,3]}
+   /// </summary>
+   [ClientCallableMethod(Name = "GetSitesByState",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public SPListItemCollection GetSitesByState(List<int> states)
+   {
+ 
+   }
+
+   /// <summary>
+   /// Gets List Item based on filters from Tenant Admin Sites List
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetFilteredSPListItems
+   /// <param name="columnName">Column Name</param>
+   /// <param name="columnValue">Column Value</param>
+   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
+   /// <returns>List Items Collection</returns>
+   /// Request Body : { "columnName": "siteUrl", "columnValue"  "https://contoso-admin.sharepoint.com"}
+   /// </summary>
+   [ClientCallableMethod(Name = "GetFilteredSPListItems",
+  OperationType = OperationType.Default,
+  ClientLibraryTargets = ClientLibraryTargets.RESTful,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public SPListItemCollection GetFilteredSPListItems(string columnName, string columnValue, string listName)
+   {
+
+   }
+
+   /// <summary>
+   /// Given a list of IBSegment GUIDS and IBMode(Optional), sets them to the site irrespective of the previous segments (and group if it is a group site) and also sets the ibMode.
+   /// Only ODB, non-teams-connected group site, non-group site can be updated.
+   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/SetIBSegmentsOnSite
+   /// Request Body : {"siteId":"54f6c9b4-abdb-4b23-a71d-239c0d2208f7", "segments":["9049237F-BF11-4G6B-433A-7A44A9BDDE42"] , "ibMode" : "Explicit"}
+   /// Returns the IB Mode for the site in case of successful updation of site.
+   /// </summary>
+   /// <param name="siteId"> siteId of the site on which segments will be applied.</param>
+   /// <param name="segments"> Comma-separated array of final IB Segment GUIDS which will be applied on the site.</param>
+   /// <param name="ibMode"> ibMode is an optional value.</param>
+   [ClientCallableMethod(Name = "SetIBSegmentsOnSite",
+    OperationType = OperationType.Default,
+    ClientLibraryTargets = ClientLibraryTargets.RESTful)]
+   public string SetIBSegmentsOnSite(Guid siteId, Guid[] segments, string ibMode = null)
+   {
+ 
+
+   /// <summary>
+   /// Registers the site with the specified URL as a HubSite.
+   /// </summary>
+   /// <param name="siteUrl">The URL of the site to make into a HubSite.</param>
+   /// <returns>The properties of the new HubSite.</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public HubSiteProperties RegisterHubSite(string siteUrl)
+  
+
+   /// <summary>
+   /// Registers the site with the specified URL as a HubSite.
+   /// </summary>
+   /// <param name="siteUrl">The URL of the site to make into a HubSite.</param>
+   /// <param name="creationInformation">Information used to create this HubSite.
+   /// If not specified, some default properties will be set instead.</param>
+   /// <returns>The properties of the new HubSite.</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public HubSiteProperties RegisterHubSiteWithCreationInformation(string siteUrl, SPHubSiteCreationInformation creationInformation)
+
+
+
+   /// <summary>
+   /// Makes the specified site no longer a HubSite and removes it from the list of HubSites.
+   /// The site is not deleted by this operation; it is merely removed from the list of available HubSites.
+   /// </summary>
+   /// <param name="siteUrl">The URL of the site which should no longer be a HubSite.</param>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public void UnregisterHubSite(string siteUrl)
+   
+
+   /// <summary>
+   /// Connects a site to a HubSite using hub site id, support multi-geo.
+   /// </summary>
+   /// <param name="siteUrl">URL of the site to connect to the HubSite.</param>
+   /// <param name="hubSiteId">Guid of the HubSite ID.</param>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public void ConnectSiteToHubSiteById(string siteUrl, Guid hubSiteId)
+   
+   /// <summary>
+   /// Grant HubSite rights to users giving HubSite ID, support multi-geo.
+   /// </summary>
+   /// <param name="hubSiteId">ID of the HubSite.</param>
+   /// <param name="principals">principals of users to grant rights.</param>
+   /// <param name="grantedRights">The HubSite rights to grant.</param>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public HubSiteProperties GrantHubSiteRightsById(Guid hubSiteId, string[] principals, SPOHubSiteUserRights grantedRights)
+  
+
+  
+
+   /// <summary>
+   /// Revoke HubSite rights from users giving HubSite ID, support multi-geo.
+   /// </summary>
+   /// <param name="hubSiteId">ID of the HubSite.</param>
+   /// <param name="principals">principals of users to revoke rights.</param>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public HubSiteProperties RevokeHubSiteRightsById(Guid hubSiteId, string[] principals)
+   
+
+   /// <summary>
+   /// Reserved for internal use only.
+   /// </summary>
+   /// <returns>SPH site URL</returns>
+   /// <example>
+   /// Get https://contoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetSPHSiteUrl
+   ///
+   /// Bypass tenant store cache:
+   /// Get https://contoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetSPHSiteUrl?bypasscache=true
+   /// </example>
+   // Gets the Company Portal URL
+   [ClientCallableMethod(
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.All,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public string GetSPHSiteUrl()
+ 
+
+   /// <summary>
+   /// Get the home site Ids, url and site title.
+   /// Reserved for internal use only.
+   /// </summary>
+   /// <returns>Home site(company portal) Ids, site title and URL</returns>
+   /// <example>
+   /// Calling the API without quesrystring:
+   ///   Return only siteId, WebId and audiences.
+   ///   Get https://contoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetHomeSitesDetails
+   ///
+   /// Calling the API with query strings:
+   ///   ?bypasscache=true    bypass tenant store cache
+   ///   ?expandDetails=true  call the expensive API with cross geo call to fill siteUrl and site title
+   ///   Get https://contoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetHomeSitesDetails?bypasscache=true&expandDetails=true
+   /// </example>
+   [ClientCallableMethod(
+  OperationType = OperationType.Read,
+  ClientLibraryTargets = ClientLibraryTargets.All,
+  RequiredRight = ResourceRight.GlobalReader)]
+   public List<HomeSitesDetails> GetHomeSitesDetails()
+  
+   /// <summary>
+   /// Add a new home site in tenant admin setting.
+   /// </summary>
+   /// <param name="homeSiteUrl">The home site URL</param>
+   /// <param name="order">The rank order of this home site. The order starts at 1, defaults to end of order if not provided.</param>
+   /// <param name="audiences">The targeting audiences</param>
+   /// <returns>Details about ID, title, URL from the adding home site</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   internal HomeSitesDetails AddHomeSite(string homeSiteUrl, int? order, Guid[] audiences)
+
+
+   /// <summary>
+   /// Update the home site with specific URL for its audiences.
+   /// </summary>
+   /// <param name="homeSiteUrl">The home site URL</param>
+   /// <param name="order">
+   /// The rank order of this home site. The order starts at 1
+   /// Order = null or Order = -1 will not change the position(order) of the home site.
+   /// </param>
+   /// <param name="audiences">The targeting audiences</param>
+   /// <returns>Details about ID, title, URL from the updating home site</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public HomeSitesDetails UpdateHomeSite(string homeSiteUrl, int? order, Guid[] audiences)
+    
+   /// <summary>
+   /// Reorder the rank of all home sites in tenant admin setting.
+   /// </summary>
+   /// <param name="homeSitesSiteIds">All home sites siteId with new order</param>
+   /// <returns>Details about siteId and webId from all home sites in a new order</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public HomeSitesDetails[] ReorderHomeSites(Guid[] homeSitesSiteIds)
+ 
+   /// <summary>
+   /// Reserved for internal use only.
+   /// </summary>
+   /// <param name="sphSiteUrl">URL of the SPH site</param>
+   /// <returns>Status message indicating that the site has been set</returns>
+   // Sets the Company Portal tenant setting to the specified site
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public string SetSPHSite(string sphSiteUrl)
+
+   /// <summary>
+   /// Remove a home site in tenant admin setting.
+   /// </summary>
+   /// <param name="homeSiteUrl">The home site URL</param>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public void RemoveHomeSite(string homeSiteUrl)
+   
+
+   /// <summary>
+   /// Reserved for internal use only.
+   /// </summary>
+   /// <returns>Status message on successful removal</returns>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
+   public string RemoveSPHSite()
+  
+
+   /// <summary>
+   /// This method validates the powershell newly added parameters for multiple home sites.
+   /// If parameters are used when flight is turned off, it throws an SPExperimentalFeatureException
+   /// </summary>
+   /// <param name="hasParameters">boolean representing if cmdlets are using new parameters</param>
+   /// <exception cref="SPExperimentalFeatureException"></exception>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All, IsBeta = true)]
+   internal void ValidateMultipleHomeSitesParameterExists(bool hasParameters)
+  
+
+   /// <summary>
+   /// Get site subscription id
+   /// </summary>
+   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.RESTful, OperationType = OperationType.Read)]
+   public Guid GetSiteSubscriptionId()
+
+
+*/
+}
+export interface ITenant extends _Tenant { }
+export const Tenant = spInvokableFactory<ITenant>(_Tenant);

--- a/packages/sp-admin/tenant.ts
+++ b/packages/sp-admin/tenant.ts
@@ -1,9 +1,28 @@
 // import { body } from "@pnp/queryable";
-import { body } from "@pnp/queryable";
+import { body, BufferParse } from "@pnp/queryable";
 import { _SPInstance, defaultPath, spInvokableFactory, spPost } from "@pnp/sp";
-import { ITenantInfo } from "./types.js";
+import { IRenderListDataParameters } from "@pnp/sp/lists/index.js";
+import { IHubSiteInfo } from "@pnp/sp/hubsites/index.js";
+import {
+    IHomeSitesDetails,
+    IPortalHealthStatus,
+    IPowerAppsEnvironment,
+    ISiteAdministratorsFieldsData,
+    ISiteAdminsInfo,
+    ISiteCreationProps,
+    ISitePropertiesEnumerableFilter,
+    ISiteUserGroupsData,
+    ISPHubSiteCreationInfo,
+    ISPOOperation,
+    ISPOSiteCreationSource,
+    ISPOWebTemplatesInfo,
+    ITenantInfo,
+    ITenantSitePropertiesInfo,
+    IUpdateGroupSiteProperties,
+    SPOHubSiteUserRights,
+} from "./types.js";
 
-@defaultPath("_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant")
+@defaultPath("_api/SPO.Tenant")
 class _Tenant extends _SPInstance<ITenantInfo> {
 
     /**
@@ -24,7 +43,7 @@ class _Tenant extends _SPInstance<ITenantInfo> {
      * @param includeDetail true to include details
      * @returns Returns a site object for the given URL
      */
-    public getSitePropertiesByUrl(url: string, includeDetail = false): Promise<any> {
+    public getSitePropertiesByUrl(url: string, includeDetail = false): Promise<Partial<ITenantSitePropertiesInfo>> {
         return spPost(Tenant(this, "GetSitePropertiesByUrl"), body({
             url,
             includeDetail,
@@ -32,1118 +51,529 @@ class _Tenant extends _SPInstance<ITenantInfo> {
     }
 
     /**
-*    #region Client Callable Methods
-
-
-
-   /// <summary>
-   /// Gets SPOSiteProperties objects for all sites from SharePoint in the tenancy that match the filter expression.
-   /// If the filter is null or empty string, then all the sites are returned.
-   /// </summary>
-   /// <returns>IEnumerable&lt;SPOSiteProperties&gt;</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public SitePropertiesEnumerable GetSitePropertiesFromSharePointByFilters(SitePropertiesEnumerableFilter speFilter)
-   {
-  
-   }
-
-
-
-
-
-   /// <summary>
-   /// Get whether this tenant has valid education license.
-   /// </summary>
-   /// <returns>bool;</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.RESTful, OperationType = OperationType.Read)]
-   public bool HasValidEducationLicense()
-   {
-  
-   }
-
-
-
-
-   /// <summary>
-   /// Queues a site collection for creation with the given properties
-   /// </summary>
-   /// <param name="SiteCreationProperties"> The initial properties for the site which is to be created. </param>
-   /// <returns>Queues a site collection for creation with the given properties</returns>
-   /// <id guid="3c1e5508-b720-4346-b9cb-d374736e613d" />
-   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
-   public SpoOperation CreateSite(SiteCreationProperties siteCreationProperties)
-   {
-  
-   }
-
-   /// <summary>
-   /// Gets all the SPWebTemplates on this Tenant.
-   /// </summary>
-   /// <returns>An SPOWebTemplateCollection containing a SPOWebTemplate information for each template</returns>
-   [ClientCallableMethod(OperationType = OperationType.Read, ClientLibraryTargets = ClientLibraryTargets.All)]
-   public SPOWebTemplateCollection GetSPOTenantAllWebTemplates()
-   {
-  
-   }
-
-   /// <summary>
-   /// Parameters required to be passed based on the <cref>UpdateGroupSitePropertiesType</cref>
-   /// </summary>
-   [ClientCallableType(Name = "UpdateGroupSitePropertiesParameters",
-  ServerTypeId = "{6d8cb9b8-0c8a-11ec-82a8-0242ac130003}",
-  ValueObject = true)]
-   public class UpdateGroupSitePropertiesParameters
-   {
-  [ClientCallableProperty(Name = "storageMaximumLevel")]
-  public Int64 StorageMaximumLevel { get; set; }
-
-  [ClientCallableProperty(Name = "storageWarningLevel")]
-  public Int64 StorageWarningLevel { get; set; }
-
-  public override string ToString()
-  {
- return JsonConvert.SerializeObject(this);
-  }
-   }
-
-   /// <summary>
-   /// Handles updating the properties based on updateType <cref>UpdateGroupSitePropertiesType</cref> of all the sites which are part of the groupId
-   /// </summary>
-   /// <example>
-   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/UpdateGroupSiteProperties
-   ///RequestBody: {"groupId":"<Guid>","siteId":"<Guid>","updateType":"StorageQuota","parameters":{"storageMaximumLevel":<Int>,"storageWarningLevel":<Int>}}
-   /// </example>
-   /// <param name="groupId">Group Id</param>
-   /// <param name="siteId">Site Id</param>
-   /// <param name="updateType">Property which is required to be updated</param>
-   /// <param name="parameters">Params which are required to be passed based on the updateType</param>
-   /// <returns>string denoting the user storage key which can be used by client to pull the async workflow status</returns>
-   [ClientCallableMethod(Name = "UpdateGroupSiteProperties",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   public string UpdateGroupSiteProperties(Guid groupId, Guid siteId, string updateType, UpdateGroupSitePropertiesParameters parameters)
-   {
- 
-   }
-
-   
-   /// <summary>
-   /// Gets all the site collection templates available in SPO for the given UI culture.
-   /// </summary>
-   /// <returns>An SPOWebTemplateCollection for all the site collection templates available in SPO for the given UI culture.</returns>
-   [ClientCallableMethod(
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.All,
-  AllowedReadRoles = new SecurityGroup[] { SecurityGroup.GlobalReader },
-  RequiredRight = ResourceRight.GlobalReader)]
-   public SPOWebTemplateCollection GetSPOAllWebTemplates(string cultureName, int compatibilityLevel)
-   {
- 
-   }
-
-   /// <summary>
-   /// Gets all the SPWebTemplates for site collections on this Tenant
-   /// </summary>
-   /// <returns>An SPOWebTemplateCollection containing a SPOWebTemplate information for each template</returns>
-   [ClientCallableMethod(OperationType = OperationType.Read, ClientLibraryTargets = ClientLibraryTargets.All)]
-   public SPOWebTemplateCollection GetSPOTenantWebTemplates(uint localeId, int compatibilityLevel)
-   {
- 
-   }
-
-   /// <summary>
-   /// Returns the site header logo by site URL.
-   /// </summary>
-   /// <param name="siteUrl"></param>
-   /// <returns>Stream containing the site logo data</returns>
-   [ClientCallableMethod(OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader,
-  IsBeta = true)]
-   public Stream GetSiteThumbnailLogo(string siteUrl)
-   {
- 
-   }
-
-   /// <summary>
-   /// Gets all the SPSiteCreationSources.
-   /// </summary>
-   /// <returns>A list of SPOSiteCreationSource objects, each object is mapped to a SPSiteCreationSource enum</returns>
-   [ClientCallableMethod(
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public IList<SPOSiteCreationSource> GetSPOSiteCreationSources()
-   {
- 
-   }
-
-  
-
-  
-
-   /// <summary>
-   /// Deletes the site to the recycle bin
-   /// </summary>
-   /// <param name="url">URL of the site to be deleted</param>
-   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
-   public SpoOperation RemoveSite(string siteUrl)
-   {
- 
-   }
-
-   /// <summary>
-   /// Gets the health Status of the site from WEX api
-   /// https://constoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetSiteHealthStatus?sourceUrl='https://contoso.sharepoint.com/sites/pwa'
-   /// </summary>
-   [ClientCallableMethodAttribute(Name = "GetSiteHealthStatus",
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   public PortalHealthStatus GetSiteHealthStatus([ClientCallableParameter(Name = "sourceUrl")] String sourceUrl)
-   {
-  
-   }
-
-   /// <summary>
-   /// Performs the Swap operation on the provided sites
-   /// </summary>
-   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
-   public SpoOperation SwapSiteWithSmartGestureOptionForce(string sourceUrl, string targetUrl, string archiveUrl, bool includeSmartGestures, bool force)
-   {
-  
-   }
-
-   /// <summary>
-   /// Performs the Swap operation on the provided sites
-   /// </summary>
-   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
-   public SpoOperation SwapSiteWithSmartGestureOption(string sourceUrl, string targetUrl, string archiveUrl, bool includeSmartGestures)
-   {
-  
-   }
-
-   /// <summary>
-   /// Performs the Swap operation on the provided sites
-   /// </summary>
-   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
-   public SpoOperation SwapSite(string sourceUrl, string targetUrl, string archiveUrl)
-   {
-  
-   }
-
-   
-
-   /// <summary>
-   /// Permanently deletes the site from the recycle bin
-   /// </summary>
-   /// <param name="siteUrl">URL of the site to be deleted</param>
-   /// <returns>operation for the request</returns>
-   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
-   public SpoOperation RemoveDeletedSite(string siteUrl)
-   {
-  
-   }
-
-   /// <summary>
-   /// Permanently deletes the site from the recycle bin
-   /// </summary>
-   /// <param name="siteUrl">URL of the site to be deleted</param>
-   /// <param name="siteId">SiteID of the site to be deleted</param>
-   /// <returns>operation for the request</returns>
-   [ClientCallableMethod(ResourceUsageHints = ResourceUsageHints.LongOperation)]
-   public SpoOperation RemoveDeletedSitePreferId(string siteUrl, Guid siteId)
-   {
- 
-   }
-
-   /// <summary>
-   /// Restores site from deleted state (recycle bin)
-   /// </summary>
-   /// <param name="siteUrl">URL of the site to be restored</param>
-   /// <returns>operation for the request</returns>
-   [ClientCallableMethod]
-   public SpoOperation RestoreDeletedSite(string siteUrl)
-   {
-  
-   }
-
-   /// <summary>
-   /// Restores site from deleted state (recycle bin)
-   /// </summary>
-   /// <param name="siteId">SiteID of the site to be deleted</param>
-   /// <returns>operation for the request</returns>
-   [ClientCallableMethod]
-   public SpoOperation RestoreDeletedSiteById(Guid siteId)
-   {
- 
-   }
-
-   /// <summary>
-   /// Restores site from deleted state (recycle bin)
-   /// </summary>
-   /// <param name="siteUrl">URL of the site to be restored</param>
-   /// <param name="siteId">SiteID of the site to be deleted</param>
-   /// <returns>operation for the request</returns>
-   [ClientCallableMethod]
-   public SpoOperation RestoreDeletedSitePreferId(string siteUrl, Guid siteId)
-   {
- 
-   }
-
-
-   /// <summary>
-   /// A collection of PowerApps environments
-   /// </summary>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.RESTful, OperationType = OperationType.Read)]
-   public ReadOnlyCollection<PowerAppsEnvironment> GetPowerAppsEnvironments()
-   {
-  
-   }
-
-
-   /// <summary>
-   /// Sets the configuration values for the following policy:
-   ///  * Idle session sign out for unmanaged devices.
-   /// </summary>
-   /// <param name="enabled">Boolean indicating if the policy should be enabled.</param>
-   /// <param name="warnAfter">TimeSpan containing the time before warning the user</param>
-   /// <param name="signOutAfter">TimeSpan containing the time before signing out the user.</param>
-   /// <returns>True if the operation succeeds, false otherwise.</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public bool SetIdleSessionSignOutForUnmanagedDevices(Boolean enabled, TimeSpan warnAfter, TimeSpan signOutAfter)
-   {
-  
-   }
-
-   /// <summary>
-   /// Gets the configuration values, as a string, for the following policy:
-   ///  * Idle session sign out for unmanaged devices.
-   /// </summary>
-   /// <remarks>
-   /// The return string is a comma delineated list of the three policy settings.  The policy settings consist of:
-   /// 1. Enabled: true or false
-   /// 2. Warn after: Time until user should be warned in seconds.
-   /// 3. Sign out after: Time until user should be signed out in seconds.
-   /// </remarks>
-   /// <returns>A string indicating the current policy settings.</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All,
-  AllowedWriteRoles = new SecurityGroup[] { SecurityGroup.GlobalReader },
-  RequiredRight = ResourceRight.GlobalReader)]
-   public string GetIdleSessionSignOutForUnmanagedDevices()
-   {
- 
-   }
-
-
-   /// <summary>
-   /// RESTful API to export SPList to CSV file and return file download link.
-   /// </summary>
-   /// <param name="viewXml">XML of the export view </param>
-   /// <example>
-   /// POST _api/SPO.Tenant/ExportToCSV
-   /// </example>
-   [ClientCallableMethodAttribute(Name = "ExportToCSV",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   public string ExportToCSV(string viewXml)
-   {
- 
-   }
-
-   /// <summary>
-   /// RESTful API to export SPList to CSV file and return file download link.
-   /// </summary>
-   /// <param name="viewXml">XML of the export view </param>
-   /// <param name="listName">Name of Admin SPList to be exported</param>
-   /// <example>
-   /// POST _api/SPO.Tenant/ExportAdminListToCSV
-   /// </example>
-   [ClientCallableMethodAttribute(Name = "ExportAdminListToCSV",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   public string ExportAdminListToCSV(string viewXml, string listName)
-   {
- 
-   }
-
-   /// <summary>
-   /// RESTful API to set site's user groups
-   /// </summary>
-   /// <param name="SiteUserGroupsData.siteId">The guid of site.</param>
-   /// <param name="SiteUserGroupsData.SiteUserGroups">The array of site's user groups that will replace the current user groups.</param>
-   /// <example>
-   /// POST https://prepspo-admin.spgrid.com/_api/SPO.Tenant/SetSiteUserGroups
-   /// </example>
-   [ClientCallableMethodAttribute(Name = "SetSiteUserGroups",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  IsBeta = true)]
-   public void SetSiteUserGroups(
-  [ClientCallableParameter(Name = "siteUserGroupsData")]
-  SiteUserGroupsData siteUserGroupsData)
-   {
-  
-   }
-
-   /// <summary>
-   /// RESTful API to set site administrators
-   /// </summary>
-   /// <param name="siteAdministratorsFieldsData.siteId">The guid of site.</param>
-   /// <param name="siteAdministratorsFieldsData.siteAdministrators">The array of site's administrators that will replace current administrators.</param>
-   /// <example>
-   /// POST https://prepspo-admin.spgrid.com/_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant/SetSiteAdministrators
-   /// with payload:
-   /// {
-   ///"siteAdministratorsFieldsData":
-   ///{
-   ///    "siteId":"1ae2d477-3e17-4dba-9f30-f1cc8bc594b9",
-   ///    "siteAdministrators":["User1@prepspo.msolctp-int.com","User2@prepspo.msolctp-int.com"]
-   ///}
-   /// }
-   /// </example>
-   [ClientCallableMethodAttribute(Name = "SetSiteAdministrators",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  IsBeta = true)]
-   public void SetSiteAdministrators(
-  [ClientCallableParameter(Name = "siteAdministratorsFieldsData")]
-  SiteAdministratorsFieldsData siteAdministratorsFieldsData)
-   {
-  
-   }
-
-   /// <summary>
-   /// RESTful API to check tenant licenses.
-   /// Full list of licenses are defined in TenantConstants class in %SRCROOT%\sporel\sts\stsom\Administration\SPOnlineProvisioning\SPTenantOMConstants.cs
-   /// </summary>
-   /// <param name="licenses">The licenses to check on tenant.</param>
-   /// <example>
-   /// GET https://prepspo-admin.spgrid.com/_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant/CheckTenantLicenses?licenses=["SPO_Standard","SPO_Project"]
-   ///It returns true for onebox.
-   /// </example>
-   /// <returns>True if and only if tenant has all licenses in parameter</returns>
-   [ClientCallableMethodAttribute(OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  IsBeta = true)]
-   public bool CheckTenantLicenses(
-  [ClientCallableParameter(Name = "licenses")]
-  string[] licenses)
-   {
-  
-   }
-
-   /// <summary>
-   /// RESTful API to check tenant intune license
-   /// </summary>
-   /// <example>
-   /// GET https://contoso-admin.sharepoint.com/_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant/CheckTenantIntuneLicense
-   /// </example>
-   /// <returns>True if and only if tenant has Intune license</returns>
-   [ClientCallableMethodAttribute(Name = "CheckTenantIntuneLicense",
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  IsBeta = true,
-  AllowedReadRoles = new SecurityGroup[] { SecurityGroup.GlobalReader },
-  RequiredRight = ResourceRight.GlobalReader)]
-   public bool CheckTenantIntuneLicense()
-   {
- 
-   }
-
-  
-
-    /// <summary>
-   /// RESTful API to get site's administrators' names and emails
-   /// </summary>
-   /// <param name="siteId">The guid of site.</param>
-   /// <example>
-   /// GET https://prepspo-admin.spgrid.com/_api/Microsoft.Online.SharePoint.TenantAdministration.Tenant/GetSiteAdministrators
-   /// with query param ?siteId=1ae2d477-3e17-4dba-9f30-f1cc8bc594b9   
-   /// </example>
-   [ClientCallableMethodAttribute(Name = "GetSiteAdministrators",
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  IsBeta = true,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public List<SiteAdministratorsInfo> GetSiteAdministrators(
-  Guid siteId)
-   {
- 
-   }
-
-   /// <summary>
-   /// RESTful API for getting Compatible Information Barrier Segments.
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetTenantAllOrCompatibleIBSegments
-   /// Request Body : {"segments":["9049237F-BF11-4G6B-433A-7A44A9BDDE42"]}
-   /// If the input guids are null, we return all the IB Segments associated to a tenant.
-   /// </summary>
-   [ClientCallableMethod(Name = "GetTenantAllOrCompatibleIBSegments",
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public IBSegmentInfo[] GetTenantAllOrCompatibleIBSegments(Guid[] segments)
-   {
-  
-   }
-
-   /// <summary>
-   /// RESTful API for getting SiteStream for  Information Barrier Segments.
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderIBSegmentListDataAsStream
-   /// Request Body : {"parameters":{"ViewXml":"<View></View>","DatesInUtc":true},segments:{"998D8D85-9D92-40BC-BBBC-4B85F13E0FB5"},overrideParameters:""}
-   /// </summary>
-   [ClientCallableMethod(Name = "RenderIBSegmentListDataAsStream",
-   OperationType = OperationType.Read,
-   ClientLibraryTargets = ClientLibraryTargets.RESTful,
-   RequiredRight = ResourceRight.GlobalReader)]
-   public Stream RenderIBSegmentListDataAsStream(
-  SPRenderListDataParameters parameters, Guid[] segments,
-  [ClientCallableParameter(RESTfulParameterSource = RESTfulParameterSource.Path)] SPRenderListDataOverrideParameters overrideParameters)
-   {
-  
-   }
-
-   /// <summary>
-   /// RESTful API for getting Information Barrier Segments Filter Options.
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderIBSegmentListFilterData
-   /// Request Body : {"parameters":{"ViewXml":"<View></View>"}}
-   /// </summary>
-   [ClientCallableMethod(Name = "RenderIBSegmentListFilterData",
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public Stream RenderIBSegmentListFilterData(
-  SPRenderListFilterDataParameters parameters)
-   {
-  
-   }
-
-   
-
-   /// <summary>
-   /// Renders Tenant Admin SPList Data after filtering based on the groupId the site belongs to
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderFilteredAdminListDataByGroupId
-   /// <param name="groupId">Group Id the sites belong to</param>
-   /// <returns>Filtered Tenant Admin list Data as stream</returns>
-   /// Request Body : {"groupId": Guid value}
-   /// </summary>
-   [ClientCallableMethod(Name = "RenderFilteredAdminListDataByGroupId",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public Stream RenderFilteredAdminListDataByGroupId(Guid groupId)
-   {
- 
-   }
-
-   /// <summary>
-   /// Renders Tenant Admin SPList Data
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderAdminListData
-   /// <param name="parameters">parameters for list data rendering</param>
-   /// <param name="overrideParameters">overrideParameter for list data renderings</param>
-   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
-   /// <returns>Tenant Admin list Data as stream</returns>
-   /// Request Body : {"parameters": {"ViewXml":"<View></View>","DatesInUtc":true}}
-   /// </summary>
-   [ClientCallableMethod(Name = "RenderAdminListData",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public Stream RenderAdminListData(SPRenderListDataParameters parameters, SPRenderListDataOverrideParameters overrideParameters, string listName)
-   {
-
-   }
-
-   /// <summary>
-   /// Renders Tenant Admin SPList Data after filtering based on filter conditions
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderFilteredAdminListData
-   /// <param name="parameters">parameters for list data rendering</param>
-   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
-   /// <returns>Filtered Tenant Admin list Data as stream</returns>
-   /// Request Body : {"parameters": {"ViewXml":"<View></View>"}}
-   /// </summary>
-   [ClientCallableMethod(Name = "RenderFilteredAdminListData",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public Stream RenderFilteredAdminListData(SPRenderListFilterDataParameters parameters, string listName)
-   {
- 
-   }
-
-   /// <summary>
-   /// Gets SPList total item Count
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetSPListItemCount
-   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
-   /// <returns>List item count</returns>
-   /// </summary>
-   [ClientCallableMethod(Name = "GetSPListItemCount",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public int GetSPListItemCount(string listName)
-   {
-    
-   }
-
-   /// <summary>
-   /// Gets the SpList Root Folder Properties
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetSPListRootFolderProperties
-   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
-   /// <returns>List Root Fodler Properties</returns>
-   /// </summary>
-   [ClientCallableMethod(Name = "GetSPListRootFolderProperties",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   internal SPPropertyValues GetSPListRootFolderProperties(string listName)
-   {
-  
-   }
-
-   /// <summary>
-   /// Gets all the views from Tenant Admin Sites List
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetAdminListViews
-   /// <returns>All the avaiable Views from the List</returns>
-   /// </summary>
-   [ClientCallableMethod(Name = "GetAdminListViews",
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public SPViewCollection GetAdminListViews()
-   {
-
-   }
-
-   /// <summary>
-   /// Gets a view by DisplayName from SPList
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetViewByDisplayName
-   /// <param name="viewName">View Name</param>
-   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
-   /// <returns>Returns SPView for given View Name</returns>
-   /// Request Body : {"viewName": "ExportView"}}
-   /// </summary>
-   [ClientCallableMethod(Name = "GetViewByDisplayName",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public SPView GetViewByDisplayName(string viewName, string listName)
-   {
-
-
-   /// <summary>
-   /// Sets Default View in SPList
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/SetDefaultView
-   /// <param name="viewId">View Id</param>
-   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
-   /// Request Body : {"viewId" : "6450c68f-e2f6-461e-ac68-dc1f9f9400eb"}
-   /// </summary>
-   [ClientCallableMethod(Name = "SetDefaultView",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public void SetDefaultView(string viewId, string listName)
-   {
-   }
-
-   /// <summary>
-   /// Removes item from SPList
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RemoveSPListItem
-   /// <param name="listItemId">List Item Id</param>
-   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
-   /// Request Body : {"listItemId" : 1}
-   /// </summary>
-   [ClientCallableMethod(Name = "RemoveSPListItem",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public void RemoveSPListItem(int listItemId, string listName)
-   {
-  
-   }
-
-   /// <summary>
-   /// Add a new view in SPList
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/AddTenantAdminListView
-   /// <param name="parameters">Creation Information for the New View</param>
-   /// <returns>Returns SPView of the Newly Added View</returns>
-   /// Request Body : {"parameters": {"Title": "NewView"}}
-   /// </summary>
-   [ClientCallableMethod(Name = "AddTenantAdminListView",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   internal SPView AddTenantAdminListView(SPViewCreationInformation parameters)
-   {
-  this.rbacManager.AssertAccess(Resources.SharePointSites, Permissions.Update);
-  return SPOTenantAdminSPListUtilities<SPListAsAggregatedStore>.AddTenantAdminListView(siteSubscription, parameters);
-   }
-
-   /// <summary>
-   /// Deletes a view in SPList
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RemoveTenantAdminListView
-   /// <param name="viewId">View Id</param>
-   /// Request Body : {"viewId": "6450c68f-e2f6-461e-ac68-dc1f9f9400eb"}
-   /// </summary>
-   [ClientCallableMethod(Name = "RemoveTenantAdminListView",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   internal void RemoveTenantAdminListView(string viewId)
-   {
-
-   }
-
-   /// <summary>
-   /// Saves a view in SPList
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/UpdateTenantAdminListView
-   /// <param name="viewId">View Id</param>
-   /// <param name="viewXml">View XML</param>
-   /// Request Body : {"viewId" : "6450c68f-e2f6-461e-ac68-dc1f9f9400eb", "viewXml":"<View></View>"}
-   /// </summary>
-   [ClientCallableMethod(Name = "UpdateTenantAdminListView",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public void UpdateTenantAdminListView(string viewId, string viewXml)
-   {
-  
-   }
-
-   /// <summary>
-   /// Updates SPField Values in Tenant Admin Lists
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/UpdateTenantAdminListItem
-   /// <param name="listItemId">List Item Id</param>
-   /// <param name="columnValues">List of TenantAdminList Column Values</param>
-   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
-   /// Request Body : {"listItemId" : 1, "columnValues": [{columnName: "State", columnValue: "1"}]}
-   /// </summary>
-   [ClientCallableMethod(Name = "UpdateTenantAdminListItem",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   internal void UpdateTenantAdminListItem(int listItemId, List<TenantAdminListItemColumnValue> columnValues, string listName)
-   {
- 
-   }
-
-   /// <summary>
-   /// Renders Recent Admin Actions SPList data as Stream
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderRecentAdminActions
-   /// <param name="parameters">parameters for list data rendering</param>
-   /// <param name="overrideParameters">overrideParameter for list data renderings</param>
-   /// <returns>Recent Admin Actions SPList Data as stream</returns>
-   /// Request Body : {"parameters": {"ViewXml":"<View></View>","DatesInUtc":true}}
-   /// </summary>
-   [ClientCallableMethod(Name = "RenderRecentAdminActions",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   internal Stream RenderRecentAdminActions(SPRenderListDataParameters parameters, SPRenderListDataOverrideParameters overrideParameters)
-   {
-
-
-   /// <summary>
-   /// Adds Recent Admin Action in Tenant RecentActions Store
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/AddRecentAdminAction
-   /// <param name="payload">RecentAdminAction value object</param>
-   /// <returns>Recent Admin Actions SPListItem</returns>
-   /// Request Body : {"payload": {"adminActionSource": "SharePointAdminCenter", "adminActionStatus": "Success", "key": "123"}}
-   /// </summary>
-   [ClientCallableMethod(Name = "AddRecentAdminAction",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   internal SPListItem AddRecentAdminAction(TenantAdminRecentActionPayload payload)
-   
-   }
-
-   /// <summary>
-   /// Get list of Policy Automation executions from SPList
-   /// </summary>
-   /// <remarks>
-   /// Returns stream of execution history item list filtered based on ViewXML passed in "parameters" object in payload.
-   /// Single Policy Execution History can also be fetched by passing Policy Id in WHERE clause of ViewXML.
-   /// <example>
-   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderPolicyExecutionsHistory
-   ///Request Body : {"parameters":{"ViewXml":"<View></View>","DatesInUtc":true}
-   ///Response Body: {
-   ///  "Row": [
-   ///    {
-   ///  "ExecutionId": "{DC3F043E-FF25-4D29-B857-CC241190E7D6}",
-   ///  "PolicyId": "{1F4062E3-8D68-4CFE-8646-97978E7BD473}",
-   ///  "PolicyVersion": "1",
-   ///  "RetryCount": "0",
-   ///  "Status": "Scheduled",
-   ///  "WorkItemId": "{0E59F3CA-59AB-4C0D-80F3-257E314657C2}",
-   ///  "WorkItemType": "Parent"
-   ///    }
-   ///  ]
-   ///}
-   /// </example>
-   /// </remarks>
-   [ClientCallableMethod(Name = "RenderPolicyExecutionsHistory",
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public Stream RenderPolicyExecutionsHistory(SPRenderListDataParameters parameters, SPRenderListDataOverrideParameters overrideParameters)
-   {
+     * Gets SPOSiteProperties objects for all sites from SharePoint in the tenancy that match the filter expression
+     *
+     * @param speFilter If the filter is null or empty string, then all the sites are returned
+     */
+    public getSitePropertiesFromSharePointByFilters(speFilter: (Partial<ISitePropertiesEnumerableFilter> | null | "")): Promise<Partial<ITenantSitePropertiesInfo>[]> {
+        return spPost(Tenant(this, "GetSitePropertiesFromSharePointByFilters"), body({
+            speFilter,
+        }));
     }
-   }
 
-   /// <summary>
-   /// Get list of Policy Automation definitions from SPList
-   /// </summary>
-   /// <remarks>
-   /// <example>
-   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/RenderPolicyDefinitionList
-   ///Request Body : {"parameters": {"ViewXml":"<View><ViewFields><FieldRef Name=\"PolicyId\"/><FieldRef Name=\"PolicyVersion\"/><FieldRef Name=\"PolicyState\"/><FieldRef Name=\"PolicyType\"/><FieldRef Name=\"PolicyTemplate\"/><FieldRef Name=\"CreatedBy\"/>
-   ///<FieldRef Name=\"PolicyCreatedTime\"/><FieldRef Name=\"UpdatedBy\"/><FieldRef Name=\"LastUpdatedTime\"/><FieldRef Name=\"EnabledTime\"/><FieldRef Name=\"DisabledTime\"/><FieldRef Name=\"PolicyDeletedTime\"/><FieldRef Name=\"PolicyFrequencyValue\"/>
-   ///<FieldRef Name=\"PolicyFrequencyUnit\"/><FieldRef Name=\"PolicyDefinition\"/></ViewFields><RowLimit Paged=\"TRUE\">30</RowLimit></View>","DatesInUtc":true}}
-   /// </example>
-   /// <param name="parameters">parameters for list data rendering</param>
-   /// <param name="overrideParameters">overrideParameter for list data renderings</param>
-   /// <returns>Policy definition SPList Data as stream</returns>
-   /// </remarks>
-   [ClientCallableMethod(Name = "RenderPolicyDefinitionList",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   internal Stream RenderPolicyDefinitionList(SPRenderListDataParameters parameters, SPRenderListDataOverrideParameters overrideParameters)
-   {
-  
-   /// <summary>
-   /// Creates Policy Automation definition record in SPList and create a work item
-   /// using Policy Automation Work item scheduler.
-   /// </summary>
-   /// <remarks>
-   /// <example>
-   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/CreatePolicyDefinition
-   ///Request Body : {
-   ///    "policyInputParameters": {
-   ///    "policyId": "4b986c69-1d8b-4c59-bf08-6310a687b35e",
-   ///    "policyCustomName": "inactivePolicy",
-   ///    "policyType": "OOTB",
-   ///    "policyTemplate": "Inactive",
-   ///    "policyFrequencyValue": "1",
-   ///    "policyFrequencyUnit": "WEEKLY"}
-   /// }
-   /// </example>
-   /// <param name="tenantAdminPolicyDefinition">TenantAdmin Policy Definition</param>
-   /// <returns>Policy Definition SPListItem</returns>
-   /// </remarks>
-   [ClientCallableMethod(Name = "CreatePolicyDefinition",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   internal SPListItem CreatePolicyDefinition(CreatePolicyRequest policyInputParameters)
-   {
-  
-   /// <summary>
-   /// Update Policy Automation definition instance in SPList.
-   /// In case of no change in schedule, only update definition SPList with a new version.
-   /// In case of schedule change, mark existing execution history as abandoned, and
-   /// create a new work item along with new execution history.
-   /// We can enable & disable any policy using this API.
-   /// </summary>
-   /// <remarks>
-   /// <example>
-   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/UpdatePolicyDefinition
-   ///Request Body : {"policyDefinition": {"policyId": "guid", "policyVersion": "1", "customPolicyName": "inactivePolicy"}, "updateType":"Enable"}
-   /// </example>
-   /// <param name="policyDefinition">Policy Definition</param>
-   /// </remarks>
-   [ClientCallableMethod(Name = "UpdatePolicyDefinition",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   internal void UpdatePolicyDefinition(int itemId, CreatePolicyRequest policyInputParameters)
-   {
-  
-   /// <summary>
-   /// Soft delete Policy by marking policy definition status as Deleted in SPList and mark existing
-   /// execution history as abandoned
-   /// </summary>
-   /// <remarks>
-   /// <example>
-   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/DeletePolicyDefinition
-   ///RequestBody: {"policyDefinition": {"policyId": "guid", "policyVersion": "1", "policyState": "Deleted","customPolicyName": "inactivePolicy"}, "updateType":"Deleted"}
-   /// </example>
-   /// <param name="policyDefinition">PolicyDefinition</param>
-   /// </remarks>
-   [ClientCallableMethod(Name = "DeletePolicyDefinition",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   internal void DeletePolicyDefinition(int itemId)
-   {
+    /**
+     * Get whether this tenant has valid education license
+     */
+    public hasValidEducationLicense(): Promise<boolean> {
+        return spPost(Tenant(this, "HasValidEducationLicense"));
+    }
 
+    /**
+     * Queues a site collection for creation with the given properties
+     *
+     * @param siteCreationProperties The initial properties for the site which is to be created
+     * @returns Queues a site collection for creation with the given properties
+     */
+    public createSite(siteCreationProperties: ISiteCreationProps): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "CreateSite"), body({
+            siteCreationProperties,
+        }));
+    }
 
-   /// <summary>
-   /// Sends a sample mail to site owner for given site URL.
-   /// </summary>
-   /// <remarks>
-   /// Note: To be used only for testing PolicyAutomationEmailNotificationUtility class.
-   /// Should be removed after integration testing is successful.
-   ///POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/SendEmail
-   /// </remarks>
-   [ClientCallableMethod(Name = "SendEmail",
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   public bool SendEmail(string siteUrl)
-   {
- 
-   }
+    /**
+     * Gets all the SPWebTemplates on this Tenant
+     *
+     * @returns An SPOWebTemplateCollection containing a SPOWebTemplate information for each template
+     */
+    public getSPOTenantAllWebTemplates(): Promise<ISPOWebTemplatesInfo> {
+        return spPost(Tenant(this, "GetSPOTenantAllWebTemplates"));
+    }
 
-   /// <summary>
-   /// Adds an item in Tenant Admin List with given Column Values
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/AddTenantAdminListItem
-   /// <param name="columnValues">List of TenantAdminList Column Values to be added in the ListItem</param>
-   /// <param name="listName">TenantAdmin SPList on which the list item will be added</param>
-   /// Request Body :
-   /// {
-   ///"columnValues":
-   ///    [{
-   ///    columnName: "PUID_KEY",
-   ///    columnValue: "admin@contoso.com:SPONewAdminCenterVisited"
-   ///    }]
-   ///"listName": "DO_NOT_DELETE_SPLIST_TENANTADMIN_USERSTORAGE"
-   /// }
-   /// </summary>
-   /// <remarks>
-   /// This API is intended to update only SPLists other than below Sites Lists in Tenant Admin Site
-   /// 1. <see cref="AllSitesAggregatedStore"/>
-   /// 2. <see cref="SPListAsAggregatedStore"/>
-   /// Calls to Update to Sites Lists is not supported
-   /// </remarks>
-   [ClientCallableMethod(Name = "AddTenantAdminListItem",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   internal SPListItem AddTenantAdminListItem(List<TenantAdminListItemColumnValue> columnValues, string listName)
-   {
-  
-   }
+    /**
+     * Handles updating the properties based on updateType of all the sites which are part of the groupId
+     *
+     * @param groupId Group Id
+     * @param siteId Site Id
+     * @param updateType Property which is required to be updated
+     * @param UpdateGroupSitePropertiesParameters
+     * @param parameters Params which are required to be passed based on the updateType
+     * @returns string denoting the user storage key which can be used by client to pull the async workflow status
+     */
+    // eslint-disable-next-line max-len
+    public updateGroupSiteProperties(groupId: string, siteId: string, updateType: "Unknow" | "StorageQuota", parameters: Partial<IUpdateGroupSiteProperties> = {}): Promise<string> {
+        return spPost(Tenant(this, "UpdateGroupSiteProperties"), body({
+            groupId,
+            siteId,
+            updateType,
+            parameters,
+        }));
+    }
 
-   /// <summary>
-   /// Gets sites based on States from Tenant Admin Sites List
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetSitesByState
-   /// <param name="states">State Values</param>
-   /// <returns>List Items Collection</returns>
-   /// Request Body : {"states" : [1,2,3]}
-   /// </summary>
-   [ClientCallableMethod(Name = "GetSitesByState",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public SPListItemCollection GetSitesByState(List<int> states)
-   {
- 
-   }
+    /**
+     * Gets all the site collection templates available in SPO for the given UI culture
+     *
+     * @returns An SPOWebTemplateCollection for all the site collection templates available in SPO for the given UI culture.
+     */
+    public getSPOAllWebTemplates(cultureName: string, compatibilityLevel: number): Promise<ISPOWebTemplatesInfo> {
+        return spPost(Tenant(this, "GetSPOAllWebTemplates"), body({
+            cultureName,
+            compatibilityLevel,
+        }));
+    }
 
-   /// <summary>
-   /// Gets List Item based on filters from Tenant Admin Sites List
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/GetFilteredSPListItems
-   /// <param name="columnName">Column Name</param>
-   /// <param name="columnValue">Column Value</param>
-   /// <param name="listName">Optional List Name. By Default Aggregated TenantAdmin SPList will be used</param>
-   /// <returns>List Items Collection</returns>
-   /// Request Body : { "columnName": "siteUrl", "columnValue"  "https://contoso-admin.sharepoint.com"}
-   /// </summary>
-   [ClientCallableMethod(Name = "GetFilteredSPListItems",
-  OperationType = OperationType.Default,
-  ClientLibraryTargets = ClientLibraryTargets.RESTful,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public SPListItemCollection GetFilteredSPListItems(string columnName, string columnValue, string listName)
-   {
+    /**
+     * Gets all the SPWebTemplates for site collections on this Tenant
+     *
+     * @returns An SPOWebTemplateCollection for all the site collection templates available in SPO for the given UI culture.
+     */
+    public getSPOTenantWebTemplates(localeId: number, compatibilityLevel: number): Promise<ISPOWebTemplatesInfo> {
+        return spPost(Tenant(this, "GetSPOTenantWebTemplates"), body({
+            localeId,
+            compatibilityLevel,
+        }));
+    }
 
-   }
+    /**
+     * Returns the site header logo by site URL.
+     *
+     * @param siteUrl Absolute URL to the site
+     * @returns Stream containing the site logo data
+     */
+    public getSiteThumbnailLogo(siteUrl: string): Promise<ArrayBuffer> {
+        return spPost(Tenant(this, "GetSiteThumbnailLogo").using(BufferParse()), body({
+            siteUrl,
+        }));
+    }
 
-   /// <summary>
-   /// Given a list of IBSegment GUIDS and IBMode(Optional), sets them to the site irrespective of the previous segments (and group if it is a group site) and also sets the ibMode.
-   /// Only ODB, non-teams-connected group site, non-group site can be updated.
-   /// POST https://contoso-admin.sharepoint.com/_api/SPO.Tenant/SetIBSegmentsOnSite
-   /// Request Body : {"siteId":"54f6c9b4-abdb-4b23-a71d-239c0d2208f7", "segments":["9049237F-BF11-4G6B-433A-7A44A9BDDE42"] , "ibMode" : "Explicit"}
-   /// Returns the IB Mode for the site in case of successful updation of site.
-   /// </summary>
-   /// <param name="siteId"> siteId of the site on which segments will be applied.</param>
-   /// <param name="segments"> Comma-separated array of final IB Segment GUIDS which will be applied on the site.</param>
-   /// <param name="ibMode"> ibMode is an optional value.</param>
-   [ClientCallableMethod(Name = "SetIBSegmentsOnSite",
-    OperationType = OperationType.Default,
-    ClientLibraryTargets = ClientLibraryTargets.RESTful)]
-   public string SetIBSegmentsOnSite(Guid siteId, Guid[] segments, string ibMode = null)
-   {
- 
+    /**
+     * Gets all the SPSiteCreationSources
+     */
+    public getSPOSiteCreationSources(): Promise<ISPOSiteCreationSource[]> {
+        return spPost(Tenant(this, "GetSPOSiteCreationSources"));
+    }
 
-   /// <summary>
-   /// Registers the site with the specified URL as a HubSite.
-   /// </summary>
-   /// <param name="siteUrl">The URL of the site to make into a HubSite.</param>
-   /// <returns>The properties of the new HubSite.</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public HubSiteProperties RegisterHubSite(string siteUrl)
-  
+    /**
+     * Deletes the site to the recycle bin
+     *
+     * @param siteUrl Absolute url of the site to remove
+     */
+    public removeSite(siteUrl: string): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "RemoveSite"), body({
+            siteUrl,
+        }));
+    }
 
-   /// <summary>
-   /// Registers the site with the specified URL as a HubSite.
-   /// </summary>
-   /// <param name="siteUrl">The URL of the site to make into a HubSite.</param>
-   /// <param name="creationInformation">Information used to create this HubSite.
-   /// If not specified, some default properties will be set instead.</param>
-   /// <returns>The properties of the new HubSite.</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public HubSiteProperties RegisterHubSiteWithCreationInformation(string siteUrl, SPHubSiteCreationInformation creationInformation)
+    /**
+     * Gets the health Status of the site
+     *
+     * @param sourceUrl Absolute url of the site
+     */
+    public getSiteHealthStatus(sourceUrl: string): Promise<IPortalHealthStatus> {
+        return spPost(Tenant(this, "GetSiteHealthStatus"), body({
+            sourceUrl,
+        }));
+    }
 
+    /**
+     * Performs the Swap operation on the provided sites
+     */
+    public swapSiteWithSmartGestureOptionForce(sourceUrl: string, targetUrl: string, archiveUrl: string, includeSmartGestures: boolean, force: boolean): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "SwapSiteWithSmartGestureOptionForce"), body({
+            sourceUrl,
+            targetUrl,
+            archiveUrl,
+            includeSmartGestures,
+            force,
+        }));
+    }
 
+    /**
+     * Performs the Swap operation on the provided sites
+     */
+    public swapSiteWithSmartGestureOption(sourceUrl: string, targetUrl: string, archiveUrl: string, includeSmartGestures: boolean): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "SwapSiteWithSmartGestureOption"), body({
+            sourceUrl,
+            targetUrl,
+            archiveUrl,
+            includeSmartGestures,
+        }));
+    }
 
-   /// <summary>
-   /// Makes the specified site no longer a HubSite and removes it from the list of HubSites.
-   /// The site is not deleted by this operation; it is merely removed from the list of available HubSites.
-   /// </summary>
-   /// <param name="siteUrl">The URL of the site which should no longer be a HubSite.</param>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public void UnregisterHubSite(string siteUrl)
-   
+    /**
+     * Performs the Swap operation on the provided sites
+     */
+    public swapSite(sourceUrl: string, targetUrl: string, archiveUrl: string): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "SwapSite"), body({
+            sourceUrl,
+            targetUrl,
+            archiveUrl,
+        }));
+    }
 
-   /// <summary>
-   /// Connects a site to a HubSite using hub site id, support multi-geo.
-   /// </summary>
-   /// <param name="siteUrl">URL of the site to connect to the HubSite.</param>
-   /// <param name="hubSiteId">Guid of the HubSite ID.</param>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public void ConnectSiteToHubSiteById(string siteUrl, Guid hubSiteId)
-   
-   /// <summary>
-   /// Grant HubSite rights to users giving HubSite ID, support multi-geo.
-   /// </summary>
-   /// <param name="hubSiteId">ID of the HubSite.</param>
-   /// <param name="principals">principals of users to grant rights.</param>
-   /// <param name="grantedRights">The HubSite rights to grant.</param>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public HubSiteProperties GrantHubSiteRightsById(Guid hubSiteId, string[] principals, SPOHubSiteUserRights grantedRights)
-  
+    /**
+     * Permanently deletes the site from the recycle bin
+     *
+     * @param siteUrl URL of the site to be deleted
+     */
+    public removeDeletedSite(siteUrl: string): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "RemoveDeletedSite"), body({
+            siteUrl,
+        }));
+    }
 
-  
+    /**
+     * Permanently deletes the site from the recycle bin
+     *
+     * @param siteUrl URL of the site to be deleted
+     * @param siteId SiteID of the site to be deleted
+     */
+    public removeDeletedSitePreferId(siteUrl: string, siteId: string): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "RemoveDeletedSitePreferId"), body({
+            siteUrl,
+            siteId,
+        }));
+    }
 
-   /// <summary>
-   /// Revoke HubSite rights from users giving HubSite ID, support multi-geo.
-   /// </summary>
-   /// <param name="hubSiteId">ID of the HubSite.</param>
-   /// <param name="principals">principals of users to revoke rights.</param>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public HubSiteProperties RevokeHubSiteRightsById(Guid hubSiteId, string[] principals)
-   
+    /**
+     * Restores site from deleted state (recycle bin)
+     *
+     * @param siteUrl URL of the site to be restored
+     */
+    public restoreDeletedSite(siteUrl: string): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "RestoreDeletedSite"), body({
+            siteUrl,
+        }));
+    }
 
-   /// <summary>
-   /// Reserved for internal use only.
-   /// </summary>
-   /// <returns>SPH site URL</returns>
-   /// <example>
-   /// Get https://contoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetSPHSiteUrl
-   ///
-   /// Bypass tenant store cache:
-   /// Get https://contoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetSPHSiteUrl?bypasscache=true
-   /// </example>
-   // Gets the Company Portal URL
-   [ClientCallableMethod(
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.All,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public string GetSPHSiteUrl()
- 
+    /**
+     * Restores site from deleted state (recycle bin)
+     *
+     * @param siteId SiteID of the site to be restored
+     */
+    public restoreDeletedSiteById(siteId: string): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "RestoreDeletedSiteById"), body({
+            siteId,
+        }));
+    }
 
-   /// <summary>
-   /// Get the home site Ids, url and site title.
-   /// Reserved for internal use only.
-   /// </summary>
-   /// <returns>Home site(company portal) Ids, site title and URL</returns>
-   /// <example>
-   /// Calling the API without quesrystring:
-   ///   Return only siteId, WebId and audiences.
-   ///   Get https://contoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetHomeSitesDetails
-   ///
-   /// Calling the API with query strings:
-   ///   ?bypasscache=true    bypass tenant store cache
-   ///   ?expandDetails=true  call the expensive API with cross geo call to fill siteUrl and site title
-   ///   Get https://contoso-admin.sharepoint.com/_api/SPOInternalUseOnly.Tenant/GetHomeSitesDetails?bypasscache=true&expandDetails=true
-   /// </example>
-   [ClientCallableMethod(
-  OperationType = OperationType.Read,
-  ClientLibraryTargets = ClientLibraryTargets.All,
-  RequiredRight = ResourceRight.GlobalReader)]
-   public List<HomeSitesDetails> GetHomeSitesDetails()
-  
-   /// <summary>
-   /// Add a new home site in tenant admin setting.
-   /// </summary>
-   /// <param name="homeSiteUrl">The home site URL</param>
-   /// <param name="order">The rank order of this home site. The order starts at 1, defaults to end of order if not provided.</param>
-   /// <param name="audiences">The targeting audiences</param>
-   /// <returns>Details about ID, title, URL from the adding home site</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   internal HomeSitesDetails AddHomeSite(string homeSiteUrl, int? order, Guid[] audiences)
+    /**
+     * Restores site from deleted state (recycle bin)
+     *
+     * @param siteUrl URL of the site to be restored
+     * @param siteId SiteID of the site to be deleted
+     */
+    public restoreDeletedSitePreferId(siteUrl: string, siteId: string): Promise<ISPOOperation> {
+        return spPost(Tenant(this, "RestoreDeletedSitePreferId"), body({
+            siteUrl,
+            siteId,
+        }));
+    }
 
+    /**
+     * A collection of PowerApps environments
+     */
+    public getPowerAppsEnvironments(): Promise<IPowerAppsEnvironment[]> {
+        return spPost(Tenant(this, "GetPowerAppsEnvironments"));
+    }
 
-   /// <summary>
-   /// Update the home site with specific URL for its audiences.
-   /// </summary>
-   /// <param name="homeSiteUrl">The home site URL</param>
-   /// <param name="order">
-   /// The rank order of this home site. The order starts at 1
-   /// Order = null or Order = -1 will not change the position(order) of the home site.
-   /// </param>
-   /// <param name="audiences">The targeting audiences</param>
-   /// <returns>Details about ID, title, URL from the updating home site</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public HomeSitesDetails UpdateHomeSite(string homeSiteUrl, int? order, Guid[] audiences)
-    
-   /// <summary>
-   /// Reorder the rank of all home sites in tenant admin setting.
-   /// </summary>
-   /// <param name="homeSitesSiteIds">All home sites siteId with new order</param>
-   /// <returns>Details about siteId and webId from all home sites in a new order</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public HomeSitesDetails[] ReorderHomeSites(Guid[] homeSitesSiteIds)
- 
-   /// <summary>
-   /// Reserved for internal use only.
-   /// </summary>
-   /// <param name="sphSiteUrl">URL of the SPH site</param>
-   /// <returns>Status message indicating that the site has been set</returns>
-   // Sets the Company Portal tenant setting to the specified site
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public string SetSPHSite(string sphSiteUrl)
+    /**
+     * Sets the configuration values for Idle session sign out for unmanaged devices
+     * @param enabled Boolean indicating if the policy should be enabled
+     * @param warnAfter TimeSpan containing the time before warning the user
+     * @param signOutAfter TimeSpan containing the time before signing out the user
+     * @returns True if the operation succeeds, false otherwise
+     */
+    public setIdleSessionSignOutForUnmanagedDevices(enabled: boolean, warnAfter: string, signOutAfter: string): Promise<IPowerAppsEnvironment[]> {
+        return spPost(Tenant(this, "SetIdleSessionSignOutForUnmanagedDevices"), body({
+            enabled,
+            warnAfter,
+            signOutAfter,
+        }));
+    }
 
-   /// <summary>
-   /// Remove a home site in tenant admin setting.
-   /// </summary>
-   /// <param name="homeSiteUrl">The home site URL</param>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public void RemoveHomeSite(string homeSiteUrl)
-   
+    /**
+     * Gets the configuration values for Idle session sign out for unmanaged devices
+     */
+    public getIdleSessionSignOutForUnmanagedDevices(): Promise<string> {
+        return spPost(Tenant(this, "GetIdleSessionSignOutForUnmanagedDevices"));
+    }
 
-   /// <summary>
-   /// Reserved for internal use only.
-   /// </summary>
-   /// <returns>Status message on successful removal</returns>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All)]
-   public string RemoveSPHSite()
-  
+    /**
+     * RESTful API to export SPList to CSV file and return file download link
+     *
+     * @param viewXml XML of the export view
+     */
+    public exportToCSV(viewXml: string): Promise<string> {
+        return spPost(Tenant(this, "ExportToCSV"), body({
+            viewXml,
+        }));
+    }
 
-   /// <summary>
-   /// This method validates the powershell newly added parameters for multiple home sites.
-   /// If parameters are used when flight is turned off, it throws an SPExperimentalFeatureException
-   /// </summary>
-   /// <param name="hasParameters">boolean representing if cmdlets are using new parameters</param>
-   /// <exception cref="SPExperimentalFeatureException"></exception>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.All, IsBeta = true)]
-   internal void ValidateMultipleHomeSitesParameterExists(bool hasParameters)
-  
+    /**
+     * RESTful API to export SPList to CSV file and return file download link
+     *
+     * @param viewXml XML of the export view
+     * @param listName Name of Admin SPList to be exported
+     */
+    public exportAdminListToCSV(viewXml: string, listName: string): Promise<string> {
+        return spPost(Tenant(this, "ExportAdminListToCSV"), body({
+            viewXml,
+            listName,
+        }));
+    }
 
-   /// <summary>
-   /// Get site subscription id
-   /// </summary>
-   [ClientCallableMethod(ClientLibraryTargets = ClientLibraryTargets.RESTful, OperationType = OperationType.Read)]
-   public Guid GetSiteSubscriptionId()
+    /**
+     * RESTful API to set site's user groups
+     *
+     */
+    public setSiteUserGroups(siteUserGroupsData: ISiteUserGroupsData): Promise<void> {
+        return spPost(Tenant(this, "SetSiteUserGroups"), body({
+            siteUserGroupsData,
+        }));
+    }
 
+    /**
+     * RESTful API to set site administrators
+     */
+    public setSiteAdministrators(siteAdministratorsFieldsData: ISiteAdministratorsFieldsData): Promise<void> {
+        return spPost(Tenant(this, "SetSiteAdministrators"), body({
+            siteAdministratorsFieldsData,
+        }));
+    }
 
-*/
+    /**
+     * RESTful API to check tenant licenses.
+     *
+     * @returns True if and only if tenant has all licenses in parameter
+     */
+    public checkTenantLicenses(licenses: string[]): Promise<boolean> {
+        return spPost(Tenant(this, "CheckTenantLicenses"), body({
+            licenses,
+        }));
+    }
+
+    /**
+     * RESTful API to check tenant intune license
+     */
+    public checkTenantIntuneLicense(): Promise<boolean> {
+        return spPost(Tenant(this, "CheckTenantIntuneLicense"));
+    }
+
+    /**
+     * Gets a list of site administrators for the given site
+     *
+     * @param siteId guid site id
+     * @returns Array of site admins
+     */
+    public getSiteAdministrators(siteId: string): Promise<ISiteAdminsInfo[]> {
+        return spPost(Tenant(this, "GetSiteAdministrators"), body({
+            siteId,
+        }));
+    }
+
+    /**
+     * Renders Tenant Admin SPList Data after filtering based on the groupId the site belongs to
+     *
+     * @param groupId Group Id the sites belong to
+     */
+    public renderFilteredAdminListDataByGroupId(groupId: string): Promise<ArrayBuffer> {
+        return spPost(Tenant(this, "RenderFilteredAdminListDataByGroupId").using(BufferParse()), body({
+            groupId,
+        }));
+    }
+
+    /**
+     * Renders Tenant Admin SPList Data
+     */
+    public renderAdminListData(listName: string, parameters: IRenderListDataParameters, overrideParameters: any = null): Promise<ArrayBuffer> {
+        return spPost(Tenant(this, "RenderAdminListData").using(BufferParse()), body({
+            parameters,
+            overrideParameters,
+            listName,
+        }));
+    }
+
+    /**
+     * Renders Tenant Admin SPList Data after filtering based on filter conditions
+     */
+    public renderFilteredAdminListData(listName: string, parameters: IRenderListDataParameters): Promise<ArrayBuffer> {
+        return spPost(Tenant(this, "RenderFilteredAdminListData").using(BufferParse()), body({
+            parameters,
+            listName,
+        }));
+    }
+
+    /**
+     * Gets SPList total item Count
+     *
+     * @param listName Optional List Name. By Default Aggregated TenantAdmin SPList will be used
+     * @returns List item count
+     */
+    public getSPListItemCount(listName?: string): Promise<number> {
+        return spPost(Tenant(this, "GetSPListItemCount"), body({
+            listName,
+        }));
+    }
+
+    /**
+     * Registers the site with the specified URL as a HubSite
+     *
+     * @param siteUrl The URL of the site to make into a HubSite
+     * @returns The properties of the new HubSite
+     */
+    public registerHubSite(siteUrl: string): Promise<IHubSiteInfo> {
+        return spPost(Tenant(this, "RegisterHubSite"), body({
+            siteUrl,
+        }));
+    }
+
+    /**
+     * Registers the site with the specified URL as a HubSite
+     *
+     * @param siteUrl The URL of the site to make into a HubSite
+     * @param creationInformation Information used to create this HubSite, If not specified, some default properties will be set instead
+     * @returns The properties of the new HubSite
+     */
+    public registerHubSiteWithCreationInformation(siteUrl: string, creationInformation: Partial<ISPHubSiteCreationInfo> = null): Promise<IHubSiteInfo> {
+        return spPost(Tenant(this, "RegisterHubSiteWithCreationInformation"), body({
+            siteUrl,
+            creationInformation,
+        }));
+    }
+
+    /**
+     * Makes the specified site no longer a HubSite and removes it from the list of HubSites The site is not deleted by this operation;
+     * it is merely removed from the list of available HubSites
+     *
+     * @param siteUrl The URL of the site which should no longer be a HubSite
+     */
+    public unregisterHubSite(siteUrl: string): Promise<IHubSiteInfo> {
+        return spPost(Tenant(this, "UnregisterHubSite"), body({
+            siteUrl,
+        }));
+    }
+
+    /**
+     * Connects a site to a HubSite using hub site id, support multi-geo
+     *
+     * @param siteUrl URL of the site to connect to the HubSite
+     * @param hubSiteId Guid of the HubSite ID
+     */
+    public connectSiteToHubSiteById(siteUrl: string, hubSiteId: string): Promise<void> {
+        return spPost(Tenant(this, "ConnectSiteToHubSiteById"), body({
+            siteUrl,
+            hubSiteId,
+        }));
+    }
+
+    /**
+     * Grant HubSite rights to users giving HubSite ID, support multi-geo
+     *
+     * @param hubSiteId ID of the HubSite
+     * @param principals principals of users to grant rights
+     * @param grantedRights The HubSite rights to grant
+     */
+    public grantHubSiteRightsById(hubSiteId: string, principals: string[], grantedRights: SPOHubSiteUserRights): Promise<IHubSiteInfo> {
+        return spPost(Tenant(this, "GrantHubSiteRightsById"), body({
+            hubSiteId,
+            principals,
+            grantedRights,
+        }));
+    }
+
+    /**
+     * Revoke HubSite rights from users giving HubSite ID, support multi-geo
+     *
+     * @param hubSiteId ID of the HubSite
+     * @param principals principals of users to revoke rights
+     */
+    public revokeHubSiteRightsById(hubSiteId: string, principals: string[]): Promise<IHubSiteInfo> {
+        return spPost(Tenant(this, "RevokeHubSiteRightsById"), body({
+            hubSiteId,
+            principals,
+        }));
+    }
+
+    /**
+     * Get the home site Ids, url and site title
+     *
+     * @param bypasscache bypass tenant store cache
+     * @param expandDetails call the expensive API with cross geo call to fill siteUrl and site title
+     */
+    public getHomeSitesDetails(bypasscache = false, expandDetails = false): Promise<IHomeSitesDetails> {
+
+        const q = Tenant(this, "GetHomeSitesDetails");
+        if (bypasscache) {
+            q.query.set("bypasscache", "true");
+        }
+        if (expandDetails) {
+            q.query.set("expandDetails", "true");
+        }
+
+        return spPost(q);
+    }
+
+    /**
+     * Add a new home site in tenant admin setting
+     *
+     * @param homeSiteUrl The home site URL
+     * @param audiences The targeting audiences
+     * @param order The rank order of this home site. The order starts at 1, defaults to end of order if not provided
+     * @returns Details about ID, title, URL from the adding home site
+     */
+    public addHomeSite(homeSiteUrl: string, audiences: string[], order?: number): Promise<IHomeSitesDetails> {
+        return spPost(Tenant(this, "AddHomeSite"), body({
+            homeSiteUrl,
+            audiences,
+            order,
+        }));
+    }
+
+    /**
+     * Update the home site with specific URL for its audiences
+     *
+     * @param homeSiteUrl The home site URL
+     * @param audiences The targeting audiences
+     * @param order The rank order of this home site. The order starts at 1, defaults to end of order if not provided
+     * @returns Details about ID, title, URL from the adding home site
+     */
+    public updateHomeSite(homeSiteUrl: string, audiences: string[], order?: number): Promise<IHomeSitesDetails> {
+        return spPost(Tenant(this, "UpdateHomeSite"), body({
+            homeSiteUrl,
+            audiences,
+            order,
+        }));
+    }
+
+    /**
+     * Reorder the rank of all home sites in tenant admin setting
+     *
+     * @param homeSitesSiteIds All home sites siteId with new order
+     * @returns Details about siteId and webId from all home sites in a new order
+     */
+    public reorderHomeSites(homeSitesSiteIds: string[]): Promise<IHomeSitesDetails[]> {
+        return spPost(Tenant(this, "ReorderHomeSites"), body({
+            homeSitesSiteIds,
+        }));
+    }
+
+    /**
+     * Remove a home site in tenant admin setting
+     *
+     * @param homeSiteUrl The home site URL
+     */
+    public removeHomeSite(homeSiteUrl: string): Promise<void> {
+        return spPost(Tenant(this, "RemoveHomeSite"), body({
+            homeSiteUrl,
+        }));
+    }
+
+    /**
+     * Get site subscription id
+     */
+    public getSiteSubscriptionId(): Promise<string> {
+        return spPost(Tenant(this, "GetSiteSubscriptionId"));
+    }
 }
 export interface ITenant extends _Tenant { }
 export const Tenant = spInvokableFactory<ITenant>(_Tenant);

--- a/packages/sp-admin/tsconfig.json
+++ b/packages/sp-admin/tsconfig.json
@@ -3,7 +3,6 @@
     "include": [
         "./**/*.ts",
         "../core/**/*.ts",
-        "../logging/**/*.ts",
         "../queryable/**/*.ts",
         "./presets/**/*.ts"
     ],

--- a/packages/sp-admin/tsconfig.json
+++ b/packages/sp-admin/tsconfig.json
@@ -13,6 +13,9 @@
         },
         {
             "path": "../queryable/tsconfig.json"
+        },
+        {
+            "path": "../sp/tsconfig.json"
         }
     ]
 }

--- a/packages/sp-admin/types.ts
+++ b/packages/sp-admin/types.ts
@@ -70,7 +70,7 @@ export interface IOffice365TenantInfo {
      */
     ShowEveryoneExceptExternalUsersClaim: boolean;
     /**
-     *  Gets a Boolean value that specifies whether EveryoneExceptExternalUsers is allowed in people picker dialogs for private group site
+     * Gets a Boolean value that specifies whether EveryoneExceptExternalUsers is allowed in people picker dialogs for private group site
      */
     AllowEveryoneExceptExternalUsersClaimInPrivateSite: boolean;
     /**
@@ -396,7 +396,7 @@ export interface IOffice365TenantInfo {
      */
     EnableAzureADB2BIntegration: boolean;
     /**
-     *  Gets a value to specify whether Add To OneDrive is disabled
+     * Gets a value to specify whether Add To OneDrive is disabled
      */
     DisableAddToOneDrive: boolean;
     /**
@@ -814,4 +814,724 @@ export interface IGroupCreationParams {
     Owners: string[];
     CreationOptions: string[];
     Classification: string;
+}
+
+export interface ITenantSitePropertiesInfo {
+    /**
+     * The Url of the site
+     */
+    Url: string;
+    /**
+     * The status of the site
+     */
+    Status: string;
+    /**
+     * The TimeZone ID
+     */
+    TimeZoneId: number;
+    /**
+     * The last time content was modified on the site
+     */
+    LastContentModifiedDate: string;
+    /**
+     * A description of the lock issue
+     */
+    LockIssue: string;
+    /**
+     * The average usuage of resources by user code
+     */
+    AverageResourceUsage: number;
+    /**
+     * The current usuage of resources by user code
+     */
+    CurrentResourceUsage: number;
+    /**
+     * The current usage of storage for the site
+     */
+    StorageUsage: number;
+    /**
+     * The number of SPWebs in the site
+     */
+    WebsCount: number;
+    /**
+     * The compatibility leve of this site
+     */
+    CompatibilityLevel: number;
+    /**
+     * The email address of the site owner
+     */
+    OwnerEmail: string;
+    /**
+     * The HubSiteId of the HubSite this site is associated with
+     */
+    HubSiteId: string;
+    /**
+     * Whether or not this site is a HubSite
+     */
+    IsHubSite: boolean;
+    /**
+     * The GroupId of the group this site is associated with
+     */
+    RelatedGroupId: string;
+    /**
+     * The GroupId of the site
+     */
+    GroupId: string;
+    /**
+     * Site's description
+     */
+    Description: string;
+    /**
+     * Gets if the site is connected to a team in Microsoft Teams
+     */
+    IsTeamsConnected: boolean;
+    /**
+     * Gets if the site is connected to a team channel in Microsoft Teams
+     */
+    IsTeamsChannelConnected: boolean;
+    /**
+     * When the site is connected to a team channel in Microsoft Teams, gets the type of channel the site is connected to
+     */
+    TeamsChannelType: TeamsChannelTypeValue;
+    /**
+     * The Storage Quota
+     */
+    StorageMaximumLevel: number;
+    /**
+     * The warning level for storage usage
+     */
+    StorageWarningLevel: number;
+    /**
+     * The storage quota type for the site
+     */
+    StorageQuotaType: string;
+    /**
+     * Title Translations for the site
+     */
+    TitleTranslations: string[];
+    /**
+     * The maximum amount of machine resources that can be used by user code
+     */
+    UserCodeMaximumLevel: number;
+    /**
+     * The amount of machine resources used by user code which triggers warning
+     */
+    UserCodeWarningLevel: number;
+    /**
+     * The site's title
+     */
+    Title: string;
+    /**
+     * Flag that indicates a site has Holds
+     */
+    HasHolds: boolean;
+    /**
+     * The decoded login name of the site owner
+     */
+    Owner: string;
+    /**
+     * The encoded login name of the site owner Example: i:0#.f|membership|admin@thing.domain.net
+     */
+    OwnerLoginName: string;
+    /**
+     * The login name of the group owner
+     */
+    GroupOwnerLoginName: string;
+    /**
+     * Whether group owner is site admin
+     */
+    IsGroupOwnerSiteAdmin: boolean;
+    /**
+     * Whether update secondary admin during setting primary admin
+     */
+    SetOwnerWithoutUpdatingSecondaryAdmin: boolean;
+    /**
+     * The site owner name
+     */
+    OwnerName: string;
+    /**
+     * The site's web template name
+     */
+    Template: string;
+    /**
+     * The Locale ID of the site
+     */
+    Lcid: number;
+    /**
+     * Flag that indicates is a site supports self-service upgrade
+     */
+    AllowSelfServiceUpgrade: boolean;
+    /**
+     * A string representing the lock state of the site
+     */
+    LockState: string;
+    /**
+     * Determines whether the site has AddAndCustomizePages denied
+     */
+    DenyAddAndCustomizePages: DenyAddAndCustomizePagesStatus;
+    /**
+     * Determines whether the site is resticted to a specific geo location
+     */
+    RestrictedToRegion: RestrictedToRegion;
+    /**
+     * Determines whether PWA is enabled for the site
+     */
+    PWAEnabled: PWAEnabledStatus;
+    /**
+     *
+     */
+    SharingCapability: SharingCapabilities;
+    /**
+     *
+     */
+    SiteDefinedSharingCapability: SharingCapabilities;
+    /**
+     * Indicates whether company wide sharing links are disabled in all the webs of this site
+     */
+    DisableCompanyWideSharingLinks: CompanyWideSharingLinksPolicy;
+    /**
+     * Flag that controls allowing members to search guest users in the directory
+     */
+    ShowPeoplePickerSuggestionsForGuestUsers: boolean;
+    /**
+     * Indicates what this site's domain restriction mode is
+     */
+    SharingDomainRestrictionMode: SharingDomainRestrictionModes;
+    /**
+     * A list of allowed domain names for this site
+     */
+    SharingAllowedDomainList: string;
+    /**
+     * A list of blocked domain names for this site
+     */
+    SharingBlockedDomainList: string;
+    /**
+     * Flag that controls access from devices that aren't compliant or joined to a domain to have limited access (web-only, without the Download, Print, and Sync commands)
+     */
+    ConditionalAccessPolicy: SPOConditionalAccessPolicyType;
+    /**
+     * Indicates whether end users can download non-viewable files (e.g. zip)
+     */
+    AllowDownloadingNonWebViewableFiles: boolean;
+    /**
+     * Specifies what files can be viewed when ConditionalAccessPolicy is set to AllowLimitedAccess
+     */
+    LimitedAccessFileType: SPOLimitedAccessFileType;
+    /**
+     * Indicates whether WAC files should be open in Edit mode.
+     */
+    AllowEditing: boolean;
+    /**
+     * The Guid of an Information Protection label
+     */
+    SensitivityLabel: string;
+    /**
+     * The Guid of an Information Protection label (2)
+     */
+    SensitivityLabel2: string;
+    /**
+     * Indicates whether app views are disabled in all the webs of this site
+     */
+    DisableAppViews: AppViewsPolicy;
+    /**
+     * Indicates whether flows are disabled in all the webs of this site
+     */
+    DisableFlows: FlowsPolicy;
+    /**
+     * Gets the authentication context strength for this site for (deprecated, use AuthenticationContextName)
+     */
+    AuthContextStrength: string;
+    /**
+     * Gets the authentication context for this site for all the webs
+     */
+    AuthenticationContextName: string;
+    /**
+     * Whether comments on site pages are disabled or not
+     */
+    CommentsOnSitePagesDisabled: boolean;
+    /**
+     * Whether social bar on site pages is enabled or not
+     */
+    SocialBarOnSitePagesDisabled: boolean;
+    /**
+     * The default link type for this site
+     */
+    DefaultSharingLinkType: SharingLinkType;
+    /**
+     * The default link permission for this site
+     */
+    DefaultLinkPermission: SharingPermissionType;
+    /**
+     *
+     */
+    BlockDownloadLinksFileType: BlockDownloadLinksFileTypes;
+    /**
+     *
+     */
+    OverrideBlockUserInfoVisibility: SiteUserInfoVisibilityPolicyValue;
+    /**
+     * The default link to existing access for this site
+     */
+    DefaultLinkToExistingAccess: boolean;
+    /**
+     * This is to reset default link to existing access for this site. After resetting, the value will be default (false) or respect the higher level value
+     */
+    DefaultLinkToExistingAccessReset: boolean;
+    /**
+     *
+     */
+    AnonymousLinkExpirationInDays: number;
+    /**
+     *
+     */
+    OverrideTenantAnonymousLinkExpirationPolicy: boolean;
+    /**
+     *
+     */
+    ExternalUserExpirationInDays: number;
+    /**
+     *
+     */
+    OverrideTenantExternalUserExpirationPolicy: boolean;
+    /**
+     *
+     */
+    SharingLockDownEnabled: boolean;
+    /**
+     *
+     */
+    SharingLockDownCanBeCleared: boolean;
+    /**
+     * The collaboration type for fluid
+     */
+    LoopSharingCapability: SharingCapabilities;
+    /**
+     * Boolean whether collaboration type for fluid can superseed that on partition level
+     */
+    LoopOverrideSharingCapability: boolean;
+    /**
+     * Default share link scope for fluid
+     */
+    LoopDefaultSharingLinkScope: boolean;
+    /**
+     * Default share link role for fluid
+     */
+    LoopDefaultSharingLinkRole: number;
+    /**
+     * Gets request files link enabled
+     */
+    RequestFilesLinkEnabled: boolean;
+    /**
+     * Gets request files link expiration days
+     */
+    RequestFilesLinkExpirationInDays: number;
+    /**
+     * Gets the IB segment GUIDs
+     */
+    IBSegments: string[];
+    /**
+     * IBMode
+     */
+    IBMode: string;
+    /**
+     * Gets the media transcription policy
+     */
+    MediaTranscription: MediaTranscriptionPolicyType;
+    /**
+     * Gets the Block download policy flag
+     */
+    BlockDownloadPolicy: boolean;
+    /**
+     * Gets the Block download policy enforced Microsoft365 group GUIDs
+     */
+    BlockDownloadMicrosoft365GroupIds: string[];
+    /**
+     * Gets the Microsoft365 group GUIDs that are excluded from Block download policy
+     */
+    ExcludedBlockDownloadGroupIds: string[];
+    /**
+     * Gets the Read only access policy flag
+     */
+    ReadOnlyAccessPolicy: boolean;
+    /**
+     * Gets the Read only access for unmanaged devices policy flag
+     */
+    ReadOnlyForUnmanagedDevices: boolean;
+}
+
+export enum SpoSiteLockState {
+    Unlock,
+    NoAdditions,
+    ReadOnly,
+    NoAccess,
+}
+
+export enum TeamsChannelTypeValue {
+    None = 0,
+    PrivateChannel = 1,
+    SharedChannel = 2,
+    StandardChannel = 3,
+}
+
+export enum DenyAddAndCustomizePagesStatus {
+    Unknown,
+    Disabled,
+    Enabled,
+}
+
+export enum RestrictedToRegion {
+    NoRestriction,
+    BlockMoveOnly,
+    BlockFull,
+    Unknown,
+}
+
+export enum PWAEnabledStatus {
+    Unknown,
+    Disabled,
+    Enabled
+}
+
+export enum CompanyWideSharingLinksPolicy {
+    Unknown = 0,
+    Disabled = 1,
+    NotDisabled = 2,
+}
+
+export enum AppViewsPolicy {
+    Unknown = 0,
+    Disabled = 1,
+    NotDisabled = 2,
+}
+
+export enum FlowsPolicy {
+    Unknown = 0,
+    Disabled = 1,
+    NotDisabled = 2,
+}
+
+export enum SharingPermissionType {
+    None,
+    View,
+    Edit,
+}
+
+export enum SiteUserInfoVisibilityPolicyValue {
+    OrganizationDefault = 0,
+    ApplyToNoUsers = 1,
+    ApplyToGuestAndExternalUsers = 2,
+    ApplyToInternalUsers = 3,
+    ApplyToAllUsers = 4,
+}
+
+export interface ITenantInfo {
+    /**
+    * Storage quota that is available for all sites in the tenant
+    */
+    StorageQuota: number;
+    /**
+    * Storage quota that is allocated for all sites in the tenant
+    */
+    StorageQuotaAllocated: number;
+    /**
+    * The resource quota for the tenant
+    */
+    ResourceQuota: number;
+    /**
+    * The resource quota allocated to all sites in the tenant
+    */
+    ResourceQuotaAllocated: number;
+    /**
+    * Determines which compatibility range is available for new
+    * site collections.
+    */
+    CompatibilityRange: string;
+    /**
+    * When a site in the tenancy is locked it is redirected to this Url.
+    */
+    NoAccessRedirectUrl: string;
+    /**
+    * The tenant's root site url
+    */
+    RootSiteUrl: string;
+    /**
+    * Get status of feature sync client restriction allowed
+    */
+    IsUnmanagedSyncClientRestrictionFlightEnabled: boolean;
+    /**
+    * Get/Set sync client restrictions
+    */
+    IsUnmanagedSyncClientForTenantRestricted: boolean;
+    /**
+    * Get/Set sync client trusted domain guids
+    */
+    AllowedDomainListForSyncClient: string[];
+    /**
+    * Get/Set whether Mac clients should be blocked from sync
+    */
+    BlockMacSync: boolean;
+    /**
+    * Get/Set whether to hide the sync button on OneDrive for Business sites
+    */
+    HideSyncButtonOnODB: boolean;
+    /**
+    * Get/Set whether the sync button should use the Next-Generation Sync Client on OneDrive for Business sites
+    */
+    ShowNGSCDialogForSyncOnODB: boolean;
+    /**
+    * Get/Set whether Nucleus Sync should be disabled for Lists
+    */
+    DisableListSync: boolean;
+    /**
+    * Get/Set whether Groove clients should be blocked
+    */
+    OptOutOfGrooveBlock: boolean;
+    /**
+    * Get/Set whether Groove clients should be soft blocked
+    */
+    OptOutOfGrooveSoftBlock: boolean;
+    /**
+    * Get/Set excluded file extensions for sync client
+    */
+    ExcludedFileExtensionsForSyncClient: string[];
+    /**
+    * Gets or sets a value to specify whether Public CDN feature is enabled or disabled for the tenant.
+    */
+    PublicCdnEnabled: boolean;
+    /**
+    * Gets or sets a value to specify what file types can be exposed through Public CDN.
+    */
+    PublicCdnAllowedFileTypes: string;
+    /**
+    * Gets a list of the Public CDN origins.
+    */
+    PublicCdnOrigins: string[];
+    /**
+    * Get/Set whether Open In Desktop should be enabled
+    */
+    ShowOpenInDesktopOptionForSyncedFiles: boolean;
+    /**
+     *
+     */
+    IsMnAFlightEnabled: boolean;
+    /**
+     *
+     */
+    PermissiveBrowserFileHandlingOverride: boolean;
+    /**
+     *
+     */
+    DisallowInfectedFileDownload: boolean;
+    /**
+    * Disable sync client report problem dialog
+    */
+    DisableReportProblemDialog: boolean;
+    /**
+     *
+     */
+    SpecialCharactersStateInFileFolderNames: SpecialCharactersState;
+    /**
+    * Whether comments on site pages are disabled or not.
+    */
+    CommentsOnSitePagesDisabled: boolean;
+    /**
+    * Whether comments on files are disabled or not.
+    */
+    CommentsOnFilesDisabled: boolean;
+    /**
+    * Whether comments on list items are disabled or not.
+    */
+    CommentsOnListItemsDisabled: boolean;
+    /**
+    * Whether viewers commenting on media items is disabled or not.
+    */
+    ViewersCanCommentOnMediaDisabled: boolean;
+    /**
+    * Whether social bar on site pages is enabled or not.
+    */
+    SocialBarOnSitePagesDisabled: boolean;
+    /**
+    * Gets or sets the MarkNewFilesSensitiveByDefault property
+    */
+    MarkNewFilesSensitiveByDefault: SensitiveByDefaultState;
+    /**
+    * Gets or sets the BlockSendLabelMismatchEmail property
+    */
+    BlockSendLabelMismatchEmail: boolean;
+    /**
+    * Gets or sets the LabelMismatchEmailHelpLink property
+    */
+    LabelMismatchEmailHelpLink: string;
+    /**
+     *
+     */
+    EnabledFlightAllowAADB2BSkipCheckingOTP: boolean;
+    /**
+    * Determines whether Hashed Proof Token IP Binding is enabled.
+    */
+    ReduceTempTokenLifetimeEnabled: boolean;
+    /**
+    * Determines the grace period for Hashed Proof Tokens from an IP address that doesn't match the
+    * IP address in the token, when the IP policy is not enabled and IP Binding is enabled.
+    */
+    ReduceTempTokenLifetimeValue: number;
+
+
+    /**
+     * rest of props from selecting *
+     */
+    AIBuilderDefaultPowerAppsEnvironment: string;
+    AIBuilderEnabled: boolean;
+    AIBuilderSiteListFileName: string;
+    AllowAnonymousMeetingParticipantsToAccessWhiteboards: number;
+    AllowCommentsTextOnEmailEnabled: boolean;
+    AllowDownloadingNonWebViewableFiles: boolean;
+    AllowEditing: boolean;
+    AllowEveryoneExceptExternalUsersClaimInPrivateSite: boolean;
+    AllowGuestUserShareToUsersNotInSiteCollection: boolean;
+    AllowLimitedAccessOnUnmanagedDevices: boolean;
+    AllowOverrideForBlockUserInfoVisibility: boolean;
+    AllowSelectSGsInODBListInTenant: boolean | null;
+    AnyoneLinkTrackUsers: boolean;
+    ApplyAppEnforcedRestrictionsToAdHocRecipients: boolean;
+    AuthContextResilienceMode: number;
+    BccExternalSharingInvitations: boolean;
+    BccExternalSharingInvitationsList: string[];
+    BlockAccessOnUnmanagedDevices: boolean;
+    BlockDownloadLinksFileType: number;
+    BlockDownloadOfAllFilesForGuests: boolean;
+    BlockDownloadOfAllFilesOnUnmanagedDevices: boolean;
+    BlockDownloadOfViewableFilesForGuests: boolean;
+    BlockDownloadOfViewableFilesOnUnmanagedDevices: boolean;
+    BlockUserInfoVisibility: string;
+    BlockUserInfoVisibilityInOneDrive: number;
+    BlockUserInfoVisibilityInSharePoint: number;
+    ConditionalAccessPolicy: number;
+    ConditionalAccessPolicyErrorHelpLink: string;
+    ContentTypeSyncSiteTemplatesList: string[];
+    CoreLoopDefaultSharingLinkRole: number;
+    CoreLoopDefaultSharingLinkScope: number;
+    CoreLoopSharingCapability: number;
+    CoreRequestFilesLinkEnabled: boolean;
+    CoreRequestFilesLinkExpirationInDays: number;
+    CoreSharingCapability: number;
+    CustomizedExternalSharingServiceUrl: string;
+    DefaultContentCenterSite: string;
+    DefaultLinkPermission: number;
+    DefaultODBMode: string;
+    DefaultSharingLinkType: number;
+    DisableAddToOneDrive: boolean;
+    DisableBackToClassic: boolean;
+    DisableCustomAppAuthentication: boolean;
+    DisabledModernListTemplateIds: string[];
+    DisabledWebPartIds: string[];
+    DisableOutlookPSTVersionTrimming: boolean;
+    DisablePersonalListCreation: boolean;
+    DisableSpacesActivation: boolean;
+    DisplayNamesOfFileViewers: boolean;
+    DisplayNamesOfFileViewersInSpo: boolean;
+    DisplayStartASiteOption: boolean;
+    EmailAttestationEnabled: boolean;
+    EmailAttestationReAuthDays: number;
+    EmailAttestationRequired: boolean;
+    EnableAIPIntegration: boolean;
+    EnableAutoNewsDigest: boolean;
+    EnableAzureADB2BIntegration: boolean;
+    EnableGuestSignInAcceleration: boolean;
+    EnableMinimumVersionRequirement: boolean;
+    EnableMipSiteLabel: boolean;
+    EnablePromotedFileHandlers: boolean;
+    ExternalServicesEnabled: boolean;
+    ExternalUserExpirationRequired: boolean;
+    ExternalUserExpireInDays: number;
+    FileAnonymousLinkType: number;
+    FilePickerExternalImageSearchEnabled: boolean;
+    FolderAnonymousLinkType: number;
+    GuestSharingGroupAllowListInTenant: string;
+    GuestSharingGroupAllowListInTenantByPrincipalIdentity: any;
+    HasAdminCompletedCUConfiguration: boolean;
+    HasIntelligentContentServicesCapability: boolean;
+    HasTopicExperiencesCapability: boolean;
+    HideSyncButtonOnDocLib: boolean;
+    IBImplicitGroupBased: boolean;
+    ImageTaggingOption: number;
+    IncludeAtAGlanceInShareEmails: boolean;
+    InformationBarriersSuspension: boolean;
+    IPAddressAllowList: string;
+    IPAddressEnforcement: boolean;
+    IPAddressWACTokenLifetime: number;
+    IsAppBarTemporarilyDisabled: boolean;
+    IsCollabMeetingNotesFluidEnabled: boolean;
+    IsFluidEnabled: boolean;
+    IsHubSitesMultiGeoFlightEnabled: boolean;
+    IsLoopEnabled: boolean;
+    IsMultiGeo: boolean;
+    IsMultipleHomeSitesFlightEnabled: boolean;
+    IsWBFluidEnabled: boolean;
+    LegacyAuthProtocolsEnabled: boolean;
+    LimitedAccessFileType: number;
+    MachineLearningCaptureEnabled: boolean;
+    MediaTranscription: number;
+    MobileFriendlyUrlEnabledInTenant: boolean;
+    NotificationsInOneDriveForBusinessEnabled: boolean;
+    NotificationsInSharePointEnabled: boolean;
+    NotifyOwnersWhenInvitationsAccepted: boolean;
+    NotifyOwnersWhenItemsReshared: boolean;
+    ODBAccessRequests: number;
+    ODBMembersCanShare: number;
+    ODBSharingCapability: number;
+    OfficeClientADALDisabled: boolean;
+    OneDriveForGuestsEnabled: boolean;
+    OneDriveLoopDefaultSharingLinkRole: number;
+    OneDriveLoopDefaultSharingLinkScope: number;
+    OneDriveLoopSharingCapability: number;
+    OneDriveRequestFilesLinkEnabled: boolean;
+    OneDriveRequestFilesLinkExpirationInDays: number;
+    OneDriveStorageQuota: string;
+    OrgNewsSiteUrl: string;
+    OrphanedPersonalSitesRetentionPeriod: number;
+    OwnerAnonymousNotification: boolean;
+    PreventExternalUsersFromResharing: boolean;
+    ProvisionSharedWithEveryoneFolder: boolean;
+    RequireAcceptingAccountMatchInvitedAccount: boolean;
+    RequireAnonymousLinksExpireInDays: number;
+    RestrictedOneDriveLicense: boolean;
+    SearchResolveExactEmailOrUPN: boolean;
+    SharingAllowedDomainList: string[];
+    SharingBlockedDomainList: string[];
+    SharingCapability: number;
+    SharingDomainRestrictionMode: number;
+    ShowAllUsersClaim: boolean;
+    ShowEveryoneClaim: boolean;
+    ShowEveryoneExceptExternalUsersClaim: boolean;
+    ShowPeoplePickerGroupSuggestionsForIB: boolean;
+    ShowPeoplePickerSuggestionsForGuestUsers: boolean;
+    SignInAccelerationDomain: string;
+    StartASiteFormUrl: string;
+    StopNew2010Workflows: boolean;
+    StopNew2013Workflows: boolean;
+    StreamLaunchConfig: number;
+    StreamLaunchConfigLastUpdated: string;
+    StreamLaunchConfigUpdateCount: number;
+    SyncAadB2BManagementPolicy: boolean;
+    SyncPrivacyProfileProperties: boolean;
+    UseFindPeopleInPeoplePicker: boolean;
+    UsePersistentCookiesForExplorerView: boolean;
+    UserVoiceForFeedbackEnabled: boolean;
+    ViewInFileExplorerEnabled: boolean;
+    WhoCanShareAllowListInTenant: string;
+    WhoCanShareAllowListInTenantByPrincipalIdentity: any;
+    Workflow2010Disabled: boolean;
+    Workflows2013State: number;
+}
+
+export enum SpecialCharactersState {
+    NoPreference,
+    Allowed,
+    Disallowed,
+}
+
+export enum SensitiveByDefaultState {
+    AllowExternalSharing,
+    BlockExternalSharing,
 }

--- a/packages/sp-admin/types.ts
+++ b/packages/sp-admin/types.ts
@@ -731,3 +731,75 @@ export enum SPOrgAssetType {
     // The flag for OfficeFontLibrary is 0100.
     OfficeFontLibrary = 0x04,
 }
+
+export enum SPOTenantCdnPolicyType {
+    IncludeFileExtensions,
+    ExcludeRestrictedSiteClassifications,
+    ExcludeIfNoScriptDisabled,
+    ExcludeRestrictedSiteClassificationsFileExtensions
+}
+
+export interface IThemeProperties {
+    Name: string;
+    Palette: Record<string, string>;
+    IsInverted: boolean;
+}
+
+export interface IGetExternalUsersResults {
+    UserCollectionPosition: number;
+    TotalUserCount: number;
+    ExternalUserCollection: any[];
+}
+
+export enum SortOrder {
+    Ascending,
+    Descending,
+}
+
+export interface IRemoveExternalUsersResults {
+    RemoveFailed: string[];
+    RemoveSucceeded: string[];
+}
+
+export enum ImportProfilePropertiesUserIdTypes {
+    Email,
+    CloudId,
+    PrincipalName,
+}
+
+export interface IImportProfilePropertiesJobInfo {
+    JobId: string;
+    State: ImportProfilePropertiesJobState;
+    SourceUri: string;
+    ImportProfilePropertiesJobError: any;
+    ErrorMessage: string;
+    LogFolderUri: string;
+}
+
+export enum ImportProfilePropertiesJobState {
+    Unknown = 0,
+    Submitted = 1,
+    Processing = 2,
+    Queued = 3,
+    Succeeded = 4,
+    Error = 5,
+}
+
+export interface ISPOUserSessionRevocationResult {
+    State: SPOUserSessionRevocationState;
+}
+
+export enum SPOUserSessionRevocationState {
+    FeatureDisabled = 0,
+    UserNotFound = 1,
+    Failure = 2,
+    NonInstantaneousSuccess = 3,
+    InstantaneousSuccess = 4,
+}
+
+export interface IGroupCreationParams {
+    Description: string;
+    Owners: string[];
+    CreationOptions: string[];
+    Classification: string;
+}

--- a/packages/sp-admin/types.ts
+++ b/packages/sp-admin/types.ts
@@ -1,0 +1,733 @@
+
+import { IResourcePath } from "@pnp/sp";
+
+export interface IOffice365TenantInfo {
+    /**
+     * Gets a value to specify what external sharing capabilities are available.  Modifying this property
+     * does not impact any settings stored on individual site collections.  This property has no impact on Partner
+     * users (users added via a support partner).
+     */
+    SharingCapability: SharingCapabilities;
+    /**
+     * Gets a value to specify what external sharing capabilities are available in ODB.  Modifying this property
+     * will impact settings stored on individual site collections.
+     */
+    ODBSharingCapability: SharingCapabilities;
+    /**
+     * Gets a value to specify if user accepting invitation must use the same email address invitation was sent to.
+     */
+    RequireAcceptingAccountMatchInvitedAccount: boolean;
+    /**
+     * Gets a bool value that if user checks generate mobile friendly Urls setting
+     */
+    MobileFriendlyUrlEnabled: boolean;
+    /**
+     * Gets a value to handle the tenant who can share settings
+     */
+    WhoCanShareAllowList: string;
+    /**
+     * Gets a value to handle guest sharing group's allow list
+     */
+    AllowSelectSGsInODBList: string[];
+    /**
+     * Gets a value to handle email attestation.
+     */
+    EmailAttestationEnabled: boolean;
+    /**
+     * Gets a value to handle guest sharing group's allow list
+     */
+    GuestSharingGroupAllowList: string;
+    /**
+     * Gets a value to handle guest user sharing to users not in guest user site collection
+     */
+    AllowGuestUserShareToUsersNotInSiteCollection: boolean;
+    /**
+     * Gets a Boolean value that specifies whether tenant users see the "Start a fresh site" menu option
+     */
+    DisplayStartASiteOption: boolean;
+    /**
+     * Gets a string which specifies the URL of the form to load in the Start a Site dialog
+     */
+    StartASiteFormUrl: string;
+    /**
+     * Gets a Boolean value that specifies whether external services are enabled for the tenancy
+     */
+    ExternalServicesEnabled: boolean;
+    /**
+     * Gets a Boolean value that specifies whether all users' My Sites are public by default
+     */
+    MySitesPublicEnabled: boolean;
+    /**
+     * Gets a Boolean value that specifies whether Everyone is visible in people picker dialogs
+     */
+    ShowEveryoneClaim: boolean;
+    /**
+     * Gets a Boolean value that specifies whether AllUsers is visible in people picker dialogs
+     */
+    ShowAllUsersClaim: boolean;
+    /**
+     * Gets a Boolean value that specifies whether EveryoneExceptExternalUsers is visible in people picker dialogs
+     */
+    ShowEveryoneExceptExternalUsersClaim: boolean;
+    /**
+     *  Gets a Boolean value that specifies whether EveryoneExceptExternalUsers is allowed in people picker dialogs for private group site
+     */
+    AllowEveryoneExceptExternalUsersClaimInPrivateSite: boolean;
+    /**
+     * Gets a Boolean value that specifies whether Search and Resolve Operations in people picker dialogs do an exact match against UPN/Email
+     * Default behavior is doing startswith match against common properties
+     */
+    SearchResolveExactEmailOrUPN: boolean;
+    /**
+     * Gets a Boolean value that specifies whether the ML Capture settings should be shown
+     */
+    MachineLearningCaptureEnabled: boolean;
+    /**
+     * Gets a SiteInfoForSitePicker instance that represents a site that tenant has opted-in as default Content Center site
+     */
+    DefaultContentCenterSite: ISiteInfoForSitePicker;
+    /**
+     * Gets a Boolean value that specifies whether the AIBuilder features should be shown
+     */
+    AIBuilderEnabled: boolean;
+    /**
+     * Gets the default PowerApps environment in which SharePoint Syntex form processing feature will create model
+     */
+    AIBuilderDefaultPowerAppsEnvironment: string;
+    /**
+     * Gets a collection value that specifies the sites for AIBuilderEnabled features
+     */
+    AIBuilderSiteList: string[];
+    /**
+     * Gets name of the file which contains the list of AIBuilder enabled sites
+     */
+    AIBuilderSiteListFileName: string;
+    /**
+     * Gets a collection value that specifies the sites for AIBuilderEnabled features
+     */
+    AIBuilderSiteInfoList: ISiteInfoForSitePicker[];
+    /**
+     * Gets Syntex consumption billing settings
+     */
+    SyntexBillingSubscriptionSettings: ISyntexBillingContext;
+    /**
+     * Gets a status value that specifies the image tagging option
+     */
+    ImageTaggingOption: ImageTaggingChoice;
+    /**
+     * Gets a status value that specifies whether admin is done with the configuration setup
+     */
+    HasAdminCompletedCUConfiguration: boolean;
+    /**
+     * Gets a Boolean value that specifies whether ADAL is disabled or not
+     */
+    OfficeClientADALDisabled: boolean;
+    /**
+     * Gets a Boolean value that specifies whether legacy auth protocols are enabled. These include MsoFba and IDCRL.
+     */
+    LegacyAuthProtocolsEnabled: boolean;
+    /**
+     * Gets a Boolean value that specifies whether ACS app only token are blocked.
+     */
+    DisableCustomAppAuthentication: boolean;
+    /**
+     * Gets the link to organization help page in case of access denied due to conditional access policy
+     */
+    ConditionalAccessPolicyErrorHelpLink: string;
+    /**
+     * Gets a Boolean value that specifies whether the following policy is enabled
+     */
+    BlockDownloadOfViewableFilesOnUnmanagedDevices: boolean;
+    /**
+     * Gets a Boolean value that specifies whether the following policy is enabled
+     */
+    BlockDownloadOfAllFilesOnUnmanagedDevices: boolean;
+    /**
+     * Gets a Boolean value that specifies whether the following access setting is enabled
+     */
+    BlockAccessOnUnmanagedDevices: boolean;
+    /**
+     * Gets a Boolean value that specifies whether the following access setting is enabled
+     */
+    AllowLimitedAccessOnUnmanagedDevices: boolean;
+    /**
+     * Gets a Boolean value that specifies whether the following policy is enabled
+     */
+    BlockDownloadOfViewableFilesForGuests: boolean;
+    /**
+     * Gets a Boolean value that specifies whether the following policy is enabled
+     */
+    BlockDownloadOfAllFilesForGuests: boolean;
+    /**
+     * Gets whether ODB sites should have the Shared with Everyone folder automatically provisioned or not
+     */
+    ProvisionSharedWithEveryoneFolder: boolean;
+    /**
+     * Gets the domain to which to accelerate the sign-in experience to. i.e. by skipping the OrgID/EvoSTS sign-in page for end-user
+     */
+    SignInAccelerationDomain: string;
+    /**
+     * Gets a value to force auto-acceleration sign-in on the tenant regardless of its external sharing status
+     */
+    EnableGuestSignInAcceleration: boolean;
+    /**
+     * Gets a Boolean value that specifies whether ExplorerView feature uses persistent cookies
+     */
+    UsePersistentCookiesForExplorerView: boolean;
+    /**
+     * Gets a value to specify if external users can reshare regardless of Members Can Share state
+     */
+    PreventExternalUsersFromResharing: boolean;
+    /**
+     * A list of site templates that tenant has opted-in/opted-out to sync Content types
+     */
+    ContentTypeSyncSiteTemplatesList: string[];
+    /**
+     * Gets a value to specify if BCC functionality is enabled for external invitations
+     */
+    BccExternalSharingInvitations: boolean;
+    /**
+     * Gets list of recipients to be BCC'ed on all external sharing invitations
+     */
+    BccExternalSharingInvitationsList: string;
+    /**
+     * Gets a value to specify if User Voice for customer feedback is enabled
+     */
+    UserVoiceForFeedbackEnabled: boolean;
+    /**
+     * Gets a value to specify if External Image Search is enabled on the File Picker
+     */
+    FilePickerExternalImageSearchEnabled: boolean;
+    /**
+     * Gets a all Organization Assets libraries
+     */
+    GetOrgAssets: ISPOrgAssets;
+    /**
+     * Gets whether Email Attestation is enabled
+     */
+    EmailAttestationRequired: boolean;
+    /**
+     * Gets the number of days between reattestation
+     */
+    EmailAttestationReAuthDays: number;
+    /**
+     * Gets whether external user expiration is enabled
+     */
+    ExternalUserExpirationRequired: boolean;
+    /**
+     * Gets the number of days before external user expiration if not individually extended
+     */
+    ExternalUserExpireInDays: number;
+    /**
+     * Gets whether or not the synced tenant properties will be updated on the next request
+     */
+    SyncPrivacyProfileProperties: boolean;
+    /**
+     * Gets whether or not the AAD B2B management policy will be synced on the next request
+     */
+    SyncAadB2BManagementPolicy: boolean;
+    /**
+     * Gets the Stream Launch Config stat
+     */
+    StreamLaunchConfig: number;
+    /**
+     * Gets the Stream Launch Config Last Updated value
+     */
+    StreamLaunchConfigLastUpdated: Date;
+    /**
+     * Gets the Stream Launch Config update count
+     */
+    StreamLaunchConfigUpdateCount: number;
+    /**
+     * Gets the Auth Context Resilient Mode
+     */
+    AuthContextResilienceMode: SPResilienceModeType;
+    /**
+     * Gets a value to specify the number of days that anonymous links expire
+     */
+    RequireAnonymousLinksExpireInDays: number;
+    /**
+     * Gets a value to specify a space separated list of allowed domain names
+     */
+    SharingAllowedDomainList: string;
+    /**
+     * Gets a value to specify a space separated list of blocked domain names
+     */
+    SharingBlockedDomainList: string;
+    /**
+     * Gets a value to specify the restriction mode
+     */
+    SharingDomainRestrictionMode: SharingDomainRestrictionModes;
+    /**
+     * Gets a value that allows members to search all existing guest users in the directory
+     */
+    ShowPeoplePickerSuggestionsForGuestUsers: boolean;
+    /**
+     * Gets default sharing link type
+     */
+    DefaultSharingLinkType: SharingLinkType;
+    /**
+     * Gets file anonymous link type
+     */
+    FileAnonymousLinkType: AnonymousLinkType;
+    /**
+     * Gets folder anonymous link type
+     */
+    FolderAnonymousLinkType: AnonymousLinkType;
+    /**
+     * Gets ODBMCS
+     */
+    ODBMembersCanShare: string;
+    /**
+     * Gets ODBAccessRequests
+     */
+    ODBAccessRequests: SharingState;
+    /**
+     * Gets a value to specify if site owner will get email notification if the user shared an item with external user
+     */
+    NotifyOwnersWhenItemsReshared: boolean;
+    /**
+     * Gets a value to specify if site owner will get email notification if the external user accepts the invitation
+     */
+    NotifyOwnersWhenInvitationsAccepted: boolean;
+    /**
+     * Gets a value to specify if site owner will get notification if the user created/updated an anonymous link in ODB
+     */
+    OwnerAnonymousNotification: boolean;
+    /**
+     * Gets a value to enable or disable push notifications in OneDrive
+     */
+    NotificationsInOneDriveForBusinessEnabled: boolean;
+    /**
+     * Gets a value to enable or disable push notifications in SharePoint
+     */
+    NotificationsInSharePointEnabled: boolean;
+    /**
+     * Whether comments on site pages are disabled or not
+     */
+    CommentsOnSitePagesDisabled: boolean;
+    /**
+     * Whether comments on files are disabled or not
+     */
+    CommentsOnFilesDisabled: boolean;
+    /**
+     * Whether comments on list items are disabled or not
+     */
+    CommentsOnListItemsDisabled: boolean;
+    /**
+     * Whether viewers commenting on media items is disabled or not
+     */
+    ViewersCanCommentOnMediaDisabled: boolean;
+    /**
+     * Whether social bar on site pages is enabled or not
+     */
+    SocialBarOnSitePagesDisabled: boolean;
+    /**
+     * Gets default link permission
+     */
+    DefaultLinkPermission: SharingLinkType;
+    BlockDownloadLinksFileType: BlockDownloadLinksFileTypes;
+    /**
+     * Gets a value to specify whether anyone links should track link users
+     */
+    AnyoneLinkTrackUsers: boolean;
+    /**
+     * Gets collaboration type for fluid on OneDrive partition
+     */
+    OneDriveLoopSharingCapability: SharingCapabilities;
+    /**
+     * Gets default share link scope for fluid on OneDrive partition
+     */
+    OneDriveLoopDefaultSharingLinkScope: SharingScope;
+    /**
+     * Gets default share link role for fluid on OneDrive partition
+     */
+    OneDriveLoopDefaultSharingLinkRole: number;
+    /**
+     * Gets request files link enabled on OneDrive partition
+     */
+    OneDriveRequestFilesLinkEnabled: boolean;
+    /**
+     * Gets request files link expiration days on OneDrive partition
+     */
+    OneDriveRequestFilesLinkExpirationInDays: number;
+    /**
+     * Gets collaboration type for fluid on core partition
+     */
+    CoreLoopSharingCapability: SharingCapabilities;
+    /**
+     * Gets default share link scope for fluid on core partition
+     */
+    CoreLoopDefaultSharingLinkScope: SharingScope;
+    /**
+     * Gets default share link role for fluid on core partition
+     */
+    CoreLoopDefaultSharingLinkRole: number;
+    /**
+     * Gets collaboration type on core partition
+     */
+    CoreSharingCapability: SharingCapabilities;
+    /**
+     * Gets request files link enabled on core partition
+     */
+    CoreRequestFilesLinkEnabled: boolean;
+    /**
+     * Gets request files link expiration days on core partition
+     */
+    CoreRequestFilesLinkExpirationInDays: number;
+    /**
+     * Gets a value to indicate whether to allow anonymous meeting participants to access whiteboards
+     */
+    AllowAnonymousMeetingParticipantsToAccessWhiteboards: SharingState;
+    /**
+     * Gets address bar link permission
+     */
+    AddressbarLinkPermission: number;
+    /**
+     * Gets a value to specify whether Auto news digest is enabled
+     */
+    EnableAutoNewsDigest: boolean;
+    /**
+     * Gets customized external sharing service Url
+     */
+    CustomizedExternalSharingServiceUrl: string;
+    /**
+     * Gets a value to specify whether AAD B2B integration is enabled
+     */
+    EnableAzureADB2BIntegration: boolean;
+    /**
+     *  Gets a value to specify whether Add To OneDrive is disabled
+     */
+    DisableAddToOneDrive: boolean;
+    /**
+     * Gets a value to specify whether to include at a glance in the sharing emails
+     */
+    IncludeAtAGlanceInShareEmails: boolean;
+    /**
+     * Get status of feature sync client restriction allowed
+     */
+    IsUnmanagedSyncClientRestrictionFlightEnabled: boolean;
+    /**
+     * Get sync client restrictions
+     */
+    IsUnmanagedSyncClientForTenantRestricted: boolean;
+    /**
+     * Get sync client trusted domain guids
+     */
+    AllowedDomainListForSyncClient: string[];
+    /**
+     * Get whether Mac clients should be blocked from sync
+     */
+    BlockMacSync: boolean;
+    /**
+     * Get sync client excluded file extensions
+     */
+    ExcludedFileExtensionsForSyncClient: string[];
+    /**
+     * Gets whether to hide the sync button on OneDrive for Business sites
+     */
+    HideSyncButtonOnODB: boolean;
+    /**
+     * Gets whether the sync button should use the Next-Generation Sync Client on OneDrive for Business sites
+     */
+    ShowNGSCDialogForSyncOnODB: boolean;
+    /**
+     * Gets whether Nucleus should be disabled for List Sync
+     */
+    DisableListSync: boolean;
+    /**
+     * Gets a value to enable or disable comment text contents in email
+     */
+    AllowCommentsTextOnEmailEnabled: boolean;
+    /**
+     * Gets whether Onedrive creation for guest users is enabled in the tenancy
+     */
+    OneDriveForGuestsEnabled: boolean;
+    /**
+     * IPAddressEnforcement for tenancy
+     */
+    IPAddressEnforcement: boolean;
+    /**
+     * Gets the IPAddress range that is allowed to access the tenancy, CIDR range that looks like 10.12.30/4. Also note: IPAddressEnforcement needs to be true
+     */
+    IPAddressAllowList: string;
+    /**
+     * Gets the WAC Token lifetime if tenant opted for IPAddressEnforcement
+     */
+    IPAddressWACTokenLifetime: number;
+    /**
+     * Gets whether Hashed Proof Token IP binding is enabled
+     */
+    ReduceTempTokenLifetimeEnabled: boolean;
+    /**
+     * Determines the grace period for Hashed Proof Tokens from an IP address that doesn't match the
+     * IP address in the token, when the IP policy is not enabled and IP Binding is enabled
+     */
+    ReduceTempTokenLifetimeValue: number;
+    /**
+     * Gets whether EWS FindPeople with ABPs is enabled in PeoplePicker
+     */
+    UseFindPeopleInPeoplePicker: boolean;
+    /**
+     * Gets conditional access policy type
+     */
+    ConditionalAccessPolicy: SPOConditionalAccessPolicyType;
+    /**
+     * Gets the advanced setting of SPO conditional access policy
+     */
+    AllowDownloadingNonWebViewableFiles: boolean;
+    /**
+     * Gets limited access file type
+     */
+    LimitedAccessFileType: SPOLimitedAccessFileType;
+    /**
+     * Gets the advanced setting of SPO conditional access policy, A boolean value that specifies whether to allow editing in WAC
+     */
+    AllowEditing: boolean;
+    /**
+     * Gets the setting of whether app-enforced restrictions apply to TOAA users
+     */
+    ApplyAppEnforcedRestrictionsToAdHocRecipients: boolean;
+    /**
+     * Gets whether to show promoted file handlers
+     */
+    EnablePromotedFileHandlers: boolean;
+    /**
+     * Gets whether 2013 workflows are configured and enabled for the tenant
+     */
+    Workflows2013State: Workflows2013State;
+    /**
+     * Gets whether 2010 workflows are enabled for the tenant
+     */
+    Workflow2010Disabled: boolean;
+    /**
+     * Gets whether new 2010 workflows can be created for the tenant
+     */
+    StopNew2010Workflows: boolean;
+    /**
+     * Gets whether new 2013 workflows can be created for the tenant
+     */
+    StopNew2013Workflows: boolean;
+    /**
+     * Gets whether back to classic link is disabled in Modern UX
+     */
+    DisableBackToClassic: boolean;
+    /**
+     * Gets IBImplicitGroupBased value
+     */
+    IBImplicitGroupBased: boolean;
+    /**
+     * Gets InformationBarriersSuspension value
+     */
+    InformationBarriersSuspension: boolean;
+    /**
+     * Gets DefaultODBMode value
+     */
+    DefaultODBMode: string;
+    /**
+     * Gets a value to specify BlockUserInfoVisibilityInOneDrive
+     */
+    BlockUserInfoVisibilityInOneDrive: TenantBrowseUserInfoPolicyValue;
+    /**
+     * Gets a value to specify BlockUserInfoVisibilityInSharePoint
+     */
+    BlockUserInfoVisibilityInSharePoint: TenantBrowseUserInfoPolicyValue;
+    /**
+     * Gets AllowOverrideForBlockUserInfoVisibility value
+     */
+    AllowOverrideForBlockUserInfoVisibility: boolean;
+    /**
+     * Indicates whether personal list creation is disabled or not on the tenant
+     */
+    DisablePersonalListCreation: boolean;
+    /**
+     * Collection of modern list template ids which are disabled on the tenant
+     */
+    DisabledModernListTemplateIds: string[];
+    /**
+     * Indicates whether activating spaces is disabled or not on the tenant
+     */
+    DisableSpacesActivation: boolean;
+    /**
+     * Gets a value to specify whether the sync button on team sites and other ODBs is hidden.
+     * (Basically this hides the sync button on all document libraries except the ODB that the user owns.)
+     */
+    HideSyncButtonOnDocLib: boolean;
+    /**
+     * Indicates whether Outlook PST version trimming is disabled or not on the tenant
+     */
+    DisableOutlookPSTVersionTrimming: boolean;
+    /**
+     * Gets MediaTranscription value
+     */
+    MediaTranscription: MediaTranscriptionPolicyType;
+    /**
+     * Gets the value of the setting which enables users to view files in Explorer
+     */
+    ViewInFileExplorerEnabled: boolean;
+    /**
+     * Gets whether Open In Desktop should be enabled
+     */
+    ShowOpenInDesktopOptionForSyncedFiles: boolean;
+    /**
+     * Gets a value to handle showing group suggestions for IB in PeoplePicker
+     */
+    ShowPeoplePickerGroupSuggestionsForIB: boolean;
+}
+
+export enum SharingCapabilities {
+    /**
+     * External user sharing (share by email) and guest link sharing are both disabled for all site collections
+     * in the tenancy.  No new external user invitations or sharing links can be created, and any content previously
+     * shared becomes inaccessible to external users.
+     */
+    Disabled = 0,
+    /**
+     * External user sharing is enabled for the tenancy, but guest link sharing is disabled.  Each individual
+     * site collection's sharing properties govern whether the site collection has sharing disabled or allows
+     * external user sharing, but a site collection cannot enable guest link sharing.
+     */
+    ExternalUserSharingOnly,
+    /**
+     * External user sharing and guest link sharing are enabled for the tenancy.  Each individual site
+     * collection's sharing properties govern whether the site collection has sharing disabled, allows external user
+     * sharing only, or allows both external user sharing and guest link sharing.
+     */
+    ExternalUserAndGuestSharing,
+    /**
+     * External user sharing and guest link sharing are both disabled for the tenancy, but AllowGuestUserSignIn is enabled.
+     * Each individual site collection's sharing properties govern whether the site collection has sharing disabled or allows
+     * existing external user signing in, but a site collection cannot enable guest link sharing and cannot share with new external users.
+     */
+    ExistingExternalUserSharingOnly
+}
+
+export interface ISiteInfoForSitePicker {
+    SiteId: string;
+    Url: string;
+    SiteName: string;
+    Error: string;
+}
+
+export enum ImageTaggingChoice {
+    Disabled = 1,
+    Basic = 2,
+    Enhanced = 3,
+}
+
+export interface ISPOrgAssets {
+    WebId: string;
+    SiteId: string;
+    Url: IResourcePath;
+    Domain: IResourcePath;
+}
+
+export enum AzureSubscriptionState {
+    Unknown = 0,
+    Active = 1,
+    Deleted = 2,
+    Disabled = 3,
+    Expired = 4,
+    PastDue = 5,
+    Warned = 6,
+}
+
+export interface ISyntexBillingContext {
+    AzureResourceId: string;
+    AzureSubscriptionState: AzureSubscriptionState;
+    Location: string;
+    Updated: Date;
+}
+
+export enum SPResilienceModeType {
+    DefaultAAD = 0,
+    Enabled = 1,
+    Disabled = 2,
+}
+
+export enum SharingDomainRestrictionModes {
+    None = 0,
+    AllowList = 1,
+    BlockList = 2,
+}
+export enum SharingLinkType {
+    View,
+    Edit,
+    Review,
+    Embed,
+    BlocksDownload,
+    CreateOnly,
+    AddressBar,
+    AdminDefault,
+    Unknown,
+}
+
+export enum AnonymousLinkType {
+    None,
+    View,
+    Edit
+}
+
+export enum SharingState {
+    Unspecified,
+    On,
+    Off
+}
+
+export enum BlockDownloadLinksFileTypes {
+    WebPreviewableFiles = 1,
+    ServerRenderedFilesOnly = 2
+}
+
+export enum SharingScope {
+    Anyone = 0,
+    Organization = 1,
+    SpecificPeople = 2,
+}
+
+export enum SPOConditionalAccessPolicyType {
+    AllowFullAccess = 0,
+    AllowLimitedAccess,
+    BlockAccess,
+    AuthenticationContext,
+}
+
+export enum SPOLimitedAccessFileType {
+    OfficeOnlineFilesOnly = 0,
+    WebPreviewableFiles,
+    OtherFiles,
+}
+
+export enum Workflows2013State {
+    Disabled,
+    Configuring,
+    Enabled,
+}
+
+export enum TenantBrowseUserInfoPolicyValue {
+    ApplyToNoUsers = 0,
+    ApplyToGuestAndExternalUsers = 1,
+    ApplyToInternalUsers = 2,
+    ApplyToAllUsers = 3,
+}
+
+export enum MediaTranscriptionPolicyType {
+    Enabled = 0,
+    Disabled = 1,
+}
+
+export enum SPOTenantCdnType {
+    Public,
+    Private,
+}
+
+export enum SPOrgAssetType {
+    // The flag for Undefined is 0000.
+    Undefined = 0x00,
+    // The flag for ImageDocumentLibrary is 0001.
+    ImageDocumentLibrary = 0x01,
+    // The flag for OfficeTemplateLibrary is 0010.
+    OfficeTemplateLibrary = 0x02,
+    // The flag for OfficeFontLibrary is 0100.
+    OfficeFontLibrary = 0x04,
+}

--- a/packages/sp-admin/types.ts
+++ b/packages/sp-admin/types.ts
@@ -1535,3 +1535,145 @@ export enum SensitiveByDefaultState {
     AllowExternalSharing,
     BlockExternalSharing,
 }
+
+export interface ISitePropertiesEnumerableFilter {
+    Filter: string;
+    StartIndex: string;
+    IncludeDetail: boolean;
+    Template: string;
+    IncludePersonalSite: PersonalSiteFilter;
+    GroupIdDefined: number;
+}
+
+export enum PersonalSiteFilter {
+    UseServerDefault = 0, // default value for enum variables
+    Include = 1,
+    Exclude = 2,
+}
+
+/**
+ * Basically useless from REST
+ */
+export interface ISPOOperation {
+    HasTimedout: boolean;
+    PollingInterval: number;
+    IsComplete: boolean;
+}
+
+export interface ISiteCreationProps {
+    Url: string;
+    Owner: string;
+    Title?: string;
+    Template?: string;
+    Lcid?: number;
+    CompatibilityLevel?: number;
+    StorageMaximumLevel?: number;
+    StorageWarningLevel?: number;
+    UserCodeMaximumLevel?: number;
+    UserCodeWarningLevel?: number;
+    TimeZoneId?: number;
+}
+
+export interface ISPOWebTemplatesInfo {
+    Items: {
+        CompatibilityLevel: number;
+        Description: string;
+        DisplayCategory: string | null;
+        Id: number;
+        Lcid: string;
+        Name: string;
+        Title: string;
+    }[];
+}
+
+export interface IUpdateGroupSiteProperties {
+    storageMaximumLevel: number;
+    storageWarningLevel: number;
+}
+
+export interface ISPOSiteCreationSource {
+    DisplayName: string;
+    Id: string;
+    Name: string;
+}
+
+export interface IPortalHealthStatus {
+    Status: ResultStatus;
+    Details: {
+        PortalHealthErrorCode: any;
+        Status: ResultStatus;
+        ErrorReason: string;
+        HelpLink: string;
+    }[];
+}
+
+export enum ResultStatus {
+    Success = 0,
+    Warning = 1,
+    Error = 2,
+}
+
+export interface IPowerAppsEnvironment {
+    DisplayName: string;
+    Name: string;
+    IsDefault: boolean;
+    AllocatedAICredits: number;
+    PurchasedAICredits: number;
+}
+
+export interface ISiteUserGroupsData {
+    siteId: string;
+    owners: IUserInfo[];
+    members: IUserInfo[];
+    visitors: IUserInfo[];
+}
+
+export interface IUserInfo {
+    Email: string;
+    DisplayName?: string;
+    UserPrincipalName: string;
+}
+
+export interface ISiteAdministratorsFieldsData {
+    siteId: string;
+    siteAdministrators: string[];
+}
+
+export interface ISiteAdminsInfo {
+    email: string;
+    name: string;
+    userPrincipalName: string;
+    loginName: string;
+}
+
+export interface ISPHubSiteCreationInfo {
+    Title: string;
+    SiteId: string;
+    TenantInstanceId: string;
+    SiteUrl: string;
+    LogoUrl: string;
+    Description: string;
+    Targets: string;
+    SiteDesignId: string;
+    RequiresJoinApproval: boolean;
+    HideNameInNavigation: boolean;
+    ParentHubSiteId: string;
+    EnablePermissionsSync: boolean;
+    EnforcedECTs: string;
+    PermissionsSyncTag: number;
+    EnforcedECTsVersion: number;
+}
+
+export enum SPOHubSiteUserRights {
+    None = 0,
+    Join = 1,
+}
+
+export interface IHomeSitesDetails {
+    SiteId: string;
+    WebId: string;
+    Audiences: string[];
+    Url: string;
+    Title: string;
+    MatchingAudiences: string[];
+}

--- a/packages/sp-admin/types.ts
+++ b/packages/sp-admin/types.ts
@@ -748,7 +748,19 @@ export interface IThemeProperties {
 export interface IGetExternalUsersResults {
     UserCollectionPosition: number;
     TotalUserCount: number;
-    ExternalUserCollection: any[];
+    ExternalUserCollection: IExternalUser[];
+}
+
+export interface IExternalUser {
+    AcceptedAs: string;
+    DisplayName: string;
+    InvitedAs: string;
+    InvitedBy: string | null;
+    IsCrossTenant: boolean;
+    LoginName: string;
+    UniqueId: string;
+    UserId: number;
+    WhenCreated: string;
 }
 
 export enum SortOrder {

--- a/packages/sp/index.ts
+++ b/packages/sp/index.ts
@@ -15,6 +15,7 @@ export * from "./utils/escape-query-str.js";
 export * from "./utils/extract-web-url.js";
 export * from "./utils/file-names.js";
 export * from "./utils/odata-url-from.js";
+export * from "./utils/to-resource-path.js";
 
 export * from "./behaviors/defaults.js";
 export * from "./behaviors/telemetry.js";

--- a/packages/sp/tsconfig.json
+++ b/packages/sp/tsconfig.json
@@ -3,9 +3,7 @@
     "include": [
         "./**/*.ts",
         "../core/**/*.ts",
-        "../logging/**/*.ts",
-        "../queryable/**/*.ts",
-        "./presets/**/*.ts"
+        "../queryable/**/*.ts"
     ],
     "references": [
         {

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -26,6 +26,9 @@
         },
         {
             "path": "./sp/tsconfig.json"
+        },
+        {
+            "path": "./sp-admin/tsconfig.json"
         }
     ]
 }


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [X] Documentation update?

#### Related Issues

fixes #1071 

#### What's in this Pull Request?

This PR adds support for the following admin APIs through the addition of a new library `sp-admin`.
- _api/Microsoft.Online.SharePoint.TenantManagement.Office365Tenant
- _api/Microsoft.Online.SharePoint.TenantAdministration.SiteProperties
- _api/Microsoft.Online.SharePoint.TenantAdministration.Tenant


Includes bare docs and side-effect free tests to generally check that the queries work, updates and other modification methods are not tested because we don't want to constantly change tenant level settings.
