### PR TITLE
V5/removal sp utilities send email

### DIFF
--- a/docs/sp/sp-utilities-utility.md
+++ b/docs/sp/sp-utilities-utility.md
@@ -2,55 +2,6 @@
 
 Through the REST api you are able to call a subset of the SP.Utilities.Utility methods. We have explicitly defined some of these methods and provided a method to call any others in a generic manner. These methods are exposed on pnp.sp.utility and support batching and caching.
 
-## sendEmail
-
-This methods allows you to send an email based on the supplied arguments. The method takes a single argument, a plain object defined by the EmailProperties interface (shown below).
-
-### EmailProperties
-
-```TypeScript
-export interface TypedHash<T> {
-    [key: string]: T;
-}
-
-export interface EmailProperties {
-
-    To: string[];
-    CC?: string[];
-    BCC?: string[];
-    Subject: string;
-    Body: string;
-    AdditionalHeaders?: TypedHash<string>;
-    From?: string;
-}
-```
-
-### Usage
-
-You must define the To, Subject, and Body values - the remaining are optional.
-
-```TypeScript
-import { spfi } from "@pnp/sp";
-import "@pnp/sp/sputilities";
-import { IEmailProperties } from "@pnp/sp/sputilities";
-
-const sp = spfi(...);
-
-const emailProps: IEmailProperties = {
-    To: ["user@site.com"],
-    CC: ["user2@site.com", "user3@site.com"],
-    BCC: ["user4@site.com", "user5@site.com"],
-    Subject: "This email is about...",
-    Body: "Here is the body. <b>It supports html</b>",
-    AdditionalHeaders: {
-        "content-type": "text/html"
-    }
-};
-
-await sp.utility.sendEmail(emailProps);
-console.log("Email Sent!");
-```
-
 ## getCurrentUserEmailAddresses
 
 This method returns the current user's email addresses known to SharePoint.
@@ -63,15 +14,6 @@ const sp = spfi(...);
 
 let addressString: string = await sp.utility.getCurrentUserEmailAddresses();
 
-// and use it with sendEmail
-await sp.utility.sendEmail({
-    To: [addressString],
-    Subject: "This email is about...",
-    Body: "Here is the body. <b>It supports html</b>",
-    AdditionalHeaders: {
-        "content-type": "text/html"
-    },
-});
 ```
 
 ## resolvePrincipal

--- a/packages/sp/sputilities/index.ts
+++ b/packages/sp/sputilities/index.ts
@@ -2,7 +2,6 @@ import { SPFI } from "../fi.js";
 import { IUtilities, Utilities } from "./types.js";
 
 export {
-    IEmailProperties,
     IUtilities,
     IWikiPageCreationInfo,
     Utilities,

--- a/packages/sp/sputilities/types.ts
+++ b/packages/sp/sputilities/types.ts
@@ -15,21 +15,6 @@ export class _Utilities extends _SPQueryable implements IUtilities {
         return spPost(this, body(props));
     }
 
-    public sendEmail(properties: IEmailProperties): Promise<void> {
-
-        if (properties.AdditionalHeaders) {
-
-            // we have to remap the additional headers into this format #2253
-            properties.AdditionalHeaders = <any>Reflect.ownKeys(properties.AdditionalHeaders).map(key => ({
-                Key: key,
-                Value: Reflect.get(properties.AdditionalHeaders, key),
-                ValueType: "Edm.String",
-            }));
-        }
-
-        return UtilitiesCloneFactory(this, "SendEmail").excute<void>({ properties });
-    }
-
     public getCurrentUserEmailAddresses(): Promise<string> {
         return UtilitiesCloneFactory(this, "GetCurrentUserEmailAddresses").excute<string>({});
     }
@@ -89,12 +74,6 @@ export class _Utilities extends _SPQueryable implements IUtilities {
 export interface IUtilities {
 
     /**
-     * This methods will send an e-mail based on the incoming properties of the IEmailProperties parameter.
-     * @param props IEmailProperties object
-     */
-    sendEmail(props: IEmailProperties): Promise<void>;
-
-    /**
      * This method returns the current user's email addresses known to SharePoint.
      */
     getCurrentUserEmailAddresses(): Promise<string>;
@@ -142,46 +121,6 @@ export interface IUtilities {
 export const Utilities: (base: SPInit, path?: string) => IUtilities = <any>spInvokableFactory(_Utilities);
 type UtilitiesCloneType = IUtilities & ISPQueryable & { excute<T>(props: any): Promise<T> };
 const UtilitiesCloneFactory = (base: SPInit, path?: string): UtilitiesCloneType => <any>Utilities(base, path);
-
-export interface IEmailProperties {
-    /**
-     * The list of receivers represented by a string array.
-     */
-    To: string[];
-
-    /**
-     * The list of receivers as CC (carbon copy) represented by a string array.
-     * This is optional.
-     */
-    CC?: string[];
-
-    /**
-     * The list of receivers as BCC (blind carbon copy) represented by a string array.
-     * This is optional.
-     */
-    BCC?: string[];
-
-    /**
-     * The subject of the email.
-     */
-    Subject: string;
-
-    /**
-     * The body of the email.
-     */
-    Body: string;
-
-    /**
-     * The additional headers appened to the request in key/value pairs.
-     */
-    AdditionalHeaders?: Record<string, string>;
-
-    /**
-     * The from address of the email.
-     * This is optional.
-     */
-    From?: string;
-}
 
 export interface IWikiPageCreationInfo {
     /**

--- a/test/sp/sputilities.ts
+++ b/test/sp/sputilities.ts
@@ -4,7 +4,6 @@ import "@pnp/sp/site-users/web";
 import "@pnp/sp/sputilities";
 import { PrincipalType, PrincipalSource } from "@pnp/sp";
 import { combine, stringIsNullOrEmpty } from "@pnp/core";
-import { IEmailProperties } from "@pnp/sp/sputilities";
 
 // cannot test with app permissions
 describe.skip("SPUtilities", function () {
@@ -37,30 +36,6 @@ describe.skip("SPUtilities", function () {
 
     it("expandGroupsToPrincipals", async function () {
         return expect(this.pnp.sp.utility.expandGroupsToPrincipals(["Everyone"], 10)).to.eventually.be.an.instanceOf(Array).and.not.be.empty;
-    });
-
-    it("sendEmail", async function () {
-
-        if (stringIsNullOrEmpty(this.pnp.settings.testUser)) {
-            this.skip();
-        }
-
-        const currentUserEmailAddress = await this.pnp.sp.utility.getCurrentUserEmailAddresses();
-
-        const headers = {
-            "content-type": "text/html",
-        };
-
-        const emailProps: IEmailProperties = {
-            AdditionalHeaders: headers,
-            BCC: [currentUserEmailAddress],
-            Body: "Here is the body. <b>It supports html</b>",
-            CC: [currentUserEmailAddress],
-            Subject: "This email is about...",
-            To: [currentUserEmailAddress],
-        };
-
-        return expect(this.pnp.sp.utility.sendEmail(emailProps)).to.eventually.be.fulfilled;
     });
 
     it("searchPrincipals", async function () {


### PR DESCRIPTION
### Category
- [X] Documentation update?

### What's in this Pull Request?
Removal of SendEmail method in v5. We already deprecated this functionality in v4.
Updated Docs
Removal of methods and tests
