### PR TITLE
Updates to simplify url & query escaping

### DIFF
--- a/debug/launch/graph.ts
+++ b/debug/launch/graph.ts
@@ -1,5 +1,6 @@
 import { Logger, LogLevel } from "@pnp/logging";
 import { graphSetup } from "./setup.js";
+import "@pnp/graph/groups";
 import "@pnp/graph/users";
 
 declare var process: { exit(code?: number): void };
@@ -8,8 +9,18 @@ export async function Example(settings: any) {
 
     const graph = graphSetup(settings);
 
-    const users = await graph.users();
-  
+    const count = await graph.users.count();
+
+    const allUsers = [];
+    let users = await graph.users.top(20).select("displayName").paged();
+
+    allUsers.push(...users.value);
+
+    while (users.hasNext) {
+        users = await users.next();
+        allUsers.push(...users.value);
+    }
+ 
     Logger.log({
       data: users,
       level: LogLevel.Info,

--- a/debug/launch/main.ts
+++ b/debug/launch/main.ts
@@ -8,8 +8,8 @@ import { ITestingSettings } from "../../test/load-settings.js";
 // add your debugging imports here and prior to submitting a PR git checkout debug/debug.ts
 // will allow you to keep all your debugging files locally
 // comment out the example
-// import { Example } from "./sp.js";
-import { Example } from "./graph.js";
+import { Example } from "./sp.js";
+// import { Example } from "./graph.js";
 
 // setup the connection to SharePoint using the settings file, you can
 // override any of the values as you want here, just be sure not to commit

--- a/debug/launch/main.ts
+++ b/debug/launch/main.ts
@@ -8,8 +8,8 @@ import { ITestingSettings } from "../../test/load-settings.js";
 // add your debugging imports here and prior to submitting a PR git checkout debug/debug.ts
 // will allow you to keep all your debugging files locally
 // comment out the example
-import { Example } from "./sp.js";
-// import { Example } from "./graph.js";
+// import { Example } from "./sp.js";
+import { Example } from "./graph.js";
 
 // setup the connection to SharePoint using the settings file, you can
 // override any of the values as you want here, just be sure not to commit

--- a/packages/core/extendable.ts
+++ b/packages/core/extendable.ts
@@ -74,7 +74,6 @@ export function extendable() {
  * @param target Object to which extensions are applied
  * @param extensions Extensions to apply
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
 export function extend<T extends object>(target: T, extensions: ExtensionType | ExtensionType[]): T {
 
     _enableExtensions = true;
@@ -115,8 +114,7 @@ export function extendFactory<T extends (...args: any[]) => any>(factory: T, ext
             factoryExtensions.set(key, []);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        extendCol(factoryExtensions.get(key)!, extensions);
+        extendCol(factoryExtensions.get(key), extensions);
     }
 }
 
@@ -153,14 +151,9 @@ export const enableExtensions = () => {
  */
 function extensionOrDefault(op: ValidProxyMethods, or: (...args: any[]) => any, target: any, ...rest: any[]): any {
 
-    if (_enableExtensions) {
+    if (_enableExtensions && Reflect.has(target, ObjExtensionsSym)) {
 
-        const extensions: ExtensionType[] = [];
-
-        // we need to invoke extensions tied to this object
-        if (Reflect.has(target, ObjExtensionsSym)) {
-            extensions.push(...Reflect.get(target, ObjExtensionsSym));
-        }
+        const extensions: ExtensionType[] = [...Reflect.get(target, ObjExtensionsSym)];
 
         let result = undefined;
 

--- a/packages/core/timeline.ts
+++ b/packages/core/timeline.ts
@@ -234,13 +234,8 @@ export abstract class Timeline<T extends Moments> {
         // initialize our timeline
         this.emit.init();
 
-        // execute the timeline and get a ref to the promise
-        // this gives the implementation of execute the ability to mutate the promise object, which
-        // enabled us to add the cancel behavior, and opens up another piece of flexibility in the framework
-        const p = this.execute(init);
-
         // attach our dispose logic
-        p.finally(() => {
+        return this.execute(init).finally(() => {
 
             try {
 
@@ -257,8 +252,6 @@ export abstract class Timeline<T extends Moments> {
                 this.error(e2);
             }
         });
-
-        return p;
     }
 
     /**

--- a/packages/graph/behaviors/paged.ts
+++ b/packages/graph/behaviors/paged.ts
@@ -1,4 +1,4 @@
-import { stringIsNullOrEmpty, TimelinePipe } from "@pnp/core";
+import { objectDefinedNotNull, stringIsNullOrEmpty, TimelinePipe } from "@pnp/core";
 import { errorCheck, parseODataJSON } from "@pnp/queryable";
 import { GraphQueryableCollection, IGraphQueryable, IGraphQueryableCollection } from "../graphqueryable.js";
 
@@ -22,7 +22,7 @@ export function AsPaged(col: IGraphQueryableCollection): IGraphQueryableCollecti
 
     for (let i = 0; i < queryParams.length; i++) {
         const param = col.query.get(queryParams[i]);
-        if (param !== undefined) {
+        if (objectDefinedNotNull(param)) {
             q.query.set(queryParams[i], param);
         }
     }

--- a/packages/graph/calendars/funcs.ts
+++ b/packages/graph/calendars/funcs.ts
@@ -34,7 +34,7 @@ export function findRooms(this: IGraphQueryable, roomList?: string): IGraphQuery
     const query = GraphQueryableCollection(this, roomList ? "findRooms(RoomList=@roomList)" : "findRooms");
     query.using(Endpoint("beta"));
     if (roomList) {
-        query.query.set("@roomList", `'${encodeURIComponent(roomList)}'`);
+        query.query.set("@roomList", `'${roomList}'`);
     }
     return query;
 }
@@ -49,8 +49,6 @@ export function findRooms(this: IGraphQueryable, roomList?: string): IGraphQuery
  */
 export function instances(this: IGraphQueryable, start: string, end: string): IGraphQueryableCollection<IInstance[]> {
     const query = GraphQueryableCollection(this, "instances");
-    // query.query.set("startDateTime", encodeURIComponent(start));
-    // query.query.set("endDateTime", encodeURIComponent(end));
     query.query.set("startDateTime", start);
     query.query.set("endDateTime", end);
     return query;

--- a/packages/graph/decorators.ts
+++ b/packages/graph/decorators.ts
@@ -149,7 +149,7 @@ export function getById<R>(factory: (...args: any[]) => R) {
 
         return class extends target {
             public getById(this: IGraphQueryable, id: string): R {
-                return factory(this, encodeURIComponent(id));
+                return factory(this, id);
             }
         };
     };

--- a/packages/graph/graphqueryable.ts
+++ b/packages/graph/graphqueryable.ts
@@ -55,7 +55,6 @@ export class _GraphQueryable<GetType = any> extends Queryable<GetType> {
      */
     public select(...selects: string[]): this {
         if (selects.length > 0) {
-            // this.query.set("$select", selects.map(encodeURIComponent).join(","));
             this.query.set("$select", selects.join(","));
         }
         return this;
@@ -68,26 +67,9 @@ export class _GraphQueryable<GetType = any> extends Queryable<GetType> {
      */
     public expand(...expands: string[]): this {
         if (expands.length > 0) {
-            // this.query.set("$expand", expands.map(encodeURIComponent).join(","));
             this.query.set("$expand", expands.join(","));
         }
         return this;
-    }
-
-    /**
-     * Gets the full url with query information
-     *
-     */
-    public toUrlAndQuery(): string {
-
-        let url = this.toUrl();
-
-        if (this.query.size > 0) {
-            const char = url.indexOf("?") > -1 ? "&" : "?";
-            url += `${char}${Array.from(this.query).map((v: [string, string]) => v[0] + "=" + v[1]).join("&")}`;
-        }
-
-        return url;
     }
 
     /**
@@ -131,7 +113,6 @@ export class _GraphQueryableCollection<GetType = any[]> extends _GraphQueryable<
     public orderBy(orderBy: string, ascending = true): this {
         const o = "$orderby";
         const query = this.query.get(o)?.split(",") || [];
-        // const eUri = encodeURIComponent(orderBy);
         query.push(`${orderBy} ${ascending ? "asc" : "desc"}`);
         this.query.set(o, query.join(","));
         return this;

--- a/packages/nodejs/sp-extensions/stream.ts
+++ b/packages/nodejs/sp-extensions/stream.ts
@@ -1,6 +1,6 @@
 import { asCancelableScope, CancelAction, headers } from "@pnp/queryable";
 import { File, Files, IFile, IFileAddResult, IFiles, IFileUploadProgressData } from "@pnp/sp/files/index.js";
-import { spPost, escapeQueryStrValue } from "@pnp/sp";
+import { spPost, encodePath } from "@pnp/sp";
 import { ReadStream } from "fs";
 import { PassThrough } from "stream";
 import { extendFactory, getGUID, isFunc } from "@pnp/core";
@@ -94,7 +94,7 @@ extendFactory(Files, {
         chunkSize = 10485760
     ) {
 
-        const response = await spPost(Files(this, `add(overwrite=${shouldOverWrite},url='${escapeQueryStrValue(url)}')`));
+        const response = await spPost(Files(this, `add(overwrite=${shouldOverWrite},url='${encodePath(url)}')`));
 
         const file = fileFromServerRelativePath(this, response.ServerRelativeUrl);
 

--- a/packages/queryable/queryable.ts
+++ b/packages/queryable/queryable.ts
@@ -34,7 +34,7 @@ export type QueryableInit = Queryable<any> | string | [Queryable<any>, string];
 export class Queryable<R> extends Timeline<typeof DefaultMoments> implements IQueryableInternal<R> {
 
     // tracks any query paramters which will be appended to the request url
-    private _query: Map<string, string>;
+    private _query: URLSearchParams;
 
     // tracks the current url for a given Queryable
     protected _url: string;
@@ -50,7 +50,7 @@ export class Queryable<R> extends Timeline<typeof DefaultMoments> implements IQu
 
         super(DefaultMoments);
 
-        this._query = new Map<string, string>();
+        this._query = new URLSearchParams();
 
         // add an intneral moment with specific implementaion for promise creation
         this.moments[this.InternalPromise] = reduce<QueryablePromiseObserver>();
@@ -102,19 +102,18 @@ export class Queryable<R> extends Timeline<typeof DefaultMoments> implements IQu
      */
     public toRequestUrl(): string {
 
-        let u = this.toUrl();
+        let url = this.toUrl();
 
-        if (this._query.size > 0) {
-            u += "?" + Array.from(this._query).map((v: [string, string]) => `${v[0]}=${encodeURIComponent(v[1])}`).join("&");
-        }
+        const char = url.indexOf("?") > -1 ? "&" : "?";
+        url += char + this.query.toString();
 
-        return u;
+        return url;
     }
 
     /**
      * Querystring key, value pairs which will be included in the request
      */
-    public get query(): Map<string, string> {
+    public get query(): URLSearchParams {
         return this._query;
     }
 
@@ -224,7 +223,7 @@ export interface Queryable<R = any> extends IInvokable<R> { }
 
 // this interface is required to stop the class from recursively referencing itself through the DefaultBehaviors type
 export interface IQueryableInternal<R = any> extends Timeline<any>, IInvokable {
-    readonly query: Map<string, string>;
+    readonly query: URLSearchParams;
     <T = R>(this: IQueryableInternal, init?: RequestInit): Promise<T>;
     using(...behaviors: TimelinePipe[]): this;
     toRequestUrl(): string;

--- a/packages/sp/appcatalog/types.ts
+++ b/packages/sp/appcatalog/types.ts
@@ -59,9 +59,7 @@ export class _AppCatalog extends _SPCollection {
             }
         }
 
-        const poster = AppCatalog([this, webUrl], `/tenantappcatalog/SyncSolutionToTeams(id=${appId})`);
-
-        return await spPost(poster);
+        return spPost(AppCatalog([this, webUrl], `/tenantappcatalog/SyncSolutionToTeams(id=${appId})`));
     }
 
     /**

--- a/packages/sp/clientside-pages/types.ts
+++ b/packages/sp/clientside-pages/types.ts
@@ -871,7 +871,7 @@ export class _ClientsidePage extends _SPQueryable {
             }
         }
 
-        return await spPost(ClientsidePage(this, `_api/sitepages/pages(${this.json.Id})/${method}`));
+        return spPost(ClientsidePage(this, `_api/sitepages/pages(${this.json.Id})/${method}`));
     }
 
     /**

--- a/packages/sp/clientside-pages/types.ts
+++ b/packages/sp/clientside-pages/types.ts
@@ -639,9 +639,9 @@ export class _ClientsidePage extends _SPQueryable {
         const filename = fileUrl.pathname.split(/[\\/]/i).pop();
 
         const request = ClientsidePage(this, "_api/sitepages/AddImageFromExternalUrl");
-        request.query.set("imageFileName", `'${encodeURIComponent(filename)}'`);
-        request.query.set("pageName", `'${encodeURIComponent(pageName)}'`);
-        request.query.set("externalUrl", `'${encodeURIComponent(url)}'`);
+        request.query.set("imageFileName", `'${filename}'`);
+        request.query.set("pageName", `'${pageName}'`);
+        request.query.set("externalUrl", `'${url}'`);
         request.select("ServerRelativeUrl");
 
         const result = await spPost<Pick<IFileInfo, "ServerRelativeUrl">>(request);

--- a/packages/sp/column-defaults/list.ts
+++ b/packages/sp/column-defaults/list.ts
@@ -4,9 +4,9 @@ import { Folder } from "../folders/types.js";
 import { IFieldDefault } from "./types.js";
 import { IResourcePath } from "../utils/to-resource-path.js";
 import { combine, isArray } from "@pnp/core";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
 import { spPost } from "../operations.js";
 import { SPCollection } from "../presets/all.js";
+import { encodePath } from "../utils/encode-path-str.js";
 
 declare module "../lists/types" {
     interface _List {
@@ -35,7 +35,7 @@ _List.prototype.getDefaultColumnValues = async function (this: _List): Promise<I
     const pathPart: { ServerRelativePath: IResourcePath } = await this.rootFolder.select("ServerRelativePath")();
     const webUrl: { ParentWeb: { Url: string } } = await this.select("ParentWeb/Url").expand("ParentWeb")();
     const path = combine("/", pathPart.ServerRelativePath.DecodedUrl, "Forms/client_LocationBasedDefaults.html");
-    const baseFilePath = combine(webUrl.ParentWeb.Url, `_api/web/getFileByServerRelativePath(decodedUrl='${escapeQueryStrValue(path)}')`);
+    const baseFilePath = combine(webUrl.ParentWeb.Url, `_api/web/getFileByServerRelativePath(decodedUrl='${encodePath(path)}')`);
 
     let xml = "";
 
@@ -197,7 +197,7 @@ _List.prototype.setDefaultColumnValues = async function (this: _List, defaults: 
     const pathPart: { ServerRelativePath: IResourcePath } = await this.rootFolder.select("ServerRelativePath")();
     const webUrl: { ParentWeb: { Url: string } } = await this.select("ParentWeb/Url").expand("ParentWeb")();
     const path = combine("/", pathPart.ServerRelativePath.DecodedUrl, "Forms");
-    const baseFilePath = combine(webUrl.ParentWeb.Url, "_api/web", `getFolderByServerRelativePath(decodedUrl='${escapeQueryStrValue(path)}')`, "files");
+    const baseFilePath = combine(webUrl.ParentWeb.Url, "_api/web", `getFolderByServerRelativePath(decodedUrl='${encodePath(path)}')`, "files");
 
     await spPost(Folder([this, baseFilePath], "add(overwrite=true,url='client_LocationBasedDefaults.html')"), { body: xml });
 

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -93,7 +93,7 @@ export class _Files extends _SPCollection<IFileInfo[]> {
             return File(file).delete();
         }));
 
-        return await file.setContentChunked(content, progress, chunkSize);
+        return file.setContentChunked(content, progress, chunkSize);
     }
 
     /**

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -14,10 +14,10 @@ import { Item, IItem } from "../items/index.js";
 import { odataUrlFrom } from "../utils/odata-url-from.js";
 import { defaultPath } from "../decorators.js";
 import { spPost, spGet } from "../operations.js";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
 import { extractWebUrl } from "../utils/extract-web-url.js";
 import { toResourcePath } from "../utils/to-resource-path.js";
 import { ISiteUserProps } from "../site-users/types.js";
+import { encodePath } from "../utils/encode-path-str.js";
 
 /**
  * Describes a collection of File objects
@@ -35,7 +35,7 @@ export class _Files extends _SPCollection<IFileInfo[]> {
         if (/%#/.test(name)) {
             throw Error("For file names containing % or # please use web.getFileByServerRelativePath");
         }
-        return File(this).concat(`('${escapeQueryStrValue(name)}')`);
+        return File(this).concat(`('${encodePath(name)}')`);
     }
 
     /**
@@ -48,7 +48,7 @@ export class _Files extends _SPCollection<IFileInfo[]> {
     @cancelableScope
     public async addUsingPath(url: string, content: string | ArrayBuffer | Blob, parameters: IAddUsingPathProps = { Overwrite: false }): Promise<IFileAddResult> {
 
-        const path = [`AddUsingPath(decodedurl='${escapeQueryStrValue(url)}'`];
+        const path = [`AddUsingPath(decodedurl='${encodePath(url)}'`];
 
         if (parameters) {
             if (parameters.Overwrite) {
@@ -58,7 +58,7 @@ export class _Files extends _SPCollection<IFileInfo[]> {
                 path.push(",AutoCheckoutOnInvalidData=true");
             }
             if (!stringIsNullOrEmpty(parameters.XorHash)) {
-                path.push(`,XorHash=${escapeQueryStrValue(parameters.XorHash)}`);
+                path.push(`,XorHash=${encodePath(parameters.XorHash)}`);
             }
         }
 
@@ -85,7 +85,7 @@ export class _Files extends _SPCollection<IFileInfo[]> {
     @cancelableScope
     public async addChunked(url: string, content: Blob, progress?: (data: IFileUploadProgressData) => void, shouldOverWrite = true, chunkSize = 10485760): Promise<IFileAddResult> {
 
-        const response = await spPost(Files(this, `add(overwrite=${shouldOverWrite},url='${escapeQueryStrValue(url)}')`));
+        const response = await spPost(Files(this, `add(overwrite=${shouldOverWrite},url='${encodePath(url)}')`));
 
         const file = fileFromServerRelativePath(this, response.ServerRelativeUrl);
 
@@ -105,7 +105,7 @@ export class _Files extends _SPCollection<IFileInfo[]> {
      */
     @cancelableScope
     public async addTemplateFile(fileUrl: string, templateFileType: TemplateFileType): Promise<IFileAddResult> {
-        const response: IFileInfo = await spPost(Files(this, `addTemplateFile(urloffile='${escapeQueryStrValue(fileUrl)}',templatefiletype=${templateFileType})`));
+        const response: IFileInfo = await spPost(Files(this, `addTemplateFile(urloffile='${encodePath(fileUrl)}',templatefiletype=${templateFileType})`));
         return {
             data: response,
             file: fileFromServerRelativePath(this, response.ServerRelativeUrl),
@@ -158,7 +158,7 @@ export class _File extends _SPInstance<IFileInfo> {
      * @param comment The comment for the approval.
      */
     public approve(comment = ""): Promise<void> {
-        return spPost(File(this, `approve(comment='${escapeQueryStrValue(comment)}')`));
+        return spPost(File(this, `approve(comment='${encodePath(comment)}')`));
     }
 
     /**
@@ -186,7 +186,7 @@ export class _File extends _SPInstance<IFileInfo> {
             throw Error("The maximum comment length is 1023 characters.");
         }
 
-        return spPost(File(this, `checkin(comment='${escapeQueryStrValue(comment)}',checkintype=${checkinType})`));
+        return spPost(File(this, `checkin(comment='${encodePath(comment)}',checkintype=${checkinType})`));
     }
 
     /**
@@ -203,7 +203,7 @@ export class _File extends _SPInstance<IFileInfo> {
      * @param shouldOverWrite Should a file with the same name in the same location be overwritten?
      */
     public copyTo(url: string, shouldOverWrite = true): Promise<void> {
-        return spPost(File(this, `copyTo(strnewurl='${escapeQueryStrValue(url)}',boverwrite=${shouldOverWrite})`));
+        return spPost(File(this, `copyTo(strnewurl='${encodePath(url)}',boverwrite=${shouldOverWrite})`));
     }
 
     /**
@@ -241,7 +241,7 @@ export class _File extends _SPInstance<IFileInfo> {
         if (comment.length > 1023) {
             throw Error("The maximum comment length is 1023 characters.");
         }
-        return spPost(File(this, `deny(comment='${escapeQueryStrValue(comment)}')`));
+        return spPost(File(this, `deny(comment='${encodePath(comment)}')`));
     }
 
     /**
@@ -277,7 +277,7 @@ export class _File extends _SPInstance<IFileInfo> {
         if (comment.length > 1023) {
             throw Error("The maximum comment length is 1023 characters.");
         }
-        return spPost(File(this, `publish(comment='${escapeQueryStrValue(comment)}')`));
+        return spPost(File(this, `publish(comment='${encodePath(comment)}')`));
     }
 
     /**
@@ -315,7 +315,7 @@ export class _File extends _SPInstance<IFileInfo> {
         if (comment.length > 1023) {
             throw Error("The maximum comment length is 1023 characters.");
         }
-        return spPost(File(this, `unpublish(comment='${escapeQueryStrValue(comment)}')`));
+        return spPost(File(this, `unpublish(comment='${encodePath(comment)}')`));
     }
 
     /**
@@ -508,7 +508,7 @@ export const File = spInvokableFactory<IFile>(_File);
  */
 export function fileFromServerRelativePath(base: ISPQueryable, serverRelativePath: string): IFile {
 
-    return File([base, extractWebUrl(base.toUrl())], `_api/web/getFileByServerRelativePath(decodedUrl='${escapeQueryStrValue(serverRelativePath)}')`);
+    return File([base, extractWebUrl(base.toUrl())], `_api/web/getFileByServerRelativePath(decodedUrl='${encodePath(serverRelativePath)}')`);
 }
 
 /**
@@ -559,7 +559,7 @@ export class _Versions extends _SPCollection {
      * @param label The version label of the file version to delete, for example: 1.2
      */
     public deleteByLabel(label: string): Promise<void> {
-        return spPost(Versions(this, `deleteByLabel(versionlabel='${escapeQueryStrValue(label)}')`));
+        return spPost(Versions(this, `deleteByLabel(versionlabel='${encodePath(label)}')`));
     }
 
     /**
@@ -568,7 +568,7 @@ export class _Versions extends _SPCollection {
      * @param label The version label of the file version to delete, for example: 1.2
      */
     public recycleByLabel(label: string): Promise<void> {
-        return spPost(Versions(this, `recycleByLabel(versionlabel='${escapeQueryStrValue(label)}')`));
+        return spPost(Versions(this, `recycleByLabel(versionlabel='${encodePath(label)}')`));
     }
 
     /**
@@ -577,7 +577,7 @@ export class _Versions extends _SPCollection {
      * @param label The version label of the file version to restore, for example: 1.2
      */
     public restoreByLabel(label: string): Promise<void> {
-        return spPost(Versions(this, `restoreByLabel(versionlabel='${escapeQueryStrValue(label)}')`));
+        return spPost(Versions(this, `restoreByLabel(versionlabel='${encodePath(label)}')`));
     }
 }
 export interface IVersions extends _Versions { }

--- a/packages/sp/files/web.ts
+++ b/packages/sp/files/web.ts
@@ -1,6 +1,5 @@
 import { _Web } from "../webs/types.js";
 import { File, fileFromServerRelativePath, IFile } from "./types.js";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
 
 declare module "../webs/types" {
     interface _Web {
@@ -42,5 +41,5 @@ _Web.prototype.getFileById = function (this: _Web, uniqueId: string): IFile {
 };
 
 _Web.prototype.getFileByUrl = function (this: _Web, fileUrl: string): IFile {
-    return File(this, `getFileByUrl('!@p1::${escapeQueryStrValue(fileUrl)}')`);
+    return File(this, `getFileByUrl('!@p1::${fileUrl}')`);
 };

--- a/packages/sp/files/web.ts
+++ b/packages/sp/files/web.ts
@@ -1,3 +1,4 @@
+import { encodePath } from "../utils/encode-path-str.js";
 import { _Web } from "../webs/types.js";
 import { File, fileFromServerRelativePath, IFile } from "./types.js";
 
@@ -41,5 +42,5 @@ _Web.prototype.getFileById = function (this: _Web, uniqueId: string): IFile {
 };
 
 _Web.prototype.getFileByUrl = function (this: _Web, fileUrl: string): IFile {
-    return File(this, `getFileByUrl('!@p1::${fileUrl}')`);
+    return File(this, `getFileByUrl('${encodePath("!@p1::" + fileUrl)}')`);
 };

--- a/packages/sp/folders/types.ts
+++ b/packages/sp/folders/types.ts
@@ -14,9 +14,9 @@ import { odataUrlFrom } from "../utils/odata-url-from.js";
 import { IItem, Item } from "../items/types.js";
 import { defaultPath } from "../decorators.js";
 import { spPost, spPostMerge } from "../operations.js";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
 import { extractWebUrl } from "../utils/extract-web-url.js";
 import { toResourcePath, IResourcePath } from "../utils/to-resource-path.js";
+import { encodePath } from "../utils/encode-path-str.js";
 
 @defaultPath("folders")
 export class _Folders extends _SPCollection<IFolderInfo[]> {
@@ -27,7 +27,7 @@ export class _Folders extends _SPCollection<IFolderInfo[]> {
      * @param name Folder's name
      */
     public getByUrl(name: string): IFolder {
-        return Folder(this).concat(`('${escapeQueryStrValue(name)}')`);
+        return Folder(this).concat(`('${encodePath(name)}')`);
     }
 
     /**
@@ -38,7 +38,7 @@ export class _Folders extends _SPCollection<IFolderInfo[]> {
      */
     public async addUsingPath(serverRelativeUrl: string, overwrite = false): Promise<IFolderAddResult> {
 
-        const data: IFolderInfo = await spPost(Folders(this, `addUsingPath(DecodedUrl='${escapeQueryStrValue(serverRelativeUrl)}',overwrite=${overwrite})`));
+        const data: IFolderInfo = await spPost(Folders(this, `addUsingPath(DecodedUrl='${encodePath(serverRelativeUrl)}',overwrite=${overwrite})`));
 
         return {
             data,
@@ -251,7 +251,7 @@ export const Folder = spInvokableFactory<IFolder>(_Folder);
  */
 export function folderFromServerRelativePath(base: ISPQueryable, serverRelativePath: string): IFolder {
 
-    return Folder([base, extractWebUrl(base.toUrl())], `_api/web/getFolderByServerRelativePath(decodedUrl='${escapeQueryStrValue(serverRelativePath)}')`);
+    return Folder([base, extractWebUrl(base.toUrl())], `_api/web/getFolderByServerRelativePath(decodedUrl='${encodePath(serverRelativePath)}')`);
 }
 
 /**

--- a/packages/sp/index.ts
+++ b/packages/sp/index.ts
@@ -16,6 +16,7 @@ export * from "./utils/extract-web-url.js";
 export * from "./utils/file-names.js";
 export * from "./utils/odata-url-from.js";
 export * from "./utils/to-resource-path.js";
+export * from "./utils/encode-path-str.js";
 
 export * from "./behaviors/defaults.js";
 export * from "./behaviors/telemetry.js";

--- a/packages/sp/items/types.ts
+++ b/packages/sp/items/types.ts
@@ -10,7 +10,7 @@ import {
     ISPInstance,
 } from "../spqueryable.js";
 import { hOP } from "@pnp/core";
-import { escapeQueryStrValue, extractWebUrl } from "@pnp/sp";
+import { extractWebUrl } from "@pnp/sp";
 import { IListItemFormUpdateValue, List } from "../lists/types.js";
 import { body, headers, parseBinderWithErrorCheck, parseODataJSON } from "@pnp/queryable";
 import { IList } from "../lists/index.js";
@@ -52,9 +52,9 @@ export class _Items extends _SPCollection {
      */
     public skip(skip: number, reverse = false): this {
         if (reverse) {
-            this.query.set("$skiptoken", encodeURIComponent(`Paged=TRUE&PagedPrev=TRUE&p_ID=${skip}`));
+            this.query.set("$skiptoken", `Paged=TRUE&PagedPrev=TRUE&p_ID=${skip}`);
         } else {
-            this.query.set("$skiptoken", encodeURIComponent(`Paged=TRUE&p_ID=${skip}`));
+            this.query.set("$skiptoken", `Paged=TRUE&p_ID=${skip}`);
         }
         return this;
     }
@@ -256,9 +256,9 @@ export class _Item extends _SPInstance {
 
         const q = SPQueryable(webUrl, "/_api/web/UploadImage");
         q.concat("(listTitle=@a1,imageName=@a2,listId=@a3,itemId=@a4)");
-        q.query.set("@a1", `'${escapeQueryStrValue(contextInfo.ParentList.Title)}'`);
-        q.query.set("@a2", `'${escapeQueryStrValue(imageName)}'`);
-        q.query.set("@a3", `'${escapeQueryStrValue(contextInfo.ParentList.Id)}'`);
+        q.query.set("@a1", `'${contextInfo.ParentList.Title}'`);
+        q.query.set("@a2", `'${imageName}'`);
+        q.query.set("@a3", `'${contextInfo.ParentList.Id}'`);
         q.query.set("@a4", contextInfo.Item.Id);
 
         const result = await spPost<IItemImageUploadResult>(q, { body: imageContent });

--- a/packages/sp/lists/types.ts
+++ b/packages/sp/lists/types.ts
@@ -15,7 +15,6 @@ import { IChangeQuery } from "../types.js";
 import { odataUrlFrom } from "../utils/odata-url-from.js";
 import { defaultPath } from "../decorators.js";
 import { spPost, spPostMerge } from "../operations.js";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
 import { IBasePermissions } from "../security/types.js";
 import { IFieldInfo } from "../fields/types.js";
 import { IFormInfo } from "../forms/types.js";
@@ -23,6 +22,7 @@ import { IFolderInfo } from "../folders/types.js";
 import { IViewInfo } from "../views/types.js";
 import { IUserCustomActionInfo } from "../user-custom-actions/types.js";
 import { IResourcePath, toResourcePath } from "../utils/to-resource-path.js";
+import { encodePath } from "../utils/encode-path-str.js";
 
 @defaultPath("lists")
 export class _Lists extends _SPCollection<IListInfo[]> {
@@ -42,7 +42,7 @@ export class _Lists extends _SPCollection<IListInfo[]> {
      * @param title The title of the list
      */
     public getByTitle(title: string): IList {
-        return List(this, `getByTitle('${escapeQueryStrValue(title)}')`);
+        return List(this, `getByTitle('${encodePath(title)}')`);
     }
 
     /**

--- a/packages/sp/lists/web.ts
+++ b/packages/sp/lists/web.ts
@@ -3,7 +3,7 @@ import { _Web, Web } from "../webs/types.js";
 import { Lists, ILists, IList, List } from "./types.js";
 import { odataUrlFrom } from "../utils/odata-url-from.js";
 import { ISPCollection, SPCollection } from "../spqueryable.js";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
+import { encodePath } from "../utils/encode-path-str.js";
 
 declare module "../webs/types" {
     interface _Web {
@@ -59,7 +59,7 @@ addProp(_Web, "defaultDocumentLibrary", List);
 addProp(_Web, "customListTemplates", SPCollection, "getcustomlisttemplates");
 
 _Web.prototype.getList = function (this: _Web, listRelativeUrl: string): IList {
-    return List(this, `getList('${escapeQueryStrValue(listRelativeUrl)}')`);
+    return List(this, `getList('${encodePath(listRelativeUrl)}')`);
 };
 
 _Web.prototype.getCatalog = async function (this: _Web, type: number): Promise<IList> {

--- a/packages/sp/profiles/types.ts
+++ b/packages/sp/profiles/types.ts
@@ -51,7 +51,7 @@ export class _Profiles extends _SPInstance {
      */
     public amIFollowedBy(loginName: string): Promise<boolean> {
         const q = Profiles(this, "amifollowedby(@v)");
-        q.query.set("@v", `'${encodeURIComponent(loginName)}'`);
+        q.query.set("@v", `'${loginName}'`);
         return q();
     }
 
@@ -62,7 +62,7 @@ export class _Profiles extends _SPInstance {
      */
     public amIFollowing(loginName: string): Promise<boolean> {
         const q = Profiles(this, "amifollowing(@v)");
-        q.query.set("@v", `'${encodeURIComponent(loginName)}'`);
+        q.query.set("@v", `'${loginName}'`);
         return q();
     }
 
@@ -82,7 +82,7 @@ export class _Profiles extends _SPInstance {
      */
     public getFollowersFor(loginName: string): Promise<any[]> {
         const q = Profiles(this, "getfollowersfor(@v)");
-        q.query.set("@v", `'${encodeURIComponent(loginName)}'`);
+        q.query.set("@v", `'${loginName}'`);
         return q();
     }
 
@@ -109,7 +109,7 @@ export class _Profiles extends _SPInstance {
      */
     public getPeopleFollowedBy(loginName: string): Promise<any[]> {
         const q = Profiles(this, "getpeoplefollowedby(@v)");
-        q.query.set("@v", `'${encodeURIComponent(loginName)}'`);
+        q.query.set("@v", `'${loginName}'`);
         return q();
     }
 
@@ -120,7 +120,7 @@ export class _Profiles extends _SPInstance {
      */
     public getPropertiesFor(loginName: string): Promise<any> {
         const q = Profiles(this, "getpropertiesfor(@v)");
-        q.query.set("@v", `'${encodeURIComponent(loginName)}'`);
+        q.query.set("@v", `'${loginName}'`);
         return q();
     }
 
@@ -142,7 +142,7 @@ export class _Profiles extends _SPInstance {
      */
     public getUserProfilePropertyFor(loginName: string, propertyName: string): Promise<string> {
         const q = Profiles(this, `getuserprofilepropertyfor(accountname=@v, propertyname='${propertyName}')`);
-        q.query.set("@v", `'${encodeURIComponent(loginName)}'`);
+        q.query.set("@v", `'${loginName}'`);
         return q();
     }
 
@@ -153,7 +153,7 @@ export class _Profiles extends _SPInstance {
      */
     public hideSuggestion(loginName: string): Promise<void> {
         const q = Profiles(this, "hidesuggestion(@v)");
-        q.query.set("@v", `'${encodeURIComponent(loginName)}'`);
+        q.query.set("@v", `'${loginName}'`);
         return spPost(q);
     }
 
@@ -166,8 +166,8 @@ export class _Profiles extends _SPInstance {
     public isFollowing(follower: string, followee: string): Promise<boolean> {
         const q = Profiles(this, null);
         q.concat(".isfollowing(possiblefolloweraccountname=@v, possiblefolloweeaccountname=@y)");
-        q.query.set("@v", `'${encodeURIComponent(follower)}'`);
-        q.query.set("@y", `'${encodeURIComponent(followee)}'`);
+        q.query.set("@v", `'${follower}'`);
+        q.query.set("@y", `'${followee}'`);
         return q();
     }
 

--- a/packages/sp/security/funcs.ts
+++ b/packages/sp/security/funcs.ts
@@ -10,7 +10,7 @@ import { spPost } from "../operations.js";
 export async function getUserEffectivePermissions(this: SecurableQueryable, loginName: string): Promise<IBasePermissions> {
 
     const q = SPInstance(this, "getUserEffectivePermissions(@user)");
-    q.query.set("@user", `'${encodeURIComponent(loginName)}'`);
+    q.query.set("@user", `'${loginName}'`);
     return q();
 }
 

--- a/packages/sp/site-groups/web.ts
+++ b/packages/sp/site-groups/web.ts
@@ -1,5 +1,4 @@
 import { addProp } from "@pnp/queryable";
-import { escapeQueryStrValue } from "../index.js";
 import { spPost } from "../operations.js";
 import { Web, _Web } from "../webs/types.js";
 import { ISiteGroups, SiteGroups, ISiteGroup, SiteGroup } from "./types.js";
@@ -66,9 +65,9 @@ _Web.prototype.createDefaultAssociatedGroups = async function (
     await this.breakRoleInheritance(copyRoleAssignments, clearSubscopes);
 
     const q = Web(this, "createDefaultAssociatedGroups(userLogin=@u,userLogin2=@v,groupNameSeed=@s)");
-    q.query.set("@u", `'${escapeQueryStrValue(siteOwner || "")}'`);
-    q.query.set("@v", `'${escapeQueryStrValue(siteOwner2 || "")}'`);
-    q.query.set("@s", `'${escapeQueryStrValue(groupNameSeed || "")}'`);
+    q.query.set("@u", `'${siteOwner || ""}'`);
+    q.query.set("@v", `'${siteOwner2 || ""}'`);
+    q.query.set("@s", `'${groupNameSeed || ""}'`);
     return spPost(q);
 };
 

--- a/packages/sp/site-scripts/types.ts
+++ b/packages/sp/site-scripts/types.ts
@@ -2,8 +2,8 @@ import { body } from "@pnp/queryable";
 import { spPost } from "../operations.js";
 import { ISPQueryable, _SPQueryable } from "../spqueryable.js";
 import { extractWebUrl } from "../utils/extract-web-url.js";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
 import { combine } from "@pnp/core";
+import { encodePath } from "../utils/encode-path-str.js";
 
 export class _SiteScripts extends _SPQueryable {
 
@@ -31,7 +31,7 @@ export class _SiteScripts extends _SPQueryable {
      */
     public createSiteScript(title: string, description: string, content: any): Promise<ISiteScriptInfo> {
         return SiteScriptsCloneFactory(this,
-            `CreateSiteScript(Title=@title,Description=@desc)?@title='${escapeQueryStrValue(title)}'&@desc='${escapeQueryStrValue(description)}'`)
+            `CreateSiteScript(Title=@title,Description=@desc)?@title='${encodePath(title)}'&@desc='${encodePath(description)}'`)
             .run<ISiteScriptInfo>(content);
     }
 

--- a/packages/sp/site-users/types.ts
+++ b/packages/sp/site-users/types.ts
@@ -38,7 +38,7 @@ export class _SiteUsers extends _SPCollection<ISiteUserInfo[]> {
      * @param loginName The login name of the user to retrieve
      */
     public getByLoginName(loginName: string): ISiteUser {
-        return SiteUser(this).concat(`('!@v::${encodeURIComponent(loginName)}')`);
+        return SiteUser(this).concat(`('!@v::${loginName}')`);
     }
 
     /**
@@ -57,7 +57,7 @@ export class _SiteUsers extends _SPCollection<ISiteUserInfo[]> {
      */
     public removeByLoginName(loginName: string): Promise<any> {
         const o = SiteUsers(this, "removeByLoginName(@v)");
-        o.query.set("@v", `'${encodeURIComponent(loginName)}'`);
+        o.query.set("@v", `'${loginName}'`);
         return spPost(o);
     }
 

--- a/packages/sp/sites/types.ts
+++ b/packages/sp/sites/types.ts
@@ -5,7 +5,6 @@ import { combine, hOP, isArray } from "@pnp/core";
 import { body, TextParse } from "@pnp/queryable";
 import { odataUrlFrom } from "../utils/odata-url-from.js";
 import { spPost } from "../operations.js";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
 import { IChangeQuery } from "../types.js";
 import { extractWebUrl } from "../utils/extract-web-url.js";
 import { emptyGuid } from "../types.js";
@@ -134,7 +133,7 @@ export class _Site extends _SPInstance {
      */
     public async getDocumentLibraries(absoluteWebUrl: string): Promise<IDocumentLibraryInformation[]> {
         const q = Site([this, this.parentUrl], "_api/sp.web.getdocumentlibraries(@v)");
-        q.query.set("@v", `'${escapeQueryStrValue(absoluteWebUrl)}'`);
+        q.query.set("@v", `'${absoluteWebUrl}'`);
         const data = await q();
         return hOP(data, "GetDocumentLibraries") ? data.GetDocumentLibraries : data;
     }
@@ -147,7 +146,7 @@ export class _Site extends _SPInstance {
     public async getWebUrlFromPageUrl(absolutePageUrl: string): Promise<string> {
 
         const q = Site([this, this.parentUrl], "_api/sp.web.getweburlfrompageurl(@v)");
-        q.query.set("@v", `'${escapeQueryStrValue(absolutePageUrl)}'`);
+        q.query.set("@v", `'${absolutePageUrl}'`);
         const data = await q();
         return hOP(data, "GetWebUrlFromPageUrl") ? data.GetWebUrlFromPageUrl : data;
     }

--- a/packages/sp/social/types.ts
+++ b/packages/sp/social/types.ts
@@ -26,15 +26,15 @@ export class _Social extends _SPInstance implements ISocial {
     }
 
     public async follow(actorInfo: ISocialActorInfo): Promise<SocialFollowResult> {
-        return await spPost(SocialCloneFactory(this, "follow"), this.createSocialActorInfoRequestBody(actorInfo));
+        return spPost(SocialCloneFactory(this, "follow"), this.createSocialActorInfoRequestBody(actorInfo));
     }
 
     public async isFollowed(actorInfo: ISocialActorInfo): Promise<boolean> {
-        return await spPost(SocialCloneFactory(this, "isfollowed"), this.createSocialActorInfoRequestBody(actorInfo));
+        return spPost(SocialCloneFactory(this, "isfollowed"), this.createSocialActorInfoRequestBody(actorInfo));
     }
 
     public async stopFollowing(actorInfo: ISocialActorInfo): Promise<void> {
-        return await spPost(SocialCloneFactory(this, "stopfollowing"), this.createSocialActorInfoRequestBody(actorInfo));
+        return spPost(SocialCloneFactory(this, "stopfollowing"), this.createSocialActorInfoRequestBody(actorInfo));
     }
 
     private createSocialActorInfoRequestBody(actorInfo: ISocialActorInfo) {

--- a/packages/sp/spqueryable.ts
+++ b/packages/sp/spqueryable.ts
@@ -82,17 +82,22 @@ export class _SPQueryable<GetType = any> extends Queryable<GetType> {
 
         const aliasedParams = new URLSearchParams(this.query);
 
-        // '!(@.*?)::(.*?)(?<!')'(?!')/ig <- Lookback query breaks Safari browser https://caniuse.com/js-regexp-lookbehind
-        let url = this.toUrl().replace(/'!(@.*?)::(.*?)'/ig, (match, labelName, value) => {
+        // this regex is designed to locate aliased parameters within url paths. These may have the form:
+        // /something(!@p1::value)
+        // /something(!@p1::value, param=value)
+        // /something(param=value,!@p1::value)
+        // /something(param=value,!@p1::value,param=value)
+        // /something(param=!@p1::value)
+        // there could be spaces or not around the boundaries
+        let url = this.toUrl().replace(/([( *| *, *| *= *])'!(@.*?)::(.*?)'([ *)| *, *])/ig, (match, frontBoundary, labelName, value, endBoundary) => {
             this.log(`Rewriting aliased parameter from match ${match} to label: ${labelName} value: ${value}`, 0);
-            aliasedParams.set(labelName, `'${value}'`);
-            return labelName;
+            aliasedParams.set(labelName,`'${value}'`);
+            return `${frontBoundary}${labelName}${endBoundary}`;
         });
 
         const query = aliasedParams.toString();
         if (!stringIsNullOrEmpty(query)) {
-            const char = url.indexOf("?") > -1 ? "&" : "?";
-            url += `${char}${query}`;
+            url += `${url.indexOf("?") > -1 ? "&" : "?"}${query}`;
         }
 
         return url;

--- a/packages/sp/taxonomy/types.ts
+++ b/packages/sp/taxonomy/types.ts
@@ -1,7 +1,7 @@
 import { isArray } from "@pnp/core";
 import { defaultPath } from "../decorators.js";
 import { _SPInstance, spInvokableFactory, _SPCollection } from "../spqueryable.js";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
+import { encodePath } from "../utils/encode-path-str.js";
 
 /**
  * Describes a collection of Form objects
@@ -33,7 +33,7 @@ export class _TermStore extends _SPInstance<ITermStoreInfo> {
     public async searchTerm(params: ISearchTermParams): Promise<Required<Pick<ITermInfo, SearchTermPickedProps>>[]> {
 
         const query = Reflect.ownKeys(params).reduce((c, prop: string) => {
-            c.push(`${prop}='${escapeQueryStrValue(params[prop])}'`);
+            c.push(`${prop}='${encodePath(params[prop])}'`);
             return c;
         }, []).join(",");
 

--- a/packages/sp/utils/encode-path-str.ts
+++ b/packages/sp/utils/encode-path-str.ts
@@ -1,7 +1,12 @@
 import { stringIsNullOrEmpty } from "@pnp/core";
 
-// deprecated, will be removed in future versions
-export function escapeQueryStrValue(value: string): string {
+/**
+ * Encodes path portions of SharePoint urls such as decodedUrl=`encodePath(pathStr)`
+ *
+ * @param value The string path to encode
+ * @returns A path encoded for use in SP urls
+ */
+export function encodePath(value: string): string {
 
     if (stringIsNullOrEmpty(value)) {
         return "";
@@ -15,6 +20,6 @@ export function escapeQueryStrValue(value: string): string {
         });
 
     } else {
-        return value.replace(/'/ig, "''");
+        return encodeURIComponent(value.replace(/'/ig, "''"));
     }
 }

--- a/packages/sp/utils/encode-path-str.ts
+++ b/packages/sp/utils/encode-path-str.ts
@@ -16,10 +16,14 @@ export function encodePath(value: string): string {
     if (/!(@.*?)::(.*?)/ig.test(value)) {
 
         return value.replace(/!(@.*?)::(.*)$/ig, (match, labelName, v) => {
+            // we do not need to encodeURIComponent v as it will be encoded automatically when it is added as a query string param
+            // we do need to double any ' chars
             return `!${labelName}::${v.replace(/'/ig, "''")}`;
         });
 
     } else {
+
+        // because this is a literal path value we encodeURIComponent after doubling any ' chars
         return encodeURIComponent(value.replace(/'/ig, "''"));
     }
 }

--- a/packages/sp/utils/escape-query-str.ts
+++ b/packages/sp/utils/escape-query-str.ts
@@ -1,6 +1,6 @@
 import { stringIsNullOrEmpty } from "@pnp/core";
 
-// deprecated, will be removed in future versions
+// deprecated, will be removed in future versions, no longer used internally
 export function escapeQueryStrValue(value: string): string {
 
     if (stringIsNullOrEmpty(value)) {

--- a/packages/sp/webs/types.ts
+++ b/packages/sp/webs/types.ts
@@ -16,9 +16,9 @@ import { defaultPath } from "../decorators.js";
 import { IChangeQuery } from "../types.js";
 import { odataUrlFrom } from "../utils/odata-url-from.js";
 import { spPost, spPostMerge } from "../operations.js";
-import { escapeQueryStrValue } from "../utils/escape-query-str.js";
 import { extractWebUrl } from "../index.js";
 import { combine, isArray } from "@pnp/core";
+import { encodePath } from "../utils/encode-path-str.js";
 
 @defaultPath("webs")
 export class _Webs extends _SPCollection<IWebInfo[]> {
@@ -182,7 +182,7 @@ export class _Web extends _SPInstance<IWebInfo> {
      */
     public applyWebTemplate(template: string): Promise<void> {
 
-        return spPost(Web(this, `applywebtemplate(webTemplate='${escapeQueryStrValue(template)}')`));
+        return spPost(Web(this, `applywebtemplate(webTemplate='${encodePath(template)}')`));
     }
 
     /**
@@ -202,7 +202,7 @@ export class _Web extends _SPInstance<IWebInfo> {
      * @param progId The ProgID of the application that was used to create the file, in the form OLEServerName.ObjectName
      */
     public mapToIcon(filename: string, size = 0, progId = ""): Promise<string> {
-        return Web(this, `maptoicon(filename='${escapeQueryStrValue(filename)}',progid='${escapeQueryStrValue(progId)}',size=${size})`)();
+        return Web(this, `maptoicon(filename='${encodePath(filename)}',progid='${encodePath(progId)}',size=${size})`)();
     }
 
     /**
@@ -211,7 +211,7 @@ export class _Web extends _SPInstance<IWebInfo> {
      * @param key Id of storage entity to be set
      */
     public getStorageEntity(key: string): Promise<IStorageEntity> {
-        return Web(this, `getStorageEntity('${escapeQueryStrValue(key)}')`)();
+        return Web(this, `getStorageEntity('${encodePath(key)}')`)();
     }
 
     /**
@@ -237,7 +237,7 @@ export class _Web extends _SPInstance<IWebInfo> {
      * @param key Id of storage entity to be removed
      */
     public removeStorageEntity(key: string): Promise<void> {
-        return spPost(Web(this, `removeStorageEntity('${escapeQueryStrValue(key)}')`));
+        return spPost(Web(this, `removeStorageEntity('${encodePath(key)}')`));
     }
 
     /**

--- a/test/sp/batch.ts
+++ b/test/sp/batch.ts
@@ -102,8 +102,11 @@ describe("Batching", function () {
             await execute();
 
             order.push(3);
+
             return expect(order.toString()).to.eql(expected.toString());
+
         } else {
+
             assert.fail(`Did not succesfully create list ${listTitle}`);
         }
     });

--- a/test/sp/lists.ts
+++ b/test/sp/lists.ts
@@ -260,7 +260,7 @@ describe("List", function () {
             ViewXml: "<View><RowLimit>5</RowLimit></View>",
         };
 
-        const r = await rList.renderListDataAsStream(renderListDataParams, {}, new Map([["FilterField1", "Title"], ["FilterValue1", encodeURIComponent("Item 2")]]));
+        const r = await rList.renderListDataAsStream(renderListDataParams, {}, new Map([["FilterField1", "Title"], ["FilterValue1", "Item 2"]]));
 
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         expect(r).to.not.be.null;

--- a/test/sp/query-escaping.ts
+++ b/test/sp/query-escaping.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import { encodePath, ISPQueryable, spfi } from "@pnp/sp";
+import "@pnp/sp/navigation";
+import "@pnp/sp/webs";
+import "@pnp/sp/files";
+import "@pnp/sp/folders";
+import { Folders } from "@pnp/sp/folders";
+
+function getTestValue(query: ISPQueryable) {
+
+    const url = query.toRequestUrl();
+    return url.substring(url.indexOf("_api/"));
+}
+
+describe("Query Escaping", function () {
+
+    let sp = null;
+
+    before(function () {
+
+        // we do this so these tests can run in non-web mode and for PRs
+        // since we'll not make these requests we don't need all the behaviors properly registered
+        sp = spfi();
+    });
+
+    it("single quote in path", function () {
+
+        let value = getTestValue(sp.web.getFileByServerRelativePath("/sites/dev/documents/folder's root/something.txt"));
+        expect(value).to.eq("_api/web/getFileByServerRelativePath(decodedUrl='%2Fsites%2Fdev%2Fdocuments%2Ffolder''s%20root%2Fsomething.txt')");
+
+        value = getTestValue(sp.web.getFileByUrl("/sites/dev/documents/folder's root/something.txt"));
+        expect(value).to.eq("_api/web/getFileByUrl(@p1)?%40p1=%27%2Fsites%2Fdev%2Fdocuments%2Ffolder%27%27s+root%2Fsomething.txt%27");
+
+        value = getTestValue(sp.web.getFolderByServerRelativePath("/sites/dev/documents/folder's root/"));
+        expect(value).to.eq(`_api/web/getFolderByServerRelativePath(decodedUrl='${encodeURIComponent("/sites/dev/documents/folder''s root/")}')`);
+
+        value = getTestValue(sp.web.folders.getByUrl("/sites/dev/documents/folder's root/"));
+        expect(value).to.eq(`_api/web/folders('${encodeURIComponent("/sites/dev/documents/folder''s root/")}')`);
+    });
+
+    it("random chars in path", function () {
+
+        let value = getTestValue(sp.web.getFileByServerRelativePath("/sites/dev/shared documents/#!@#$%^&()_+-/readme.md"));
+        expect(value).to.eq("_api/web/getFileByServerRelativePath(decodedUrl='%2Fsites%2Fdev%2Fshared%20documents%2F%23!%40%23%24%25%5E%26()_%2B-%2Freadme.md')");
+
+        value = getTestValue(sp.web.getFileByUrl("/sites/dev/shared documents/#!@#$%^&()_+-/readme.md"));
+        expect(value).to.eq("_api/web/getFileByUrl(@p1)?%40p1=%27%2Fsites%2Fdev%2Fshared+documents%2F%23%21%40%23%24%25%5E%26%28%29_%2B-%2Freadme.md%27");
+
+        value = getTestValue(sp.web.getFolderByServerRelativePath("/sites/dev/documents/folder #!@#$%^&()_+-"));
+        expect(value).to.eq("_api/web/getFolderByServerRelativePath(decodedUrl='%2Fsites%2Fdev%2Fdocuments%2Ffolder%20%23!%40%23%24%25%5E%26()_%2B-')");
+
+        value = getTestValue(sp.web.folders.getByUrl("/sites/dev/documents/folder #!@#$%^&()_+-"));
+        expect(value).to.eq("_api/web/folders('%2Fsites%2Fdev%2Fdocuments%2Ffolder%20%23!%40%23%24%25%5E%26()_%2B-')");
+    });
+
+    it("aliasing", function () {
+
+        let value = getTestValue(sp.web.getFileByServerRelativePath("!@p1::/sites/dev/shared documents/#!@#$%^&()_+-/readme.md"));
+        expect(value).to.eq("_api/web/getFileByServerRelativePath(decodedUrl=@p1)?%40p1=%27%2Fsites%2Fdev%2Fshared+documents%2F%23%21%40%23%24%25%5E%26%28%29_%2B-%2Freadme.md%27");
+
+        // fake addUsingPath to ensure alias works in multi value calls
+        value = getTestValue(Folders("", `addUsingPath(DecodedUrl='${encodePath("!@p1::/sites/dev/documents/folder's root/something.txt")}',overwrite=${true})`));
+        expect(value).to.eq("addUsingPath(DecodedUrl=@p1,overwrite=true)?%40p1=%27%2Fsites%2Fdev%2Fdocuments%2Ffolder%27%27s+root%2Fsomething.txt%27");
+
+        // fake made up request to ensure alias works in multi value calls in the other order
+        value = getTestValue(Folders("", `addUsingPath(overwrite=${true},DecodedUrl='${encodePath("!@p1::/sites/dev/documents/folder's root/something.txt")}')`));
+        expect(value).to.eq("addUsingPath(overwrite=true,DecodedUrl=@p1)?%40p1=%27%2Fsites%2Fdev%2Fdocuments%2Ffolder%27%27s+root%2Fsomething.txt%27");
+
+        // fake made up request to ensure alias works in multi value calls in the other order
+        value = getTestValue(Folders("", `addUsingPath(overwrite=${true},DecodedUrl='${encodePath("!@p1::/sites/dev/documents/folder's root/something.txt")}',something=false)`));
+        expect(value).to.eq("addUsingPath(overwrite=true,DecodedUrl=@p1,something=false)?%40p1=%27%2Fsites%2Fdev%2Fdocuments%2Ffolder%27%27s+root%2Fsomething.txt%27");
+
+        value = getTestValue(sp.web.getFileByServerRelativePath("!@p1::/sites/dev/documents/folder's root/something.txt"));
+        expect(value).to.eq("_api/web/getFileByServerRelativePath(decodedUrl=@p1)?%40p1=%27%2Fsites%2Fdev%2Fdocuments%2Ffolder%27%27s+root%2Fsomething.txt%27");
+
+        value = getTestValue(sp.web.getFileByServerRelativePath("!@p1::/sites/dev/shared documents/tom's files/readme.md"));
+        expect(value).to.eq("_api/web/getFileByServerRelativePath(decodedUrl=@p1)?%40p1=%27%2Fsites%2Fdev%2Fshared+documents%2Ftom%27%27s+files%2Freadme.md%27");
+
+        value = getTestValue(sp.web.getFileByServerRelativePath("!@p1::/sites/dev/documents/folder #!@#$%^&()_+-/something.txt"));
+        // eslint-disable-next-line max-len
+        expect(value).to.eq("_api/web/getFileByServerRelativePath(decodedUrl=@p1)?%40p1=%27%2Fsites%2Fdev%2Fdocuments%2Ffolder+%23%21%40%23%24%25%5E%26%28%29_%2B-%2Fsomething.txt%27");
+
+        value = getTestValue(sp.web.getFolderByServerRelativePath("!@p1::/sites/dev/documents/folder #!@#$%^&()_+-"));
+        expect(value).to.eq("_api/web/getFolderByServerRelativePath(decodedUrl=@p1)?%40p1=%27%2Fsites%2Fdev%2Fdocuments%2Ffolder+%23%21%40%23%24%25%5E%26%28%29_%2B-%27");
+
+        // multiple ' chars
+        value = getTestValue(sp.web.getFileByServerRelativePath("!@p1::/sites/dev/documents/folder's ro'ot/something.txt"));
+        expect(value).to.eq("_api/web/getFileByServerRelativePath(decodedUrl=@p1)?%40p1=%27%2Fsites%2Fdev%2Fdocuments%2Ffolder%27%27s+ro%27%27ot%2Fsomething.txt%27");
+
+        // multiple ' chars2
+        value = getTestValue(sp.web.getFileByServerRelativePath("!@p1::/sites/dev/documents/folder''s ro'ot/something.txt"));
+        expect(value).to.eq("_api/web/getFileByServerRelativePath(decodedUrl=@p1)?%40p1=%27%2Fsites%2Fdev%2Fdocuments%2Ffolder%27%27%27%27s+ro%27%27ot%2Fsomething.txt%27");
+    });
+});

--- a/test/sp/spfx.ts
+++ b/test/sp/spfx.ts
@@ -5,7 +5,7 @@ import "@pnp/sp/webs";
 import "@pnp/sp/lists/web";
 import { ISPFXContext, SPFI, spfi, SPFx } from "@pnp/sp";
 import { NodeFetchWithRetry } from "@pnp/nodejs";
-import { isArray } from "@pnp/core";
+import { CopyFrom, isArray } from "@pnp/core";
 import { Queryable } from "@pnp/queryable";
 
 describe("SPFx", function () {
@@ -28,16 +28,10 @@ describe("SPFx", function () {
             },
         };
 
-        spfxSP = spfi().using(SPFx(SPFxContext), NodeFetchWithRetry({ replace: true }));
-
-        const auth = this.pnp.sp.web.on.auth.toArray();
-
-        spfxSP.using(function (instance: Queryable) {
-
-            for (let i = 0; i < auth.length; i++) {
-                instance.on.auth(auth[i]);
-            }
-        });
+        spfxSP = spfi().using(
+            SPFx(SPFxContext),
+            NodeFetchWithRetry({ replace: true }),
+            CopyFrom(this.pnp.sp.web, "replace", (m) => m === "auth"));
     });
 
     it("get web", async function () {

--- a/test/sp/spfx.ts
+++ b/test/sp/spfx.ts
@@ -6,7 +6,6 @@ import "@pnp/sp/lists/web";
 import { ISPFXContext, SPFI, spfi, SPFx } from "@pnp/sp";
 import { NodeFetchWithRetry } from "@pnp/nodejs";
 import { CopyFrom, isArray } from "@pnp/core";
-import { Queryable } from "@pnp/queryable";
 
 describe("SPFx", function () {
 


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #2222 
fixes #2356 

#### What's in this Pull Request?

- Replaces Map with URLSearchParams for storing query values
- Simplifies all query escaping
- Replaces escapeQueryStrValue with encodePath which more clearly represents the purpose of the method
- DEPRECATES escapeQueryStrValue, this utility function will be removed in a future version
- Fixes timing issues between the library and how the runtime event loop runs the code.
- Some general code cleanup
- Simplification of batching request resolution for graph/sp
