### PR TITLE
docs(graph--lists): add notice on how to get items

### DIFF
--- a/docs/graph/items.md
+++ b/docs/graph/items.md
@@ -1,0 +1,28 @@
+# @pnp/graph/items
+
+Currently, there is no module in graph to access all items directly. Please, instead, default to search by path using the following methods.
+
+[![Selective Imports Banner](https://img.shields.io/badge/Selective%20Imports-informational.svg)](../concepts/selective-imports.md)  
+
+### Get list items
+
+```TypeScript
+import { Site } from "@pnp/graph/sites";
+
+const sites = graph.sites.getById("{site id}");
+
+const items = await Site(sites, "lists/{listid}/items")();
+```
+
+### Get list items with fields included
+
+```TypeScript
+import { Site } from "@pnp/graph/sites";
+import "@pnp/graph/lists";
+
+const sites = graph.sites.getById("{site id}");
+
+const listItems : IList[] = await Site(sites, "lists/{site id}/items?$expand=fields")();
+```
+
+#### Hint: Note that you can just use normal [graph queries](https://developer.microsoft.com/en-us/graph/graph-explorer) in this search.

--- a/docs/graph/items.md
+++ b/docs/graph/items.md
@@ -14,6 +14,16 @@ const sites = graph.sites.getById("{site id}");
 const items = await Site(sites, "lists/{listid}/items")();
 ```
 
+### Get File/Item version information
+
+```TypeScript
+import { Site } from "@pnp/graph/sites";
+
+const sites = graph.sites.getById("{site id}");
+
+const users = await Site(sites, "lists/{listid}/items/{item id}/versions")();
+```
+
 ### Get list items with fields included
 
 ```TypeScript

--- a/docs/graph/lists.md
+++ b/docs/graph/lists.md
@@ -79,3 +79,9 @@ const graph = graphfi(...);
 
 await graph.sites.getById("{site identifier}").lists.getById("{list identifier}").columns();
 ```
+
+## Get List Items
+
+Currently, recieving list items via @pnpjs/graph API is not possible.
+
+This can currently be done with a call by path as documented under [@pnpjs/graph/sites](./sites.md)

--- a/docs/graph/lists.md
+++ b/docs/graph/lists.md
@@ -84,4 +84,4 @@ await graph.sites.getById("{site identifier}").lists.getById("{list identifier}"
 
 Currently, recieving list items via @pnpjs/graph API is not possible.
 
-This can currently be done with a call by path as documented under [@pnpjs/graph/sites](./sites.md)
+This can currently be done with a call by path as documented under [@pnpjs/graph/sites](./items.md)

--- a/docs/graph/lists.md
+++ b/docs/graph/lists.md
@@ -84,4 +84,4 @@ await graph.sites.getById("{site identifier}").lists.getById("{list identifier}"
 
 Currently, recieving list items via @pnpjs/graph API is not possible.
 
-This can currently be done with a call by path as documented under [@pnpjs/graph/sites](./items.md)
+This can currently be done with a call by path as documented under [@pnpjs/graph/items](./items.md)

--- a/docs/graph/sites.md
+++ b/docs/graph/sites.md
@@ -26,26 +26,6 @@ const graph = graphfi(...);
 const siteInfo = await graph.sites.getById("{site identifier}")();
 ```
 
-## Make additional calls
+## Make additional calls or recieve items from lists
 
-We don't currently implement all of the available options in graph for sites, rather focusing on the sp library. While we do accept PRs to add functionality, you can also make calls by path:
-
-### Get list items
-
-```TypeScript
-import { Site } from "@pnp/graph/sites";
-
-const sites = graph.sites.getById("{site id}");
-
-const users = await Site(sites, "lists/{listid}/items")();
-```
-
-### Get File/Item version information
-
-```TypeScript
-import { Site } from "@pnp/graph/sites";
-
-const sites = graph.sites.getById("{site id}");
-
-const users = await Site(sites, "lists/{listid}/items/{item id}/versions")();
-```
+We don't currently implement all of the available options in graph for sites, rather focusing on the sp library. While we do accept PRs to add functionality, you can [also make calls by path.](./items.md)


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### Related Issues

N/A

#### What's in this Pull Request?

As there is no documentation about retrieving items from the lists.getByID object "IList" returned from the query:
- add a notice that links to other document file stating that you can query list items with call by path (this is only stated under "sites", which makes no sense, because anyone looking for items will look under lists as it's a property of "IList")