### PR TITLE
Add SP Siteusers addById() method

### DIFF
--- a/docs/sp/site-users.md
+++ b/docs/sp/site-users.md
@@ -90,7 +90,11 @@ const sp = spfi(...);
 const user = await sp.web.ensureUser("userLoginname")
 const users = await sp.web.siteUsers;
   
+// Add user object by LoginName
 await users.add(user.LoginName);
+
+// Add user object by id
+await users.addById(user.Id);
 ```
 
 ### Get user by Id, Email, or LoginName

--- a/packages/sp/site-users/types.ts
+++ b/packages/sp/site-users/types.ts
@@ -73,6 +73,15 @@ export class _SiteUsers extends _SPCollection<ISiteUserInfo[]> {
         await spPost(this, body({ LoginName: loginName }));
         return this.getByLoginName(loginName);
     }
+
+    /**
+     * Add a user to the collection by id
+     *
+     * @param id The id of the user to add
+     */
+    public addById(id: number): Promise<any> {
+        return spPost(SiteUsers(this, `addUserById(${id})`));
+    }
 }
 export interface ISiteUsers extends _SiteUsers { }
 export const SiteUsers = spInvokableFactory<ISiteUsers>(_SiteUsers);


### PR DESCRIPTION
### Category

- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [x] Documentation update?

### What's in this Pull Request?

This PR adds the `addUserById()` method to be able to add siteusers using their ID.