### PR TITLE
Fixes 3309

### DIFF
--- a/packages/sp/files/types.ts
+++ b/packages/sp/files/types.ts
@@ -186,7 +186,8 @@ export class _File extends ReadableFile<IFileInfo> {
             throw Error("The maximum comment length is 1023 characters.");
         }
 
-        return spPost(File(this, `checkin(comment='${encodePath(comment)}',checkintype=${checkinType})`));
+        return spPost(File(this, `checkin(comment=@a2,checkintype=@a3)?@a2=${encodeURIComponent(`'${comment.replace(/'/g, "''")}'`)}&@a3=${checkinType}`));
+
     }
 
     /**


### PR DESCRIPTION
Comments on Checkins did not allow special characters.

### Category

- [X] Bug fix?

### Related Issues

fixes #3309
### What's in this Pull Request?

Updates to File types.ts to use @a2 parametrized values and use of encodeURIComponent instead of our custom encodePath method to fix encoding issues on comment checkins.

