### PR TITLE
Fixes Message mapping in Graph sendMail method

### DIFF
--- a/packages/graph/messages/users.ts
+++ b/packages/graph/messages/users.ts
@@ -2,19 +2,20 @@ import { addProp, body } from "@pnp/queryable";
 import { _User, User } from "../users/types.js";
 import { IMessages, Messages, IMailboxSettings, MailboxSettings, IMailFolders, MailFolders, IMessage } from "./types.js";
 import { graphPost } from "../operations.js";
+import { Message } from "@microsoft/microsoft-graph-types";
 
 declare module "../users/types" {
     interface _User {
         readonly messages: IMessages;
         readonly mailboxSettings: IMailboxSettings;
         readonly mailFolders: IMailFolders;
-        sendMail(message: IMessage): Promise<void>;
+        sendMail(message: Message): Promise<void>;
     }
     interface IUser {
         readonly messages: IMessages;
         readonly mailboxSettings: IMailboxSettings;
         readonly mailFolders: IMailFolders;
-        sendMail(message: IMessage): Promise<void>;
+        sendMail(message: Message): Promise<void>;
     }
 }
 
@@ -22,6 +23,6 @@ addProp(_User, "messages", Messages);
 addProp(_User, "mailboxSettings", MailboxSettings);
 addProp(_User, "mailFolders", MailFolders);
 
-_User.prototype.sendMail = function (this: _User, message: IMessage): Promise<void> {
+_User.prototype.sendMail = function (message: Message): Promise<void> {
     return graphPost(User(this, "sendMail"), body(message));
 };

--- a/packages/graph/messages/users.ts
+++ b/packages/graph/messages/users.ts
@@ -1,6 +1,6 @@
 import { addProp, body } from "@pnp/queryable";
 import { _User, User } from "../users/types.js";
-import { IMessages, Messages, IMailboxSettings, MailboxSettings, IMailFolders, MailFolders, IMessage } from "./types.js";
+import { IMessages, Messages, IMailboxSettings, MailboxSettings, IMailFolders, MailFolders } from "./types.js";
 import { graphPost } from "../operations.js";
 import { Message } from "@microsoft/microsoft-graph-types";
 


### PR DESCRIPTION
#### Category
- [X] Bug fix?

#### Related Issues

fixes #2789 

#### What's in this Pull Request?

Fixes the typing on the sendmail method. It appears to be implemented incorrectly. Updated the sendMail definition to only take a Graph message Object.

However, because we are on old typings, some of the new properties such as saveToSentItems isn't available. 