### PR TITLE
Updates getChanges sample

### DIFF
--- a/docs/sp/lists.md
+++ b/docs/sp/lists.md
@@ -241,7 +241,7 @@ import { IChangeQuery } from "@pnp/sp";
 
 //Resource is the list Id (as Guid)
 const resource = list.Id;
-const changeStart = new Date("2022-02-22").getTime();
+const changeStart = (new Date("2022-02-22").getTime() * 10000) + 621355968000000000); // We need to convert the timestamp to ticks
 const changeTokenStart = `1;3;${resource};${changeStart};-1`;
 
 // build the changeQuery object, here we look at changes regarding Add and Update for Items.


### PR DESCRIPTION
### Category

- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [x] Documentation update?

### Related Issues

N/A

### What's in this Pull Request?

Change to the documentation:
The API expects ticks as they would've been provided by C#
JavaScripts default .getTime() only returns Unix Ticks, which the API doesn't like - this might be something a better solution could we written for, such as a ChangeQuery constructor that simply takes in a date object, but for now this will resolve this docs being incorrect