### PR TITLE
changed register custom request client factory to add runtime as parameter

### DIFF
--- a/packages/sp/operations.ts
+++ b/packages/sp/operations.ts
@@ -4,8 +4,8 @@ import { ISharePointQueryable } from "./sharepointqueryable.js";
 import { IFetchOptions, mergeOptions, objectDefinedNotNull, IRequestClient, isFunc, Runtime } from "@pnp/common";
 import { toAbsoluteUrl } from "./utils/toabsoluteurl.js";
 
-export function registerCustomRequestClientFactory(requestClientFactory: () => IRequestClient) {
-    httpClientFactory = isFunc(requestClientFactory) ? () => requestClientFactory : defaultFactory;
+export function registerCustomRequestClientFactory(requestClientFactory: (runtime: Runtime) => () => IRequestClient) {
+    httpClientFactory = isFunc(requestClientFactory) ? requestClientFactory : defaultFactory;
 }
 
 const defaultFactory = (runtime: Runtime) => () => new SPHttpClient(runtime);


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues
fixes #2795. Another solution for the same problem is in #2797 

#### What's in this Pull Request?
Problem is described here: #2795. Added the runtime parameter to the registerCustomRequestClientFactory method. So now the runtime is also a parameter in the constructor of the custom request client factory.