### PR TITLE
Remove RequestDigest behavior from SPBrowser

### DIFF
--- a/docs/sp/behaviors.md
+++ b/docs/sp/behaviors.md
@@ -68,7 +68,7 @@ await sp.web();
 
 ## SPBrowser
 
-A composed behavior suitable for use within a SPA or other scenario outside of SPFx. It includes DefaultHeaders, DefaultInit, BrowserFetchWithRetry, DefaultParse, and RequestDigest. As well it adds a pre observer to try and ensure the request url is absolute if one is supplied in props.
+A composed behavior suitable for use within a SPA or other scenario outside of SPFx. It includes DefaultHeaders, DefaultInit, BrowserFetchWithRetry, and DefaultParse. As well it adds a pre observer to try and ensure the request url is absolute if one is supplied in props.
 
 The baseUrl prop can be used to configure a fallback when making urls absolute.
 

--- a/packages/sp/behaviors/spbrowser.ts
+++ b/packages/sp/behaviors/spbrowser.ts
@@ -1,7 +1,6 @@
 import { combine, isUrlAbsolute, TimelinePipe } from "@pnp/core";
 import { BrowserFetchWithRetry, DefaultParse, Queryable } from "@pnp/queryable";
 import { DefaultHeaders, DefaultInit } from "./defaults.js";
-import { RequestDigest } from "./request-digest.js";
 
 export interface ISPBrowserProps {
     baseUrl?: string;
@@ -19,8 +18,7 @@ export function SPBrowser(props?: ISPBrowserProps): TimelinePipe<Queryable> {
             DefaultHeaders(),
             DefaultInit(),
             BrowserFetchWithRetry(),
-            DefaultParse(),
-            RequestDigest());
+            DefaultParse());
 
         if (isUrlAbsolute(props?.baseUrl)) {
 


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [x] Documentation update?

#### Related Issues

fixes #2661 

#### What's in this Pull Request?

Removal of RequestDigest from SPBrowser.

When used in Batching, requesting the RequestDigest with spPost inside the behavior adds the requests to the entire batch. The retrieval of the request digest hangs.

Rather than fix the underlying digest issue with Batching, I think we should remove request digest all together. Given this scenario is using SPBrowser, which is meant for implementation outside of SharePoint, this implies authentication is handled with OAuth with a Bearer Token. Using a Bearer Token means we don't need to use a X-RequestDigest header for updates to SharePoint.
