### PR TITLE
fix content-type order type on folder

### DIFF
--- a/packages/sp/folders/types.ts
+++ b/packages/sp/folders/types.ts
@@ -343,8 +343,8 @@ export interface IFolderInfo {
     TimeLastModified: string;
     UniqueId: string;
     WelcomePage: string;
-    ContentTypeOrder: string[];
-    UniqueContentTypeOrder: string[];
+    ContentTypeOrder: { StringValue: string }[];
+    UniqueContentTypeOrder: { StringValue: string }[];
     StorageMetrics?: IStorageMetrics;
 }
 


### PR DESCRIPTION
### Category

- [x] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

### What's in this Pull Request?

This PR updates types for ```Folder.ContentTypeOrder``` and ```Folder.UniqueContentTypeOrder``` properties from ```string``` array to array of ```StringValue``` objects.

At least at some time it was described correctly: https://pnp.github.io/pnpjs/v1/sp/docs/content-types/
