### PR TITLE
RequestDigest with Batching Fix

### DIFF
--- a/packages/sp/behaviors/request-digest.ts
+++ b/packages/sp/behaviors/request-digest.ts
@@ -3,6 +3,7 @@ import { JSONParse, Queryable } from "@pnp/queryable";
 import { extractWebUrl } from "../utils/extract-web-url.js";
 import { ISPQueryable, SPQueryable } from "../spqueryable.js";
 import { spPost } from "../operations.js";
+import { BatchNever } from "../batching.js";
 
 interface IDigestInfo {
     expiration: Date;
@@ -44,7 +45,7 @@ export function RequestDigest(hook?: (url: string, init: RequestInit) => IDigest
 
                 if (!objectDefinedNotNull(digest)) {
 
-                    digest = await spPost(SPQueryable([this, combine(webUrl, "_api/contextinfo")]).using(JSONParse()), {
+                    digest = await spPost(SPQueryable([this, combine(webUrl, "_api/contextinfo")]).using(JSONParse(),BatchNever()), {
                         headers: {
                             "X-PnPjs-NoDigest": "1",
                         },


### PR DESCRIPTION
Adding BatchNever behavior to Batching.ts
Adjusting Batching 'pre' logic in timeline to handle new BatchNever requests 
Adding BatchNever to Request-Digest Behavior when retrieving a new RequestDigest token.

#### Category
- [X] Bug fix?

#### Related Issues

#2661 

#### What's in this Pull Request?

A bug existed where requesting a new RequestDigest was not resolving within the Request-DigestBehavior. spPost was adding the request to the same timeline on the batch. As such, batched requests were hanging in scenarios where a new digest token was being requested.

A new BatchNever batch behavior was added to allow ignoring requests from being added to the timeline. Moved this logic up in the Batching timeline as well within register method. 

Adding a new BatchNever behavior to the spPost within Request-Digest.ts to prevent adding to a batch.


