### PR TITLE
Fix for 2629

### DIFF
--- a/packages/sp/recycle-bin/types.ts
+++ b/packages/sp/recycle-bin/types.ts
@@ -52,7 +52,7 @@ export class _RecycleBin extends _SPCollection<IRecycleBinItemObject[]> {
     * @param id The string id of the recycle bin item
     */
     public getById(id: string): IRecycleBinItem {
-        return RecycleBinItem(this).concat(`(${id})`);
+        return RecycleBinItem(this).concat(`('${id}')`);
     }
 
     /**


### PR DESCRIPTION
Wrapping the getById string value with quotes as is required by SharePoint API.

#### Category
- [x] Bug fix?

#### Related Issues

fixes #2629 

#### What's in this Pull Request?

Update to getById on recycle bin. SharePoint API expects the ID of the recycle bin item to be a string. We were not wrapping the ID in quotes.


