### PR TITLE
docs: fix ConsoleListener creation

### DIFF
--- a/docs/logging/index.md
+++ b/docs/logging/index.md
@@ -113,7 +113,7 @@ import {
 } from "@pnp/logging";
 
 // subscribe a listener
-Logger.subscribe(new ConsoleListener());
+Logger.subscribe(ConsoleListener());
 
 // set the active log level
 Logger.activeLogLevel = LogLevel.Info;
@@ -143,7 +143,7 @@ import {
 } from "@pnp/logging";
 
 const LOG_SOURCE: string = 'MyAwesomeWebPart';
-Logger.subscribe(new ConsoleListener(LOG_SOURCE));
+Logger.subscribe(ConsoleListener(LOG_SOURCE));
 Logger.activeLogLevel = LogLevel.Info;
 ```
 
@@ -166,7 +166,7 @@ import {
 } from "@pnp/logging";
 
 const LOG_SOURCE: string = 'MyAwesomeWebPart';
-Logger.subscribe(new ConsoleListener(LOG_SOURCE, {color:'#0b6a0b',warningColor:'magenta'}));
+Logger.subscribe(ConsoleListener(LOG_SOURCE, {color:'#0b6a0b',warningColor:'magenta'}));
 Logger.activeLogLevel = LogLevel.Info;
 ```
 
@@ -192,7 +192,7 @@ Color options:
 To set colors without a prefix, specify either `undefined` or an empty string for the first parameter:
 
 ```TypeScript
-Logger.subscribe(new ConsoleListener(undefined, {color:'purple'}));
+Logger.subscribe(ConsoleListener(undefined, {color:'purple'}));
 ```
 
 ### FunctionListener
@@ -247,7 +247,7 @@ import "@pnp/sp/webs";
 import "@pnp/sp/lists";
 
 // subscribe a listener
-Logger.subscribe(new ConsoleListener());
+Logger.subscribe(ConsoleListener());
 
 // at the root we only want to log errors, which will be sent to all subscribed loggers on Logger
 const sp = spfi().using(SPFx(this.context), PnPLogging(LogLevel.Error));


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### Related Issues

none

#### What's in this Pull Request?
The docs still mention to use `new ConsoleListener()`, which is wrong and gives `Only a void function can be called with the 'new' keyword.ts(2350)` error in TypeScript.

https://github.com/pnp/pnpjs/blob/e757e59fb568aafcf5788558e3ffd1b212c9de1a/packages/logging/listeners.ts#L3-L5

So because that is now a wrapper function, it should be called as function.

