### PR TITLE
Add `drive` endpoint to lists in Graph

### DIFF
--- a/docs/graph/lists.md
+++ b/docs/graph/lists.md
@@ -81,6 +81,18 @@ const graph = graphfi(...);
 await graph.sites.getById("{site identifier}").lists.getById("{list identifier}").columns();
 ```
 
+## Get the corresponding drive to a list
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/lists";
+import "@pnp/graph/files";
+
+const graph = graphfi(...);
+
+await graph.sites.getById("{site identifier}").lists.getById("{list identifier}").drive();
+```
+
 ## Get List Items
 
 Currently, recieving list items via @pnpjs/graph API is not possible.

--- a/packages/graph/files/index.ts
+++ b/packages/graph/files/index.ts
@@ -2,6 +2,7 @@ import { GraphFI } from "../fi.js";
 import "./users.js";
 import "./groups.js";
 import "./sites.js";
+import "./lists.js";
 import { Drives, IDrives } from "./types.js";
 
 export {

--- a/packages/graph/files/lists.ts
+++ b/packages/graph/files/lists.ts
@@ -1,0 +1,30 @@
+import { addProp } from "@pnp/queryable";
+import { _List } from "../lists/types.js";
+import { IDrive, Drive, _DriveItem } from "./types.js";
+import { checkIn, ICheckInOptions, checkOut } from "./funcs.js";
+
+declare module "../sites/types" {
+    interface _List {
+        readonly drive: IDrive;
+    }
+    interface IList {
+        readonly drive: IDrive;
+    }
+}
+
+addProp(_List, "drive", Drive);
+
+declare module "./types" {
+    interface _DriveItem {
+        checkIn(checkInOptions?: ICheckInOptions): Promise<void>;
+        checkOut(): Promise<void>;
+    }
+
+    interface DriveItem {
+        checkIn(checkInOptions?: ICheckInOptions): Promise<void>;
+        checkOut(): Promise<void>;
+    }
+}
+
+_DriveItem.prototype.checkIn = checkIn;
+_DriveItem.prototype.checkOut = checkOut;


### PR DESCRIPTION
### Category

- [ ] Bug fix?
- [X] New feature?
- [ ] New sample?
- [ ] Documentation update?

### What's in this Pull Request?

This adds the `drive` endpoint to Graph lists, so that the corresponding Drive can be fetched from a list.