### PR TITLE
setStreamContentChunked: await loading chunks

### DIFF
--- a/packages/nodejs/sp-extensions/stream.ts
+++ b/packages/nodejs/sp-extensions/stream.ts
@@ -43,20 +43,26 @@ extendFactory(File, {
 
             stream.on("data", (chunk) => {
 
+                stream.pause();
+
                 blockNumber += 1;
 
                 if (blockNumber === 0) {
 
-                    promise = promise.then(() => {
+                    promise = promise.then(async () => {
                         progress({ uploadId, blockNumber, chunkSize: chunk.length, currentPointer: 0, fileSize: -1, stage: "starting", totalBlocks: -1 });
-                        return fileRef.startUpload(uploadId, <any>chunk);
+                        const result = await fileRef.startUpload(uploadId, <any>chunk);
+                        stream.resume();
+                        return result;
                     });
 
                 } else {
 
-                    promise = promise.then((pointer) => {
+                    promise = promise.then(async (pointer) => {
                         progress({ uploadId, blockNumber, chunkSize: chunk.length, currentPointer: pointer, fileSize: -1, stage: "continue", totalBlocks: -1 });
-                        return fileRef.continueUpload(uploadId, pointer, <any>chunk);
+                        const result = await fileRef.continueUpload(uploadId, pointer, <any>chunk);
+                        stream.resume();
+                        return result;
                     });
 
                 }


### PR DESCRIPTION
fixes #2532

#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #2532

#### What's in this Pull Request?

The previous version of the code was creating a promise chain in-advance for every chunk that has to be uploaded. Since every chunk has to be kept in memory until the promise is finished, it led to a situation in which the whole file content was kept in memory.

The solution is to pause the stream on every chunk and resume it after a successful push, so that the next chunk can be processed.

#### TODO

Tests