### PR TITLE
Fixing Small File upload using Chunks

### DIFF
--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -442,6 +442,7 @@ export class _File extends ReadableFile<IFileInfo> {
                     progress({ offset, stage: "starting", uploadId });
                     offset = await spPost(File(fileRef, `startUpload(uploadId=guid'${uploadId}')`), { body: buffer });
                     first = false;
+                    buffer = new Uint8Array(); // reset buffer on small file upload, so we don't duplicate the buffer on finishUpload. Issue #3278
                 }
                 progress({ offset, stage: "finishing", uploadId });
                 return spPost(File(fileRef, `finishUpload(uploadId=guid'${uploadId}',fileOffset=${offset})`), { body: buffer.length ? buffer : "" });


### PR DESCRIPTION
Resetting a buffer on small file uploads. While we don't recommend using chunked uploads for files < 10mb, to handle backwards compatibility, I tried to support this.

An issue arises on small file uploads where the chunk has been read, and the buffer has been set... and then we finishUpload which causes the file to be duplicated in content.

This is due to trying to reusing a single finishUpload call at the end. A quick fix is to reset the buffer on the small upload first.

We should revisit this code in v5.

### Category

- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

### Related Issues

fixes #3278 

### What's in this Pull Request?

Update to files types in setContentChunked to reset buffer on smaller file uploads that only have a single chunk.
