### PR TITLE
Fix for JsonHeaderParse

### DIFF
--- a/packages/graph/content-types/types.ts
+++ b/packages/graph/content-types/types.ts
@@ -82,7 +82,7 @@ export class _ContentTypes extends _GraphCollection<IContentTypeEntity[]>{
     public async addCopyFromContentTypeHub(contentTypeId: string): Promise<IContentTypeAddResult> {
         const creator = ContentType(this, "addCopyFromContentTypeHub").using(JSONHeaderParse());
         const result = await graphPost(creator, body({ contentTypeId }));
-        const pendingLocation = result?.headers?.location || null;
+        const pendingLocation = result?.headers?.get("location") || null;
         return {
             data: result.data,
             contentType: (<any>this).getById(result.data.id),

--- a/packages/queryable/behaviors/parsers.ts
+++ b/packages/queryable/behaviors/parsers.ts
@@ -48,14 +48,14 @@ export function JSONHeaderParse(): TimelinePipe {
     return parseBinderWithErrorCheck(async (response) => {
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        if ((response.headers.has("Content-Length") && parseFloat(response.headers.get("Content-Length")!) === 0) || response.status === 204) {
+        if (response.status === 204) {
             return {};
         }
 
         // patch to handle cases of 200 response with no or whitespace only bodies (#487 & #545)
         const txt = await response.text();
         const json = txt.replace(/\s/ig, "").length > 0 ? JSON.parse(txt) : {};
-        return { data: { ...parseODataJSON(json) }, headers: { ...response.headers } };
+        return { data: { ...parseODataJSON(json) }, headers: response.headers };
     });
 }
 


### PR DESCRIPTION
Fixing return on response.headers to return the Header typed object. Header type is not enumerable so the spread operator doesn't work.

Update to addCopyContentTypeFromHub to use Header type methods to retrieve location.

### Category

- [X] Bug fix?


### What's in this Pull Request?
Update to Parsers to adjust the initial conditional for content-length on JsonHeaderParser.

Update to addCopyContentTypeFromHub to use Headers type methods to retrieve location instead of trying to get values from an object property.

