### PR TITLE
Fix - Missing Context  on NullUndefined Check

### DIFF
--- a/packages/graph/behaviors/spfx.ts
+++ b/packages/graph/behaviors/spfx.ts
@@ -26,7 +26,7 @@ class SPFxTokenNullOrUndefinedError extends Error {
 
 export function SPFxToken(context: ISPFXContext): TimelinePipe<Queryable> {
 
-    SPFxTokenNullOrUndefinedError.check("SPFxToken");
+    SPFxTokenNullOrUndefinedError.check("SPFxToken", context);
 
     return (instance: Queryable) => {
 
@@ -47,7 +47,7 @@ export function SPFxToken(context: ISPFXContext): TimelinePipe<Queryable> {
 
 export function SPFx(context: ISPFXContext): TimelinePipe<Queryable> {
 
-    SPFxTokenNullOrUndefinedError.check("SPFx");
+    SPFxTokenNullOrUndefinedError.check("SPFx", context);
 
     return (instance: Queryable) => {
 


### PR DESCRIPTION
#### Category
- [X] Bug fix?


#### Related Issues

fixes #3012 

#### What's in this Pull Request?
Fixes SPFx null check by passing in missing context parameter.

