### PR TITLE
Add Missing parameter to AddUsingPath

### DIFF
--- a/docs/sp/files.md
+++ b/docs/sp/files.md
@@ -134,6 +134,8 @@ Likewise you can add files using one of two methods, addUsingPath or addChunked.
 
 The addUsingPath method, supports the percent or pound characters in file names.
 
+When using EnsureUniqueFileName property, you must omit the Overwrite parameter.
+
 ```TypeScript
 import { spfi } from "@pnp/sp";
 import "@pnp/sp/webs";

--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -59,6 +59,9 @@ export class _Files extends _SPCollection<IFileInfo[]> {
             if (parameters.Overwrite) {
                 path.push(",Overwrite=true");
             }
+            if (parameters.EnsureUniqueFileName) {
+                path.push(`,EnsureUniqueFileName=${parameters.EnsureUniqueFileName}`);
+            }
             if (parameters.AutoCheckoutOnInvalidData) {
                 path.push(",AutoCheckoutOnInvalidData=true");
             }
@@ -703,7 +706,7 @@ export interface IAddUsingPathProps {
     /**
      * Overwrite the file if it exists
      */
-    Overwrite: boolean;
+    Overwrite?: boolean;
     /**
      * specifies whether to auto checkout on invalid Data. It'll be useful if the list contains validation whose requirements upload will not be able to meet.
      */
@@ -712,6 +715,10 @@ export interface IAddUsingPathProps {
      * Specifies a XOR hash of the file data which should be used to ensure end-2-end data integrity, base64 representation
      */
     XorHash?: string;
+    /**
+     * Specifies whether to force unique file name. When using this, omit the Overwrite parameter.
+     */
+    EnsureUniqueFileName?: boolean;
 }
 
 export interface IFileInfo {


### PR DESCRIPTION
Updating Docs
Adding Missing Parameter from interface.

#### Category
- [X] Bug fix?
- [X] Documentation update?

#### Related Issues

fixes #2840 

#### What's in this Pull Request?

Update to IAddUsingPathProps interface for missing property
Update to documentation
