### PR TITLE
Add new content type fields / update method

### DIFF
--- a/docs/sp/content-types.md
+++ b/docs/sp/content-types.md
@@ -29,6 +29,16 @@ const d: IContentType = await sp.web.contentTypes.getById("0x01")();
 console.log(d.name);
 ```
 
+### Update a Content Type
+
+```Typescript
+import { IContentType } from "@pnp/sp/content-types";
+
+const sp = spfi(...);
+
+await sp.web.contentTypes.getById("0x01").update({EditFormClientSideComponentId: "9dfdb916-7380-4b69-8d92-bc711f5fa339"});
+```
+
 ### Add a new Content Type
 
 To add a new Content Type to a collection, parameters id and name are required. For more information on creating content type IDs reference the [Microsoft Documentation](https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/aa543822(v=office.14)). While this documentation references SharePoint 2010 the structure of the IDs has not changed.

--- a/packages/sp/content-types/types.ts
+++ b/packages/sp/content-types/types.ts
@@ -133,10 +133,14 @@ export const FieldLink = spInvokableFactory<IFieldLink>(_FieldLink);
 
 export interface IContentTypeInfo {
     Description: string;
+    DispFormClientSideComponentId: string;
+    DispFormClientSideComponentProperties: string;
     DisplayFormTemplateName: string;
     DisplayFormUrl: string;
     DocumentTemplate: string;
     DocumentTemplateUrl: string;
+    EditFormClientSideComponentId: string;
+    EditFormClientSideComponentProperties: string;
     EditFormTemplateName: string;
     EditFormUrl: string;
     Group: string;
@@ -147,6 +151,8 @@ export interface IContentTypeInfo {
     MobileEditFormUrl: string;
     MobileNewFormUrl: string;
     Name: string;
+    NewFormClientSideComponentId: string;
+    NewFormClientSideComponentProperties: string;
     NewFormTemplateName: string;
     NewFormUrl: string;
     ReadOnly: boolean;

--- a/packages/sp/content-types/types.ts
+++ b/packages/sp/content-types/types.ts
@@ -9,7 +9,7 @@ import {
     IDeleteable,
 } from "../spqueryable.js";
 import { defaultPath } from "../decorators.js";
-import { spPost } from "../operations.js";
+import { spPost, spPostMerge } from "../operations.js";
 
 @defaultPath("contenttypes")
 export class _ContentTypes extends _SPCollection<IContentTypeInfo[]> {
@@ -39,7 +39,8 @@ export class _ContentTypes extends _SPCollection<IContentTypeInfo[]> {
     /**
      * Adds a new content type to the collection
      *
-     * @param id The desired content type id for the new content type (also determines the parent content type)
+     * @param id The desired content type id for the new content type (also determines the parent
+     *   content type)
      * @param name The name of the content type
      * @param description The description of the content type
      * @param group The group in which to add the content type
@@ -72,6 +73,15 @@ export const ContentTypes = spInvokableFactory<IContentTypes>(_ContentTypes);
 export class _ContentType extends _SPInstance<IContentTypeInfo> {
 
     public delete = deleteable();
+
+    /**
+     * Updates this list instance with the supplied properties
+     *
+     * @param properties A plain object hash of values to update for the web
+     */
+    public async update(properties: Record<string, any>): Promise<void> {
+        return spPostMerge(this, body(properties));
+    }
 
     /**
      * Gets the column (also known as field) references in the content type.

--- a/test/sp/content-types.ts
+++ b/test/sp/content-types.ts
@@ -57,4 +57,22 @@ describe("Content Type", function () {
     it("workflowAssociations", function () {
         return expect(this.pnp.sp.web.contentTypes.getById(contentTypeId).workflowAssociations()).to.eventually.be.fulfilled;
     });
+
+    it("update", function () {
+
+        const p = this.pnp.sp.web.contentTypes.getById(contentTypeId)().then((ct) => {
+
+            const newName = ct.Name + " updated";
+            this.pnp.sp.web.contentTypes.getById(contentTypeId).update({ Name: newName }).then(() => {
+
+                this.pnp.sp.web.contentTypes.getById(contentTypeId)().then(function (ct2) {
+                    if (ct2.Name !== newName) {
+                        throw Error("Update web failed");
+                    }
+                });
+            });
+        });
+
+        return expect(p).to.eventually.be.fulfilled;
+    });
 });


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?


#### What's in this Pull Request?

Hey guys, been a while :)

- Adds new content type fields used by field customizer extensions (added as part of SPFx 1.15)
- Adds missing `update` method to content type object, inc. test and docs

