### PR TITLE
2895 - Rootweb fix

### DIFF
--- a/packages/sp/webs/types.ts
+++ b/packages/sp/webs/types.ts
@@ -71,7 +71,7 @@ function rebaseWebUrl(candidate: string, path: string | undefined): string {
     // - test if `candidate` already has an api path
     // - ensure that we append the correct one as sometimes a web is not defined
     //   by _api/web, in the case of _api/site/rootweb for example
-    const matches = /(_api[/|\\](site|web))/i.exec(candidate);
+    const matches = /(_api[/|\\](site\/rootweb|site|web))/i.exec(candidate);
     if (matches?.length > 0) {
         // we want just the base url part (before the _api)
         candidate = extractWebUrl(candidate);

--- a/test/sp/sites.ts
+++ b/test/sp/sites.ts
@@ -3,11 +3,12 @@ import "@pnp/sp/sites";
 import "@pnp/sp/webs";
 import "@pnp/sp/lists/web";
 import { IDocumentLibraryInformation, IOpenWebByIdResult, ISiteLogoProperties, Site, SiteLogoAspect, SiteLogoType } from "@pnp/sp/sites";
+import "@pnp/sp/site-users";
+import { IWebEnsureUserResult } from "@pnp/sp/site-users";
 import { IWeb } from "@pnp/sp/webs";
 import { combine, getRandomString, stringIsNullOrEmpty } from "@pnp/core";
 import { IContextInfo } from "@pnp/sp/context-info";
 import "@pnp/sp/context-info";
-
 
 import "@pnp/sp/files";
 import { IFiles } from "@pnp/sp/files";
@@ -34,6 +35,11 @@ describe("Sites", function () {
     it("getRootWeb", async function () {
         const rootWeb: IWeb = await this.pnp.sp.site.getRootWeb();
         return expect(rootWeb).to.haveOwnProperty("_url");
+    });
+
+    it("rootWeb - ensureUser", async function () {
+        const user: IWebEnsureUserResult = await this.pnp.sp.site.rootWeb.ensureUser(this.pnp.settings.testUser);
+        return expect(user.data).to.haveOwnProperty("id");
     });
 
     it("getContextInfo", async function () {


### PR DESCRIPTION
Current rebasing logic handles for /_api/site and /_api/web only. Any methods attached to rootweb eventually get truncated.

This adds a new /_api/site/rootweb regex test to rebase to.

#### Category
- [X] Bug fix?

#### Related Issues

fixes #2895 

#### What's in this Pull Request?
Update to Web to allow rebasing back to _api/site/rootweb
Including a new test for ensureUser() on sites.ts test for continually verify this method works.


