### PR TITLE
Add back in .clone() for errors

### DIFF
--- a/packages/queryable/behaviors/parsers.ts
+++ b/packages/queryable/behaviors/parsers.ts
@@ -127,7 +127,7 @@ export class HttpRequestError extends Error {
     }
 
     public static async init(r: Response): Promise<HttpRequestError> {
-        const t = await r.text();
+        const t = await r.clone().text();
         return new HttpRequestError(`Error making HttpClient request in queryable [${r.status}] ${r.statusText} ::> ${t}`, r);
     }
 }


### PR DESCRIPTION
### Category

- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

### Related Issues

fixes #3171 

### What's in this Pull Request?

Puts back the .clone() call in http error generation