### PR TITLE
Correct broken 'list template codes' documentation reference

### DIFF
--- a/docs/sp/lists.md
+++ b/docs/sp/lists.md
@@ -70,7 +70,7 @@ console.log(r.Title);
 });
 ```
 
-You can also provide other (optional) parameters like description, template and enableContentTypes. If that is not enough for you, you can use the parameter named 'additionalSettings' which is just a TypedHash, meaning you can sent whatever properties you'd like in the body (provided that the property is supported by the SharePoint API). You can find a [listing of list template codes](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sharepoint.splisttemplatetype?view=sharepoint-server) in the official docs.
+You can also provide other (optional) parameters like description, template and enableContentTypes. If that is not enough for you, you can use the parameter named 'additionalSettings' which is just a TypedHash, meaning you can sent whatever properties you'd like in the body (provided that the property is supported by the SharePoint API). You can find a [listing of list template codes](https://learn.microsoft.com/en-us/openspecs/sharepoint_protocols/ms-wssts/8bf797af-288c-4a1d-a14b-cf5394e636cf) in the official docs.
 
 ```TypeScript
 // this will create a list with template 101 (Document library), content types enabled and show it on the quick launch (using additionalSettings)


### PR DESCRIPTION
### Category

- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [X] Documentation update?

### Related Issues

N/A

### What's in this Pull Request?

Changes the hyperlink referencing 'list template codes' at `/sp/lists/#add-list` to the correct address found within the Microsoft 'Sharepoint Products and Technologies' protocols documentation. Exisiting link is broken.
