### PR TITLE
Fixing typing on TermSet add method

### DIFF
--- a/packages/sp/taxonomy/types.ts
+++ b/packages/sp/taxonomy/types.ts
@@ -120,7 +120,7 @@ export class _TermSets extends _SPCollection<ITermSetInfo[]> {
      * @param props The set of properties
      * @returns The information on the create group
      */
-    public add(props: Partial<ITermSetCreateParams>): Promise<ITermGroupInfo> {
+    public add(props: Partial<ITermSetCreateParams>): Promise<ITermSetInfo> {
 
         return spPost(this, body(props));
     }

--- a/packages/sp/taxonomy/types.ts
+++ b/packages/sp/taxonomy/types.ts
@@ -118,10 +118,9 @@ export class _TermSets extends _SPCollection<ITermSetInfo[]> {
     /**
      * Adds a new term set to this collection
      * @param props The set of properties
-     * @returns The information on the create group
+     * @returns The information on the created set
      */
     public add(props: Partial<ITermSetCreateParams>): Promise<ITermSetInfo> {
-
         return spPost(this, body(props));
     }
 }


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

fixes bug mentioned in #2775

#### What's in this Pull Request?

Corrects typing on `add` method of `_TermSets` class to match data returned from SP API. 
[MS docs reference](https://learn.microsoft.com/en-us/graph/api/termstore-set-post?view=graph-rest-1.0&tabs=http)

