### PR TITLE
Small change to make the IGraphDefaultProps and ISPDefaultProps optional

### DIFF
--- a/packages/nodejs/behaviors/graphdefault.ts
+++ b/packages/nodejs/behaviors/graphdefault.ts
@@ -18,9 +18,9 @@ export interface IGraphDefaultProps {
  * @param props - Specify the IGraphDefaultProps for configuring the object
  *        props.msal: (deprecated, use separate MSAL behavior)
  */
-export function GraphDefault(props: IGraphDefaultProps): TimelinePipe<Queryable> {
+export function GraphDefault(props?: IGraphDefaultProps): TimelinePipe<Queryable> {
 
-    if (props.baseUrl && !isUrlAbsolute(props.baseUrl)) {
+    if (props?.baseUrl && !isUrlAbsolute(props?.baseUrl)) {
         throw Error("GraphDefault props.baseUrl must be absolute when supplied.");
     }
 
@@ -31,7 +31,7 @@ export function GraphDefault(props: IGraphDefaultProps): TimelinePipe<Queryable>
 
     return (instance: Queryable) => {
         const behaviors: TimelinePipe<any>[] = [DefaultHeaders(), DefaultInit(), NodeFetchWithRetry(), DefaultParse()];
-        if(props.msal){
+        if(props?.msal){
             behaviors.push(MSAL(msal.config, msal?.scopes || [combine(baseUrl, ".default")]));
         }
         instance.using(...behaviors);

--- a/packages/nodejs/behaviors/spdefault.ts
+++ b/packages/nodejs/behaviors/spdefault.ts
@@ -18,15 +18,15 @@ export interface ISPDefaultProps {
  * @param props - Specify the ISPDefaultProps for configuring the object
  *        props.msal: (deprecated, use separate MSAL behavior)
  */
-export function SPDefault(props: ISPDefaultProps): TimelinePipe<Queryable> {
+export function SPDefault(props?: ISPDefaultProps): TimelinePipe<Queryable> {
 
-    if (props.baseUrl && !isUrlAbsolute(props.baseUrl)) {
+    if (props?.baseUrl && !isUrlAbsolute(props?.baseUrl)) {
         throw Error("SPDefault props.baseUrl must be absolute when supplied.");
     }
 
     return (instance: Queryable) => {
         const behaviors: TimelinePipe<any>[] = [DefaultHeaders(), DefaultInit(), NodeFetchWithRetry(), DefaultParse()];
-        if(props.msal){
+        if(props?.msal){
             behaviors.push(MSAL(props.msal.config, props.msal.scopes));
         }
         instance.using(...behaviors);
@@ -34,7 +34,7 @@ export function SPDefault(props: ISPDefaultProps): TimelinePipe<Queryable> {
         instance.on.pre.prepend(async (url, init, result) => {
 
             if (!isUrlAbsolute(url)) {
-                url = combine(props.baseUrl, url);
+                url = combine(props?.baseUrl, url);
             }
 
             return [url, init, result];


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

N/A

#### What's in this Pull Request?

Realized that if you do not need to provide properties you must still provide an empty object when using the SPDefault and GraphDefault behaviors.
