### PR TITLE
Updated Batching - Support Chunked Batch Size

### DIFF
--- a/packages/graph/batching.ts
+++ b/packages/graph/batching.ts
@@ -172,6 +172,7 @@ export function createBatch(base: IGraphQueryable, props?: IGraphBatchProps): [T
         const requestsWorkingCopy = requests.slice();
 
         // this is the root of our promise chain
+        let chunkIndex = 0;
         while (requestsWorkingCopy.length > 0) {
 
             const requestsChunk = requestsWorkingCopy.splice(0, maxRequests);
@@ -182,30 +183,17 @@ export function createBatch(base: IGraphQueryable, props?: IGraphBatchProps): [T
 
             const response: ParsedGraphResponse = await graphPost(batchQuery, body(batchRequest));
 
-            return new Promise<void>((res, rej) => {
-
+            for (let index = 0; index < response.responses.length; index++) {
+                const [, , , resolve, reject] = requests[index + chunkIndex];
                 try {
-
-                    for (let index = 0; index < response.responses.length; index++) {
-                        const [, , , resolve, reject] = requests[index];
-                        try {
-                            resolve(response.responses[index]);
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }
-
-                    // this small delay allows the promises to resolve correctly in order by dropping this resolve behind
-                    // the other work in the event loop. Feels hacky, but it works so 🤷
-                    setTimeout(res, 0);
-
+                    resolve(response.responses[index]);
                 } catch (e) {
-
-                    setTimeout(() => rej(e), 0);
+                    reject(e);
                 }
-
-            }).then(() => Promise.all(completePromises)).then(() => void (0));
+            }
+            chunkIndex += requestsChunk.length;
         }
+        await Promise.all(completePromises).then(() => void (0));
     };
 
     const register = (instance: Queryable) => {


### PR DESCRIPTION
#### Category
- [X] Bug fix?

#### What's in this Pull Request?

Our current implementation of batching supports a maxRequests props, which splits up the batching into chunks based on that maxRequest value specified. However, it does not work. When the count of requests does not equal the maxRequests value, batching will fail to return the promise. 

I've updated this, to keep track of indexes on the chunks to properly resolve() the promises we've added to our list of requests. I've removed some additional timeouts and promise returns, in favor of the single promise.all


