### PR TITLE
Spawn Fix

### DIFF
--- a/debug/serve/plumbing/run.ts
+++ b/debug/serve/plumbing/run.ts
@@ -15,10 +15,12 @@ const isWin = process.platform === "win32";
 spawn(isWin ? "npx.cmd" : "npx", ["tsc", "-p", "./debug/serve/tsconfig.json", "--watch"], {
     cwd: projectRoot,
     stdio: "inherit",
+    shell:true,
 });
 
 // run our server
 spawn("node", ["./serve.js"], {
     cwd: __dirname,
     stdio: "inherit",
+    shell:true
 });

--- a/debug/spfx/pnpjs-local-debug-start.js
+++ b/debug/spfx/pnpjs-local-debug-start.js
@@ -10,10 +10,12 @@ const isWin = process.platform === "win32";
 child_process.spawn(isWin ? "npx.cmd" : "npx", ["tsc", "-p", "./packages/tsconfig-watch.json"], {
     cwd: projectRoot,
     stdio: "inherit",
+    shell:true,
 });
 
 // run our server
 child_process.spawn(isWin ? "npx.cmd" : "npx", ["gulp", "serve", "--nobrowser"], {
     cwd: __dirname,
     stdio: "inherit",
+    shell: true,
 });


### PR DESCRIPTION
Windows 11 introduces an issue with the use of nodejs Spawn when not run through Shell. Updating Spawn Methods where needed to include shell:true.

### Category

- [X] Bug fix?

### What's in this Pull Request?
Windows 11 has some security changes which causes spawn() to run function without error. This means we cannot locally debug the solution in our debug folder. 

### Guidance
To test, on an Windows 11 machine run `npm run serve`