### PR TITLE
Removed redundant await while creating batch

### DIFF
--- a/docs/concepts/batching-caching.md
+++ b/docs/concepts/batching-caching.md
@@ -10,7 +10,7 @@ import { Caching } from "@pnp/queryable";
 
 const sp = spfi(...);
 
-const [batchedSP, execute] = await sp.batched();
+const [batchedSP, execute] = sp.batched();
 
 batchedSP.using(Caching());
 
@@ -43,7 +43,7 @@ import { Caching } from "@pnp/queryable";
 
 const sp = spfi(...);
 
-const [batchedSP, execute] = await sp.batched();
+const [batchedSP, execute] = sp.batched();
 
 batchedSP.using(Caching());
 


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### Related Issues

None, should I create one?

#### What's in this Pull Request?

Noticed a redundant `await` in the docs while creating a batch object.
