### PR TITLE
Update Planner/Task docs

### DIFF
--- a/docs/graph/planner.md
+++ b/docs/graph/planner.md
@@ -247,3 +247,18 @@ const graph = graphfi(...);
 const bucketTasks = await graph.planner.buckets.getById('bucketId').tasks();
 
 ```
+
+## Get Plans for a group
+
+Gets all the plans for a group
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/groups";
+import "@pnp/graph/planner";
+
+const graph = graphfi(...);
+
+const plans = await graph.groups.getById("b179a282-9f94-4bb5-a395-2a80de5a5a78").plans();
+
+```

--- a/docs/graph/planner.md
+++ b/docs/graph/planner.md
@@ -106,6 +106,20 @@ const updPlan = await graph.planner.plans.getById('planId').update({title: 'New 
 
 ```
 
+## Get All My Tasks from all plans
+
+Using the tasks() you can get the Tasks across all plans
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/planner";
+
+const graph = graphfi(...);
+
+const planTasks = await graph.me.tasks()
+
+```
+
 ## Get Task by Id
 
 Using the planner.tasks.getById() you can get a specific Task.


### PR DESCRIPTION
Planner endpoints (technically groups), support retrieving all plans for a group and all the of the tasks of "me". Adding this to planner, not groups/user because it seems like the logical place for it. Let me know if it's not true.

Adding this to v3 as it's already supported by our library.

#### Category
- [x] Documentation update?


#### What's in this Pull Request?

New documentation sample.


