### PR TITLE
Remove unsupported drive root analytics

### DIFF
--- a/packages/graph/content-types/types.ts
+++ b/packages/graph/content-types/types.ts
@@ -81,7 +81,7 @@ export class _ContentTypes extends _GraphQueryableCollection<IContentTypeEntity[
      * @param contentTypeId The ID of the content type in the content type hub that will be added to a target site or a list.
      */
     public async addCopyFromContentTypeHub(contentTypeId: string): Promise<IContentTypeAddResult> {
-        const creator = ContentType(this, null).using(JSONHeaderParse());
+        const creator = ContentType(this, "addCopyFromContentTypeHub").using(JSONHeaderParse());
         const data = await graphPost(creator, body({ contentTypeId }));
         const pendingLocation = data.headers.location || null;
         return {

--- a/packages/graph/onedrive/types.ts
+++ b/packages/graph/onedrive/types.ts
@@ -182,16 +182,6 @@ export class _Root extends _GraphQueryableInstance<IDriveItemType> {
     public async upload(fileOptions: IFileOptions): Promise<IDriveItemAddResult> {
         return Reflect.apply(driveItemUpload, this, [fileOptions]);
     }
-
-    /**
-     * Method for getting item analytics. Defaults to lastSevenDays.
-     * @param analyticsOptions - IAnalyticsOptions (Optional)
-     * @returns IGraphQueryableCollection<IItemAnalytics>
-     */
-    public analytics(analyticsOptions?: IAnalyticsOptions): IGraphQueryableCollection<IItemAnalytics> {
-        const query = `analytics/${analyticsOptions?analyticsOptions.timeRange:"lastSevenDays"}`;
-        return GraphQueryableCollection(this, query);
-    }
 }
 export interface IRoot extends _Root { }
 export const Root = graphInvokableFactory<IRoot>(_Root);

--- a/test/graph/onedrive.ts
+++ b/test/graph/onedrive.ts
@@ -351,17 +351,6 @@ describe("OneDrive", function () {
         return expect(previewDriveItem).to.haveOwnProperty("getUrl");
     });
 
-    it("Get Drive Root Analytics - All Time", async function () {
-        if (stringIsNullOrEmpty(driveId)) {
-            this.skip();
-        }
-        const analyticOptions: IAnalyticsOptions = {
-            timeRange: "allTime",
-        };
-        const analytics = await this.pnp.graph.users.getById(testUserName).drives.getById(driveId).root.analytics(analyticOptions)();
-        return expect(analytics).to.haveOwnProperty("@odata.context");
-    });
-
     it("Get Drive Item Analytics - Last Seven Days", async function () {
         if (stringIsNullOrEmpty(driveId)) {
             this.skip();


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes #2677

#### What's in this Pull Request?

Removed analytics endpoint on drive root as it is no longer supported. V4 updates will include new analytics module that will add support for sites and list items and also move drive item analytics.
