### PR TITLE
Fix: fromAbsolutePath methods reference undefined `this`

### DIFF
--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -543,7 +543,7 @@ export function fileFromServerRelativePath(base: ISPQueryable, serverRelativePat
  */
 export async function fileFromAbsolutePath(base: ISPQueryable, absoluteFilePath: string): Promise<IFile> {
 
-    const { WebFullUrl } = await File(this).using(BatchNever()).getContextInfo(absoluteFilePath);
+    const { WebFullUrl } = await File(base).using(BatchNever()).getContextInfo(absoluteFilePath);
     const { pathname } = new URL(absoluteFilePath);
     return fileFromServerRelativePath(File([base, combine(WebFullUrl, "_api/web")]), decodeURIComponent(pathname));
 }

--- a/packages/sp/folders/types.ts
+++ b/packages/sp/folders/types.ts
@@ -322,7 +322,7 @@ export function folderFromServerRelativePath(base: ISPQueryable, serverRelativeP
  */
 export async function folderFromAbsolutePath(base: ISPQueryable, absoluteFolderPath: string): Promise<IFolder> {
 
-    const { WebFullUrl } = await Folder(this).using(BatchNever()).getContextInfo(absoluteFolderPath);
+    const { WebFullUrl } = await Folder(base).using(BatchNever()).getContextInfo(absoluteFolderPath);
     const { pathname } = new URL(absoluteFolderPath);
     return folderFromServerRelativePath(Folder([base, combine(WebFullUrl, "_api/web")]), decodeURIComponent(pathname));
 }


### PR DESCRIPTION
#### Category
- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### Related Issues

No related issue.

When creating a File/Folder object based on the absolute path you would get the error:
`Cannot read property '_url' of undefined`, because the `init` value here would be `undefined`:
https://github.com/pnp/pnpjs/blob/e62c30d92b8e6cae63baac8cd3fcd3f391c2dcc2/packages/queryable/queryable.ts#L80-L81

#### What's in this Pull Request?

The methods `fileFromAbsolutePath`/`folderFromAbsolutePath` now use the `base` argument