### PR TITLE
feat(graph): add advanced query behaviour

### DIFF
--- a/docs/graph/behaviors.md
+++ b/docs/graph/behaviors.md
@@ -194,3 +194,18 @@ const graph = graphfi().using(ConsistencyLevel("{level value}"));
 
 await graph.users();
 ```
+
+## AdvancedQuery
+
+Using this behaviour, you can enable [advanced query capabilities](https://learn.microsoft.com/en-us/graph/aad-advanced-queries?tabs=http) when filtering supported collections.
+
+This sets the consistency level to eventual and enables the `$count` query parameter.
+
+```TypeScript
+import { graphfi, AdvancedQuery } from "@pnp/graph";
+import "@pnp/graph/users";
+
+const graph = graphfi().using(AdvancedQuery());
+
+await graph.users.filter("companyName ne null and NOT(companyName eq 'Microsoft')")();
+```

--- a/packages/graph/behaviors/advanced-query.ts
+++ b/packages/graph/behaviors/advanced-query.ts
@@ -1,0 +1,14 @@
+import { TimelinePipe } from "@pnp/core";
+import { Queryable } from "@pnp/queryable";
+import { ConsistencyLevel } from "@pnp/graph";
+
+export function AdvancedQuery(): TimelinePipe<Queryable> {
+
+    return (instance: Queryable) => {
+
+        instance.using(ConsistencyLevel());
+        instance.query.set("$count", "true");
+
+        return instance;
+    };
+}

--- a/packages/graph/index.ts
+++ b/packages/graph/index.ts
@@ -2,6 +2,7 @@ export { graphfi as graphfi, GraphFI as GraphFI } from "./fi.js";
 
 export * from "./graphqueryable.js";
 
+export * from "./behaviors/advanced-query.js";
 export * from "./behaviors/consistency-level.js";
 export * from "./behaviors/defaults.js";
 export * from "./behaviors/endpoint.js";

--- a/test/graph/query-params.ts
+++ b/test/graph/query-params.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { pnpTest } from "../pnp-test.js";
 import "@pnp/graph/groups";
 import "@pnp/graph/users";
-import { ConsistencyLevel } from "@pnp/graph/index.js";
+import { ConsistencyLevel, AdvancedQuery } from "@pnp/graph/index.js";
 
 describe("Graph Query Params", function () {
 
@@ -41,4 +41,27 @@ describe("Graph Query Params", function () {
 
         return expect(query()).to.eventually.be.fulfilled;
     }));
+
+    describe("AdvancedQuery", () => {
+        it("NOT groupTypes/any(c:c eq 'Unified')", pnpTest("d24d9b36-d5dc-4a6c-81fa-2e9a73911372", async function () {
+
+            const query = this.pnp.graph.groups.using(AdvancedQuery()).filter("NOT groupTypes/any(c:c eq 'Unified')");
+
+            return expect(query()).to.eventually.be.fulfilled;
+        }));
+
+        it("companyName ne null and NOT(companyName eq 'Microsoft')", pnpTest("33791988-de36-4a6d-88e1-23f6838236ac", async function () {
+
+            const query = this.pnp.graph.users.using(AdvancedQuery()).filter("companyName ne null and NOT(companyName eq 'Microsoft')");
+
+            return expect(query()).to.eventually.be.fulfilled;
+        }));
+
+        it("not(assignedLicenses/$count eq 0)", pnpTest("fe202c37-e10e-4b1c-b410-99cf059a491b", async function () {
+
+            const query = this.pnp.graph.users.using(AdvancedQuery()).filter("not(assignedLicenses/$count eq 0)");
+
+            return expect(query()).to.eventually.be.fulfilled;
+        }));
+    });
 });


### PR DESCRIPTION
### Category

- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?

### What's in this Pull Request?

Hey, been a while!

Currently enabling [advanced query capabilities](https://learn.microsoft.com/en-us/graph/aad-advanced-queries?tabs=http) is supported, but a two-step process:

```ts
const filter = "companyName ne null and NOT(companyName eq 'Microsoft')";
const query = graph.users.using(ConsistencyLevel()).filter(filter);
query.query.set("$count", "true");
const res = await query();
```

This PR adds a new behaviour which simply combines the two steps to make this more ergonomic:

```ts
const filter = "companyName ne null and NOT(companyName eq 'Microsoft')";
const res = await graph.users.using(AdvancedQuery()).filter(filter)();
```

I have updated docs but have NOT updated the relevant tests yet. If you can let me know whether you'd be happy to accept this change, I'll go through and update the tests.