### PR TITLE
files: alias the path inside addChunked

### DIFF
--- a/packages/nodejs/sp-extensions/stream.ts
+++ b/packages/nodejs/sp-extensions/stream.ts
@@ -85,7 +85,7 @@ extendFactory(Files, {
 
         const response = await spPost(Files(this, `add(overwrite=${shouldOverWrite},url='${encodePath(url)}')`));
 
-        const file = fileFromServerRelativePath(this, response.ServerRelativeUrl);
+        const file = fileFromServerRelativePath(this, `!@pnpFileAddResult::${response.ServerRelativeUrl}`);
 
         file.using(CancelAction(async () => {
             return File(file).delete();


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #2723

#### What's in this Pull Request?

`addChunked` uses `fileFromServerRelativePath` internally, which tends to fail if the path is long and [aliases](https://pnp.github.io/pnpjs/sp/alias-parameters/) are not used
