### PR TITLE
added new register custom request client factory with runtime as parameter

### DIFF
--- a/packages/sp/operations.ts
+++ b/packages/sp/operations.ts
@@ -8,6 +8,10 @@ export function registerCustomRequestClientFactory(requestClientFactory: () => I
     httpClientFactory = isFunc(requestClientFactory) ? () => requestClientFactory : defaultFactory;
 }
 
+export function registerCustomRequestClientFactoryWithRuntime(requestClientFactory: (runtime: Runtime) => () => IRequestClient) {
+    httpClientFactory = isFunc(requestClientFactory) ? requestClientFactory : defaultFactory;
+}
+
 const defaultFactory = (runtime: Runtime) => () => new SPHttpClient(runtime);
 let httpClientFactory: (runtime: Runtime) => () => IRequestClient = defaultFactory;
 


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues
fixes #2795. I've already created another pull request #2796 for this problem. This is just another possible solution for that.

#### What's in this Pull Request?
Problem is described here #2795. The pull request creates a new method registerCustomRequestClientFactoryWithRuntime which enables to set a custom request client factory with the runtime as parameter.