### PR TITLE
docs: fix example minimal local debug config

### DIFF
--- a/docs/contributing/local-debug-configuration.md
+++ b/docs/contributing/local-debug-configuration.md
@@ -14,13 +14,11 @@ You can control which tests are run by including or omitting sp and graph sectio
 The following configuration file allows you to run all the tests that do not contact services.
 
 ```js
- var sets = {
-     testing: {
-         enableWebTests: false,
-     }
- }
-
-module.exports = sets;
+export const settings = {
+  testing: {
+    enableWebTests: false,
+  },
+}
 ```
 
 ## Test your setup


### PR DESCRIPTION
#### Category
- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

#### What's in this Pull Request?

Setting up the repository for the first time I noticed that using the minimal settings from the current docs gives the following error: 

>   1) "before all" hook: setup in "{root}":
>      ReferenceError: module is not defined in ES module scope
> This file is being treated as an ES module because it has a '.js' file extension and '/Users/krystianfowler/projects/pnpjs/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
>       at file:///Users/krystianfowler/projects/pnpjs/settings.js:72:1
>       at ModuleJob.run (node:internal/modules/esm/module_job:194:25)

This PR converts the minimal settings example to ES module so that the issue above doesn't occur. 