### PR TITLE
Update for v2: Now using the newer adal-node version (0.2.3)

### DIFF
--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -10,7 +10,7 @@
         "@pnp/logging": "0.0.0-PLACEHOLDER",
         "@pnp/odata": "0.0.0-PLACEHOLDER",
         "@pnp/sp": "0.0.0-PLACEHOLDER",
-        "adal-node": "0.2.2",
+        "adal-node": "^0.2.3",
         "https-proxy-agent": "^5.0.0",
         "jsonwebtoken": "8.5.1",
         "node-fetch": "2.6.1",


### PR DESCRIPTION
Now using the newer adal-node version (0.2.3) so the @xmldom/xmldom version can be used

#### Category
- [x ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues
https://github.com/pnp/pnpjs/issues/2496

fixes #2496 as @xmldom/xmldom is used in the newer adal-node version (0.2.3) which than can be fixed via "npm audit fix". Because the "xmldom"-package can no longer be updated and therefore moved to "@xmldom/xmldom" where the critical security issue https://security.snyk.io/package/npm/xmldom is fixed in newer versions.

#### What's in this Pull Request?

Just a package update for "adal-dom" to version ^0.2.3.


