### PR TITLE
Update type of ViewsLifeTime from number to string

### DIFF
--- a/packages/sp/search/types.ts
+++ b/packages/sp/search/types.ts
@@ -299,7 +299,7 @@ export interface ISearchResult {
     FileExtension?: string;
     ContentTypeId?: string;
     ParentLink?: string;
-    ViewsLifeTime?: number;
+    ViewsLifeTime?: string;
     ViewsRecent?: number;
     SectionNames?: string;
     SectionIndexes?: string;


### PR DESCRIPTION
API returns value as a string. This causes some weirdness in code for sorting, etc... since a string can't be used for parseInt().

#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

Update the type of ViewsLifeTime from number to string since the API returns it as a string.

