### PR TITLE
Fix2847 - Adding missing ItemId to IListItemFormUpdateValue 

### DIFF
--- a/packages/sp/lists/types.ts
+++ b/packages/sp/lists/types.ts
@@ -717,6 +717,11 @@ export interface IListItemFormUpdateValue {
      * Indicates whether there was an error result after validating the value for the field.
      */
     HasException?: boolean;
+
+    /**
+     * The ItemId
+     */
+    ItemId?: number;
 }
 
 /**


### PR DESCRIPTION
#### Category
- [X] Bug fix?

#### Related Issues

fixes #2847 

#### What's in this Pull Request?

Adding missing property

