### PR TITLE
Add rate item to _Item #2367

### DIFF
--- a/packages/sp/comments/item.ts
+++ b/packages/sp/comments/item.ts
@@ -13,7 +13,7 @@ declare module "../items/types" {
         like(): Promise<void>;
         unlike(): Promise<void>;
         getLikedByInformation(): Promise<ILikedByInformation>;
-        rate(rating: RatingValues): Promise<void>;
+        rate(rating: RatingValues): Promise<number>;
     }
     interface IItem {
         readonly comments: IComments;
@@ -36,8 +36,9 @@ declare module "../items/types" {
         /**
          * Rates this item as the current user
          * @param rating rating number between 1-5
+         * @returns rating number
          */
-        rate(rating: RatingValues): Promise<void>;
+        rate(rating: RatingValues): Promise<number>;
     }
 }
 
@@ -67,7 +68,7 @@ _Item.prototype.getLikedByInformation = function (this: _Item): Promise<ILikedBy
     return Item(this, "likedByInformation").expand("likedby")<ILikedByInformation>();
 };
 
-_Item.prototype.rate = async function(this: _Item, value: RatingValues): Promise<void> {
+_Item.prototype.rate = async function(this: _Item, value: RatingValues): Promise<number> {
     const itemInfo = await this.getParentInfos();
     const baseUrl = extractWebUrl(this.toUrl());
     const reputationUrl = "_api/Microsoft.Office.Server.ReputationModel.Reputation.SetRating(listID=@a1,itemID=@a2,rating=@a3)";

--- a/packages/sp/comments/types.ts
+++ b/packages/sp/comments/types.ts
@@ -157,3 +157,4 @@ export interface ILikedByInformation {
     isLikedByUser: boolean;
     likeCount: number;
 }
+export type RatingValues = 1|2|3|4|5;

--- a/test/sp/items.ts
+++ b/test/sp/items.ts
@@ -169,4 +169,9 @@ describe("Items", function () {
         const item = await list.items.select("Id").top(1)().then(r => r[0]);
         return expect(list.items.getById(item.Id).getWopiFrameUrl()).to.eventually.be.fulfilled;
     });
+
+    it("rate", async function () {
+        const item = await list.items.select("Id").top(1)().then(r => r[0]);
+        return expect(item.rate(2)).to.eventually.be.fulfilled;
+    });
 });


### PR DESCRIPTION
Add the functionality to rate an item

#### Category
- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes question, mentioned in #2367 

#### What's in this Pull Request?

Added the function rate to _Item.prototype. 
This was placed analogous to like / unlike in comments. However, it refers to the item itself.
The test was placed under items.ts.

This is my first pull request and I hope I did everything right.
