### PR TITLE
SP Utility SendEmail soft deprecation

### DIFF
--- a/docs/sp/sp-utilities-utility.md
+++ b/docs/sp/sp-utilities-utility.md
@@ -4,6 +4,9 @@ Through the REST api you are able to call a subset of the SP.Utilities.Utility m
 
 ## sendEmail
 
+> ⚠️ **Deprecated**: This method is deprecated in favor of the [Graph module's `sendMessage`](https://pnp.github.io/pnpjs/graph/mail-messages/#send-message).
+> Please migrate to the Graph module for sending emails. This functionality will be removed in future versions.
+
 This methods allows you to send an email based on the supplied arguments. The method takes a single argument, a plain object defined by the EmailProperties interface (shown below).
 
 ### EmailProperties
@@ -63,7 +66,8 @@ const sp = spfi(...);
 
 let addressString: string = await sp.utility.getCurrentUserEmailAddresses();
 
-// and use it with sendEmail
+// and use it with sendEmail 
+// note: sendEmail has been deprecated in favor of Graph module's sendMessage functionality
 await sp.utility.sendEmail({
     To: [addressString],
     Subject: "This email is about...",

--- a/packages/sp/sputilities/types.ts
+++ b/packages/sp/sputilities/types.ts
@@ -89,8 +89,14 @@ export class _Utilities extends _SPQueryable implements IUtilities {
 export interface IUtilities {
 
     /**
-     * This methods will send an e-mail based on the incoming properties of the IEmailProperties parameter.
-     * @param props IEmailProperties object
+     * Sends an email based on the provided {@link IEmailProperties}.
+     *
+     * @param props - The email configuration object.
+     *
+     * @deprecated This method is deprecated in favor of the Graph module's email functionality.
+     * Use {@link https://pnp.github.io/pnpjs/graph/mail-messages/#send-message | Graph: sendMessage} instead.
+     *
+     * @see {@link https://pnp.github.io/pnpjs/graph/mail-messages/#send-message}
      */
     sendEmail(props: IEmailProperties): Promise<void>;
 


### PR DESCRIPTION
Adding deprecation annotations  for SendEmail method Updating Docs to include additional messaging to use Graph instead.

### Category
- [X] Documentation update?


### What's in this Pull Request?
New Annotations for jsdoc / intellisense for deprecation of sendEmail from utilities
Updated docs

![image](https://github.com/user-attachments/assets/89ae9e57-ae64-44df-b7c1-3eb9968412b5)

