### PR TITLE
3.12.1 fix for spfx token in default behaviors causing issues

### DIFF
--- a/packages/sp/behaviors/spfx.ts
+++ b/packages/sp/behaviors/spfx.ts
@@ -50,7 +50,8 @@ export function SPFx(context: ISPFXContext): TimelinePipe<Queryable> {
             DefaultInit(),
             BrowserFetchWithRetry(),
             DefaultParse(),
-            SPFxToken(context),
+            // remove SPFx Token in default due to issues #2570, #2571
+            // SPFxToken(context),
             RequestDigest((url) => {
 
                 const sameWeb = (new RegExp(`^${combine(context.pageContext.web.absoluteUrl, "/_api")}`, "i")).test(url);


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #2570
fixes #2571

#### What's in this Pull Request?

We added to the default SPFx behavior code to auto-include the default SPFx token in all requests. It turns out that for deployments that have not requested the required SPFx scopes in the manifest these calls are blocked with access denied.

Long term the fix is to ensure the required scopes are requested for your SPFx applications, but we don't want to break people.