### PR TITLE
Fix sp/items Get Paged Items async iterator documentation

### DIFF
--- a/docs/sp/items.md
+++ b/docs/sp/items.md
@@ -42,7 +42,7 @@ import "@pnp/sp/items";
 const sp = spfi(...);
 
 // Using async iterator to loop through pages of items in a large list
-for await (const items of sp.web.lists.getByTitle("BigList").items()) {
+for await (const items of sp.web.lists.getByTitle("BigList").items) {
   console.log(items);
   break; // closes the iterator, returns
 }


### PR DESCRIPTION
### Category

- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [X] Documentation update?

### Related Issues

### What's in this Pull Request?

The documentation example for [Get Paged Items](https://pnp.github.io/pnpjs/sp/items/#get-paged-items) incorrectly shows invoking a `.items()` function to access an AsyncIterator, when the correct usage is not to call the function. I have updated the example.
