### PR TITLE
Timeline: fix unhandlable promise in start()

### DIFF
--- a/packages/core/timeline.ts
+++ b/packages/core/timeline.ts
@@ -309,7 +309,7 @@ export abstract class Timeline<T extends Moments> {
 
                 this.error(e2);
             }
-        });
+        }).catch(() => void(0));
 
         // give the promise back to the caller
         return p;


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #2539

#### What's in this Pull Request?

Inside `start` method the `.execute` promise is wrapped in `.finally`, but this wrap was not returned. Therefore, the event loop had to handle 2 promises (wrapped and not-wrapped), and the wrapped one couldn't be handled properly in case of errors.

This PR fixes the problem by adding an empty `catch` to the wrapped promise.