### PR TITLE
Test Fixes and notes

### DIFF
--- a/test/sp/folders.ts
+++ b/test/sp/folders.ts
@@ -21,7 +21,7 @@ describe("Folders", function () {
 
     it("addUsingPath", function () {
         const name = `test_${getRandomString(4)}`;
-        return expect(this.pnp.sp.web.folders.addUsingPath(name)).to.eventually.be.fulfilled;
+        return expect(this.pnp.sp.web.rootFolder.folders.getByUrl("SiteAssets").folders.addUsingPath(name)).to.eventually.be.fulfilled;
     });
 
     it("getByUrl", function () {

--- a/test/sp/groupsitemanager.ts
+++ b/test/sp/groupsitemanager.ts
@@ -6,8 +6,8 @@ import { stringIsNullOrEmpty } from "@pnp/core/util";
 describe("GroupSiteManager (without group context)", function () {
 
     it("canUserCreateGroup", async function () {
-        const isGroupCreationEnable = await this.pnp.sp.groupSiteManager.canUserCreateGroup();
-        return expect(isGroupCreationEnable).to.be.false;
+        // skip because app only tests.
+        this.skip();
     });
 
     it("getAllOrgLabels", async function () {

--- a/test/sp/groupsitemanager.ts
+++ b/test/sp/groupsitemanager.ts
@@ -4,10 +4,10 @@ import "@pnp/sp/groupsitemanager";
 import { stringIsNullOrEmpty } from "@pnp/core/util";
 
 describe("GroupSiteManager (without group context)", function () {
-
-    it("canUserCreateGroup", async function () {
-        // skip because app only tests.
-        this.skip();
+    // skip because app only tests.
+    it.skip("canUserCreateGroup", async function () {
+        const isGroupCreationEnable = await this.pnp.sp.groupSiteManager.canUserCreateGroup();
+        return expect(isGroupCreationEnable).to.be.false;
     });
 
     it("getAllOrgLabels", async function () {

--- a/test/sp/site-groups.ts
+++ b/test/sp/site-groups.ts
@@ -41,8 +41,8 @@ describe("SiteGroups", function () {
             return expect(this.pnp.sp.web.associatedVisitorGroup()).to.eventually.be.fulfilled;
         });
 
+        // requires Custom Scripts to be enabled. Set-PnPSite -Identity <SiteURL> -NoScriptSite $false
         it("createDefaultAssociatedGroups()", async function () {
-
             await this.pnp.sp.web.ensureUser(this.pnp.settings.testUser);
             const groupName = `TestGroup_${getRandomString(4)}`;
             return expect(this.pnp.sp.web.createDefaultAssociatedGroups(groupName,


### PR DESCRIPTION
Updating test for folders and groupsite manager.
Adding note to createDefaultAssociatedGroups

Testing do not work under app only credentials or on modern team sites. Fixing tests.
#### Category
- [X] Bug fix?

#### Related Issues

fixes #X, mentioned in #Y

#### What's in this Pull Request?
Updating test for folders and groupsite manager.
Adding note to createDefaultAssociatedGroups


