### PR TITLE
Fixed typo on defaultDocumentLibrary description

### DIFF
--- a/docs/sp/webs.md
+++ b/docs/sp/webs.md
@@ -639,7 +639,7 @@ const items = await list.items.top(2)();
 
 ### defaultDocumentLibrary
 
-Get a reference the default documents library of a web
+Get a reference of the default documents library of a web
 
 ```TypeScript
 import { spfi } from "@pnp/sp";


### PR DESCRIPTION
Missing 'of' from the description of the defaultDocumentLibrary.
Added it now.

#### Category

Documentation update?

#### Related Issues

None

#### What's in this Pull Request?

The original description of defaultDocumentLibrary was gramatically incorrect as it was missing an 'of' in the appropriate place. Possible overlook. 
This commit fixes it and adds the 'of' there.

Original Text: "Get a reference the default documents library of a web".
Modified Text: "Get a reference of the default documents library of a web"

