### PR TITLE
Updating Taxonomy

### DIFF
--- a/docs/graph/taxonomy.md
+++ b/docs/graph/taxonomy.md
@@ -384,27 +384,3 @@ const termInfo = await graph.termStore.sets.getById("338666a8-1111-2222-3333-f72
 
 const termInfo2 = await graph.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets.getById("338666a8-1111-2222-3333-f72471314e72").getTermById("338666a8-1111-2222-3333-f72471314e72").delete();
 ```
-
-## Get Term Parent
-
-The server API changed again, resulting in the removal of the "parent" property from ITerm as it is not longer supported as a path property. You now must use "expand" to load a term's parent information. The side affect of this is that the parent is no longer chainable, meaning you need to load a new term instance to work with the parent term. An approach for this is shown below.
-
-```TypeScript
-import { graphfi } from "@pnp/graph";
-import "@pnp/graph/taxonomy";
-
-const graph = graphfi(...);
-
-// get a ref to the set
-const set = graph.termStore.groups.getById("338666a8-1111-2222-3333-f72471314e72").sets.getById("338666a8-1111-2222-3333-f72471314e72");
-
-// get a term's information and expand parent to get the parent info as well
-const w = await set.getTermById("338666a8-1111-2222-3333-f72471314e72").expand("parent")();
-
-// get a ref to the parent term
-const parent = set.getTermById(w.parent.id);
-
-// make a request for the parent term's info - this data currently match the results in the expand call above, but this
-// is to demonstrate how to gain a ref to the parent and select its data
-const parentInfo = await parent.select("Id", "Descriptions")();
-```

--- a/packages/graph/taxonomy/types.ts
+++ b/packages/graph/taxonomy/types.ts
@@ -60,10 +60,6 @@ export class _TermSet extends _GraphInstance<ITermStoreType.Set> {
         return Terms(this);
     }
 
-    public get parentGroup(): ITermGroup {
-        return TermGroup(this, "parentGroup");
-    }
-
     public get children(): IChildren {
         return Children(this);
     }

--- a/test/graph/taxonomy.ts
+++ b/test/graph/taxonomy.ts
@@ -94,12 +94,6 @@ describe("Taxonomy", function () {
             return expect(terms).to.be.an("Array");
         });
 
-        // TODO: parentGroup gives API not found error on termset... need to remove/or fix.
-        it.skip(".parentGroup", async function () {
-            const parentGroup = await termset.parentGroup();
-            return expect(parentGroup).has.property("id");
-        });
-
         it("children", async function () {
             const children = await termset.children();
             return expect(children).to.be.an("Array");


### PR DESCRIPTION
Removing ParentGroup. This does not work in Microsoft Graph anymore. 
Updating Docs to remove Term Parent sample.

### Category
- [X] Documentation update?

### Related Issues

fixes #3068 

### What's in this Pull Request?

Updated Guidance Samples in Taxonomy
Removal of ParentGroup() from sets, as it does not work in Graph.


