### PR TITLE
Update request-digest.ts

### DIFF
--- a/packages/sp/behaviors/request-digest.ts
+++ b/packages/sp/behaviors/request-digest.ts
@@ -47,6 +47,7 @@ export function RequestDigest(hook?: (url: string, init: RequestInit) => IDigest
 
                     digest = await spPost(SPQueryable([this, combine(webUrl, "_api/contextinfo")]).using(JSONParse(),BatchNever()), {
                         headers: {
+                            "Accept": "application/json",
                             "X-PnPjs-NoDigest": "1",
                         },
                     }).then(p => ({


### PR DESCRIPTION
#### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

#### What's in this Pull Request?

When using InjectHeaders, you can set odata=verbose. When pnpjs is updating X-RequestDigest, and calls _api/contextinfo, it is using the injected headers, containing odata=verbose, and the code fails to set X-RequestDigest. So forcing to set the Accept parameter correctly without odata=verbose.

To demostrate the issue, you can run following code. 
What we need to do is to set custom Accept header, and execute POST query, which search is using

This code will throw error. There is fix for this issue in this PR, which will set Accept to application/json for the internal _api/contextinfo call to get the digest 

```typescript
import { InjectHeaders } from "@pnp/queryable";
import { spfi, SPBrowser, SearchResults } from "@pnp/sp/presets/all";
import "@pnp/sp/webs";

const sp = spfi().using(SPBrowser({ baseUrl: (window as any)._spPageContextInfo.webAbsoluteUrl }))
  .using(InjectHeaders({
    "Accept": "application/json;odata=verbose",
  }));

(async () => {

  // run a search query, it uses POST method and needs X-RequestDigest
  const results: SearchResults = await sp.search("test");

})().catch(console.log)
```