### PR TITLE
Fixing 3268

### DIFF
--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -422,7 +422,7 @@ export class _File extends ReadableFile<IFileInfo> {
                 buffer = newBuffer;
             }
 
-            while (buffer.length >= chunkSize || (chunk.done && buffer.length > 0)) {
+            while (buffer.length >= chunkSize) {
                 const chunkToUpload = buffer.slice(0, chunkSize);
                 buffer = buffer.slice(chunkSize);
 
@@ -430,9 +430,6 @@ export class _File extends ReadableFile<IFileInfo> {
                     progress({ offset, stage: "starting", uploadId });
                     offset = await spPost(File(fileRef, `startUpload(uploadId=guid'${uploadId}')`), { body: chunkToUpload });
                     first = false;
-                } else if (chunk.done && buffer.length === 0) {
-                    progress({ offset, stage: "finishing", uploadId });
-                    return spPost(File(fileRef, `finishUpload(uploadId=guid'${uploadId}',fileOffset=${offset})`), { body: chunkToUpload });
                 } else {
                     progress({ offset, stage: "continue", uploadId });
                     offset = await spPost(File(fileRef, `continueUpload(uploadId=guid'${uploadId}',fileOffset=${offset})`), { body: chunkToUpload });
@@ -440,7 +437,14 @@ export class _File extends ReadableFile<IFileInfo> {
             }
 
             if (chunk.done) {
-                break;
+                if (first) {
+                    // Small file: not enough data to trigger a chunk upload
+                    progress({ offset, stage: "starting", uploadId });
+                    offset = await spPost(File(fileRef, `startUpload(uploadId=guid'${uploadId}')`), { body: buffer });
+                    first = false;
+                }
+                progress({ offset, stage: "finishing", uploadId });
+                return spPost(File(fileRef, `finishUpload(uploadId=guid'${uploadId}',fileOffset=${offset})`), { body: buffer.length ? buffer : "" });
             }
         }
     }


### PR DESCRIPTION
Had an issue where the promise wasn't resolving correcting because the finishing progress wasn't firing and it was breaking out early as the reader was done before the final upload was happening.

In addition, realized it didn't support small files either where the file was smaller than the default chunksize. Added a fix for that too.

### Category


- [X] Bug fix?

### Related Issues

fixes #3268

### What's in this Pull Request?

Update to Files setChunked method to better handle chunk sizing and progress events.
