### PR TITLE
Graph Group Members Fix

### DIFF
--- a/docs/graph/members.md
+++ b/docs/graph/members.md
@@ -22,7 +22,7 @@ const owners = await graph.groups.getById({groupId}).owners();
 
 ## Add Member/Owner
 
-Add a member/owner to an group
+Add a member/owner to a group
 
 ```TypeScript
 import { graphfi } from "@pnp/graph";
@@ -32,8 +32,21 @@ import "@pnp/graph/members";
 const graph = graphfi(...);
 const members = await graph.groups.getById({groupId}).members.add({directoryObjectId}).
 const owners = await graph.groups.getById({groupId}).owners.add({directoryObjectId});
-```
 
+```
+## Add Members to Group in bulk
+
+Add a list of members to a group in a single call
+
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import "@pnp/graph/groups";
+import "@pnp/graph/members";
+
+const graph = graphfi(...);
+await graph.groups.getById({groupId}).members.addBulk(["https://graph.microsoft.com/v1.0/directoryObjects/f5ac7788-8ab1-5a62-bf9a-380aaf0f1afc","https://graph.microsoft.com/v1.0/directoryObjects/950381e3-9d63-561d-a160-20b95ae388d0"]).
+
+```
 ## Remove Member/Owner
 
 Remove a member/owner to an group

--- a/packages/graph/members/groups.ts
+++ b/packages/graph/members/groups.ts
@@ -1,38 +1,41 @@
 
 import { addProp, body } from "@pnp/queryable";
-import { _Group } from "../groups/types.js";
-import { IMembers, Members } from "./types.js";
-import { graphPatch } from "../graphqueryable.js";
+import { _Group, Group } from "../groups/types.js";
+import { _Members, IMember, IMembers, Members } from "./types.js";
+import { graphInvokableFactory, graphPatch } from "../graphqueryable.js";
+import { getById, IGetById } from "../decorators.js";
+import { Member } from "./types.js";
 
-declare module "../groups/types" {
-    interface _Group {
-        readonly owners: IMembers;
-        readonly members: IMembers;
-    }
-    interface IGroup {
-        readonly owners: IMembers;
-        readonly members: IMembers;
-    }
-}
-
-addProp(_Group, "owners", Members, "owners");
-addProp(_Group, "members", Members);
-
-declare module "./types" {
-    interface IMembers {
-        addBulk(members: string[]): Promise<void>;
-    }
-    interface _Members {
-        addBulk(members: string[]): Promise<void>;
-    }
-}
 /**
-     * Use this API to add a members to an Microsoft 365 group, a security group or a mail-enabled security group through
+ * Members of a group.
+ * Specific subclass to expose additional methods only available on member objects for groups, such as the addBulk method.
+ */
+@getById(Member)
+export class _GroupMembers extends _Members {
+    /**
+     * Use this API to add members to a Microsoft 365 group, a security group, or a mail-enabled security group through
      * the members navigation property. You can add users or other groups.
      * Important: You can add only users to Microsoft 365 groups.
      *
      * @param members Array of full @odata.id of the directoryObject, user, or group object you want to add (ex: `https://graph.microsoft.com/v1.0/directoryObjects/${id}`)
      */
-_Group.prototype.members.addBulk = function (members: string[]): Promise<void> {
-    return graphPatch(Members(this), body({ "members@odata.bind": members }));
-};
+    public addBulk(members: string[]): Promise<void> {
+        return graphPatch(this.getParent(Group), body({ "members@odata.bind": members }));
+    }
+}
+export interface IGroupMembers extends _GroupMembers, IGetById<IMember> { }
+export const GroupMembers = graphInvokableFactory<IGroupMembers>(_GroupMembers);
+
+declare module "../groups/types" {
+    interface _Group {
+        readonly owners: IMembers;
+        readonly members: IGroupMembers;
+    }
+    interface IGroup {
+        readonly owners: IMembers;
+        readonly members: IGroupMembers;
+    }
+}
+
+addProp(_Group, "owners", Members, "owners");
+addProp(_Group, "members", GroupMembers);

--- a/packages/graph/members/index.ts
+++ b/packages/graph/members/index.ts
@@ -6,3 +6,8 @@ export {
     Member,
     Members,
 } from "./types.js";
+
+export {
+    IGroupMembers,
+    GroupMembers,
+} from "./groups.js";


### PR DESCRIPTION
Group Members has unique functionality for adding members in bulk. It's technically a Group endpoint (a PATCH to Group), but to maintain a clean fluent intellisense, I implemented a subclass for members specific to groups and attached the addBulk method to it.

The previous implementation had some issues with extending the prototype, and cause issues when importing members functionality into code.

### Category

- [X] Bug fix?

### What's in this Pull Request?

Updates to Groups.ts in Members for a new subclass. You'll notice I am using Members for Owners and ChatMembers for members on the Group interface, this is because addBulk does not exist on owners, so it should not use the new ChatMembers class.

Updated Docs with an example of addBulk
