### PR TITLE
V5 Documentation Improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-## Contributing Guidance - v3
+## Contributing Guidance - v5
 
-* Target your pull requests to the **version-3** branch
+* Target your pull requests to the **version-5** branch
 * Add/Update any docs articles related to your changes
 * Include a test for any new functionality and ensure all existing tests are passing by running `npm test`
   * If you are fixing a bug, include a test that would have caught the bug you are fixing

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please see the [Getting Started guide](https://pnp.github.io/pnpjs/getting-start
 ## Documentation
 
 Please review the [documentation](https://pnp.github.io/pnpjs/) for the PnPjs libraries. This
-site is updated with each release. If cannot find what you need, please let us know by logging an [documentation request](https://github.com/pnp/pnpjs/issues).
+site is updated with each release. If you cannot find what you need, please [open an issue](https://github.com/pnp/pnpjs/issues) with the `documentation` label.
 
 ## Authors
 This project's contributors include Microsoft and [community contributors](AUTHORS). Work is done as an open source community project.

--- a/docs/concepts/auth-spfx.md
+++ b/docs/concepts/auth-spfx.md
@@ -44,7 +44,7 @@ We support MSAL for both browser and nodejs by providing a thin wrapper around t
 
 `npm install @pnp/msaljsclient --save`
 
-At this time we're using version 1.x of the `msal` library which uses Implicit Flow. For more informaiton on the msal library please see the [AzureAD/microsoft-authentication-library-for-js](https://github.com/AzureAD/microsoft-authentication-library-for-js#readme).
+At this time we're using version 3.x of the `msal` library which uses Implicit Flow. For more information on the msal library please see the [AzureAD/microsoft-authentication-library-for-js](https://github.com/AzureAD/microsoft-authentication-library-for-js#readme).
 
 Each of the following samples reference a MSAL configuration that utilizes an Azure AD App Registration, these are samples that show the typings for those objects:
 

--- a/docs/concepts/authentication.md
+++ b/docs/concepts/authentication.md
@@ -22,19 +22,22 @@ async function(url, init) {
 You can follow this example as a general pattern to build your own custom authentication model. You can then wrap your authentication in a [behavior](../core/behaviors.md) for easy reuse.
 
 ```TypeScript
-import { spfi } from "@pnp/sp";
+import { spfi, SPBrowser } from "@pnp/sp";
 import "@pnp/sp/webs";
 
-const sp = spfi().using({behaviors});
+// Use custom auth when built-in behaviors don't meet your needs
+// For example, integrating with a custom identity provider
+const sp = spfi("https://tenant.sharepoint.com").using(SPBrowser());
 const web = sp.web;
 
-// we will use custom auth on this web
+// Add custom authentication to this web instance
 web.on.auth(async function(url, init) {
 
-    // some code to get a token
-    const token = getToken();
+    // Replace with your actual token acquisition logic
+    const token = await myCustomAuthProvider.getAccessToken();
 
     // set the Authorization header in the init (this init is what is passed directly to the fetch call)
+    init.headers = init.headers || {};
     init.headers["Authorization"] = `Bearer ${token}`;
 
     return [url, init];

--- a/docs/concepts/error-handling.md
+++ b/docs/concepts/error-handling.md
@@ -23,9 +23,11 @@ All errors resulting from executed web requests will be returned as an `HttpRequ
 For all operations involving a web request you should account for the possibility they might fail. That failure might be transient or permanent - you won't know until they happen 😉. The most basic type of error handling involves a simple try-catch when using the [async/await promises pattern](https://javascript.info/async-await).
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/lists/web";
+
+const sp = spfi().using(SPFx(this.context));
 
 try {
 
@@ -51,10 +53,12 @@ This is very descriptive and provides full details as to what happened, but you 
 In some cases the response body will have additional details such as a localized error messages which can be nicer to display rather than our normalized string. You can read the response directly and process it however you desire:
 
 ```TypeScript
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/lists/web";
 import { HttpRequestError } from "@pnp/queryable";
+
+const sp = spfi().using(SPFx(this.context));
 
 try {
   
@@ -92,9 +96,11 @@ Using the [PnPjs Logging Framework](../logging/index.md) you can directly pass t
 
 ```TypeScript
 import { Logger } from "@pnp/logging";
-import { sp } from "@pnp/sp";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/lists/web";
+
+const sp = spfi().using(SPFx(this.context));
 
 try {
   // get a list that doesn't exist
@@ -108,11 +114,13 @@ try {
 You may want to read the response and customize the message as described above:
 
 ```TypeScript
-import { Logger } from "@pnp/logging";
-import { sp } from "@pnp/sp";
+import { Logger, LogLevel } from "@pnp/logging";
+import { spfi, SPFx } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/lists/web";
 import { HttpRequestError } from "@pnp/queryable";
+
+const sp = spfi().using(SPFx(this.context));
 
 try {
   // get a list that doesn't exist

--- a/docs/concepts/selective-imports.md
+++ b/docs/concepts/selective-imports.md
@@ -60,7 +60,7 @@ import "@pnp/sp/webs";
 import { IList } from "@pnp/sp/lists";
 
 // do this instead
-import { sp } from "@pnp/sp";
+import { spfi } from "@pnp/sp";
 import "@pnp/sp/webs";
 import "@pnp/sp/lists";
 import { IList } from "@pnp/sp/lists";
@@ -68,7 +68,7 @@ import { IList } from "@pnp/sp/lists";
 // placeholder for fully configuring the sp interface
 const sp = spfi();
 
-const lists = await sp.web.lists();
+const lists: IList[] = await sp.web.lists();
 ```
 
 ## Presets

--- a/docs/contributing/setup-dev-machine.md
+++ b/docs/contributing/setup-dev-machine.md
@@ -10,16 +10,9 @@ These steps will help you get your environment setup for contributing to the cor
 
 1. Install [Node JS](https://nodejs.org/en/download/) - this provides two key capabilities; the first is the nodejs server which will act as our development server (think iisexpress), the second is npm a package manager (think nuget).
 
-    > This library requires node >= 10.18.0
+    > This library requires Node.js 18 or later.
 
 1. On Windows: Install [Python](https://www.python.org/downloads)
-
-1. [Optional] Install the tslint extension in VS Code:
-
-    1. Press Shift + Ctrl + "p" to open the command panel
-    2. Begin typing "install extension" and select the command when it appears in view
-    3. Begin typing "tslint" and select the package when it appears in view
-    4. Restart Code after installation
 
 ## Fork The Repo
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,23 @@ This library is geared towards folks working with TypeScript but will work equal
 
 If you need to support older browsers, SharePoint on premises servers, or older versions of the SharePoint Framework, please revert to [version 2](./v2/SPFx-on-premises/index.html) of the library and see related documentation on [polyfills](./v2/concepts/polyfill/index.html) for required functionality.
 
+## Quick Start (SPFx)
+
+```bash
+npm install @pnp/sp @pnp/graph --save
+```
+
+```typescript
+import { spfi, SPFx } from "@pnp/sp";
+import "@pnp/sp/webs";
+
+// In your webpart's onInit or component:
+const sp = spfi().using(SPFx(this.context));
+const webTitle = (await sp.web()).Title;
+```
+
+For more detailed setup options, continue reading below.
+
 ## Minimal Requirements
 
     - NodeJs: >= 18
@@ -18,20 +35,19 @@ First you will need to install those libraries you want to use in your applicati
 
 Next we can import and use the functionality within our application. Below is a very simple example, please see the individual package documentation for more details and examples.
 
-    ```ts
-    import { getRandomString } from "@pnp/core";
+```
+import { spfi, SPFx } from "@pnp/sp";
+import "@pnp/sp/webs";
 
-    (function() {
-
-        // get and log a random string
-        console.log(getRandomString(20));
-
-    })()
-    ```
+// Example: Get web title in SPFx
+const sp = spfi().using(SPFx(this.context));
+const web = await sp.web();
+console.log(web.Title);
+```
 
 ## Getting Started with SharePoint Framework
 
-### Quick References (v3 and v4 are the same for getting started)
+### Quick References (v3,v4,v5 are the same for getting started)
 
 - [Code Sample: SharePoint Framework 1.19.0 with PnPjs v4](https://github.com/pnp/pnpjs/tree/version-4/samples/spfx-react-components/README.md)
 - [Code Sample: SharePoint Framework 1.15.2 with PnPjs v3 utilizing ReactJS Hooks](https://github.com/pnp/sp-dev-fx-webparts/tree/main/samples/react-pnp-js-hooks)
@@ -74,29 +90,29 @@ Version 4 is not supported, you must use Version 3. In addition because as of SP
 1. Replace the contents of the gulpfile.js with:
     >Note: The only change is the addition of the line to disable tslint.
 
-        ```js
-        'use strict';
+```js
+'use strict';
 
-        const build = require('@microsoft/sp-build-web');
+const build = require('@microsoft/sp-build-web');
 
-        build.addSuppression(`Warning - [sass] The local CSS class 'ms-Grid' is not camelCase and will not be type-safe.`);
+build.addSuppression(`Warning - [sass] The local CSS class 'ms-Grid' is not camelCase and will not be type-safe.`);
 
-        var getTasks = build.rig.getTasks;
-        build.rig.getTasks = function () {
-            var result = getTasks.call(build.rig);
+var getTasks = build.rig.getTasks;
+build.rig.getTasks = function () {
+    var result = getTasks.call(build.rig);
 
-            result.set('serve', result.get('serve-deprecated'));
+    result.set('serve', result.get('serve-deprecated'));
 
-            return result;
-        };
+    return result;
+};
 
-        // ********* ADDED *******
-        // disable tslint
-        build.tslintCmd.enabled = false;
-        // ********* ADDED *******
+// ********* ADDED *******
+// disable tslint
+build.tslintCmd.enabled = false;
+// ********* ADDED *******
 
-        build.initialize(require('gulp'));
-        ```
+build.initialize(require('gulp'));
+```
 
 ### SPFx Version 1.11.0 & earlier
 
@@ -112,68 +128,72 @@ Depending on how you architect your solution establishing context is done where 
 
 ### Using @pnp/sp `spfi` factory interface in SPFx
 
-    ```TypeScript
-    import { spfi, SPFx } from "@pnp/sp";
+```TypeScript
+import { spfi, SPFx } from "@pnp/sp";
 
-    // ...
+// ...
 
-    protected async onInit(): Promise<void> {
+protected async onInit(): Promise<void> {
 
-        await super.onInit();
-        const sp = spfi().using(SPFx(this.context));
-        
-    }
+    await super.onInit();
+    const sp = spfi().using(SPFx(this.context));
+    
+}
 
-    // ...
+// ...
 
-    ```
+```
 
 ### Using @pnp/graph `graphfi` factory interface in SPFx
 
-    ```TypeScript
-    import { graphfi, SPFx } from "@pnp/graph";
+```TypeScript
+import { graphfi, SPFx } from "@pnp/graph";
 
-    // ...
+// ...
 
-    protected async onInit(): Promise<void> {
+protected async onInit(): Promise<void> {
 
-        await super.onInit();
-        const graph = graphfi().using(SPFx(this.context));
+    await super.onInit();
+    const graph = graphfi().using(SPFx(this.context));
 
-    }
+}
 
-    // ...
+// ...
 
-    ```
+```
 
 ### Using both @pnp/sp and @pnp/graph in SPFx
 
-    ```TypeScript
+```TypeScript
 
-    import { spfi, SPFx as spSPFx } from "@pnp/sp";
-    import { graphfi, SPFx as graphSPFx} from "@pnp/graph";
+import { spfi, SPFx as spSPFx } from "@pnp/sp";
+import { graphfi, SPFx as graphSPFx} from "@pnp/graph";
 
-    // ...
+// ...
 
-    protected async onInit(): Promise<void> {
+protected async onInit(): Promise<void> {
 
-        await super.onInit();
-        const sp = spfi().using(spSPFx(this.context));
-        const graph = graphfi().using(graphSPFx(this.context));
+    await super.onInit();
+    const sp = spfi().using(spSPFx(this.context));
+    const graph = graphfi().using(graphSPFx(this.context));
 
-    }
+}
 
-    // ...
+// ...
 
-    ```
+```
 
 ## Project Config/Services Setup
 
-Please see the [documentation](./concepts/project-preset.md) on setting up a config file or a services for more information about establishing and instance of the spfi or graphfi interfaces that can be reused. It is a common mistake with users of V3 that they try and create the interface in event handlers which causes issues.
+Please see the [documentation](./concepts/project-preset.md) on setting up a config file or a services for more information about establishing and instance of the spfi or graphfi interfaces that can be reused. It is a common mistake with users of V3+ that they try and create the interface in event handlers which causes issues.
 
 ## Getting started with NodeJS
 
-> Due to the way in which Node resolves ESM modules when you use selective imports in node you must include the `index.js` part of the path. Meaning an import like `import "@pnp/sp/webs"` in examples must be `import "@pnp/sp/webs/index.js"`. Root level imports such as `import { spfi } from "@pnp/sp"` remain correct. The samples in this section demonstrate this for their selective imports.
+> **Important:** In Node.js ESM projects, you must include `index.js` in selective import paths due to Node's module resolution rules. This applies to sub-module imports like `@pnp/sp/webs`, but **not** to root imports like `@pnp/sp`.
+>
+> ✅ Correct: `import "@pnp/sp/webs/index.js"`  
+> ❌ Incorrect: `import "@pnp/sp/webs"`  
+> ✅ Root imports work: `import { spfi } from "@pnp/sp"`
 
 ### Importing NodeJS support
 
@@ -230,91 +250,95 @@ We recommend switching the project to ESModules by making the following changes:
 
 To call the SharePoint APIs via MSAL you are required to use certificate authentication with your application. Fully covering certificates is outside the scope of these docs, but the following commands were used with openssl to create testing certs for the sample code below.
 
-    ```cmd
-    mkdir \temp
-    cd \temp
-    openssl req -x509 -newkey rsa:2048 -keyout keytmp.pem -out cert.pem -days 365 -passout pass:HereIsMySuperPass -subj '/C=US/ST=Washington/L=Seattle'
-    openssl rsa -in keytmp.pem -out key.pem -passin pass:HereIsMySuperPass
-    ```
+```cmd
+mkdir \temp
+cd \temp
+openssl req -x509 -newkey rsa:2048 -keyout keytmp.pem -out cert.pem -days 365 -passout pass:HereIsMySuperPass -subj '/C=US/ST=Washington/L=Seattle'
+openssl rsa -in keytmp.pem -out key.pem -passin pass:HereIsMySuperPass
+```
 
 > Using the above code you end up with three files, "cert.pem", "key.pem", and "keytmp.pem". The "cert.pem" file is uploaded to your AAD application registration. The "key.pem" is read as the private key for the configuration.
 
 ### Using @pnp/sp `spfi` factory interface in NodeJS
 
-> Version 3 of this library only supports ESModules. If you still require commonjs modules please check out [version 2](./v2/SPFx-on-premises/index.html).
+> Version 4+ of this library only supports ESModules. If you still require commonjs modules please check out [version 2](./v2/SPFx-on-premises/index.html).
 
 The first step is to install the packages that will be needed. You can read more about what each package does starting on the [packages](packages.md) page.
 
-    ```cmd
-    npm i @pnp/sp @pnp/nodejs
-    ```
+```cmd
+npm i @pnp/sp @pnp/nodejs
+```
 
 Once these are installed you need to import them into your project, to communicate with SharePoint from node we'll need the following imports:
 
-    ```TypeScript
+```TypeScript
+import { spfi } from "@pnp/sp";
+import { SPDefault } from "@pnp/nodejs";
+import "@pnp/sp/webs/index.js";
+import { readFileSync } from 'fs';
+import { Configuration } from "@azure/msal-node";
 
-    import { SPDefault } from "@pnp/nodejs";
-    import "@pnp/sp/webs/index.js";
-    import { readFileSync } from 'fs';
-    import { Configuration } from "@azure/msal-node";
+function main() {
+    // configure your node options (only once in your application)
+    const buffer = readFileSync("c:/temp/key.pem");
 
-    function() {
-        // configure your node options (only once in your application)
-        const buffer = readFileSync("c:/temp/key.pem");
-
-        const config: Configuration = {
-            auth: {
-                authority: "https://login.microsoftonline.com/{tenant id or common}/",
-                clientId: "{application (client) i}",
-                clientCertificate: {
-                thumbprint: "{certificate thumbprint, displayed in AAD}",
+    const config: Configuration = {
+        auth: {
+            authority: "https://login.microsoftonline.com/{tenant id or common}/",
+            clientId: "{application-client-id}",
+            clientCertificate: {
+                thumbprint: "{certificate-thumbprint}",
                 privateKey: buffer.toString(),
-                },
             },
-        };
+        },
+    };
 
-        const sp = spfi().using(SPDefault({
-            baseUrl: 'https://{my tenant}.sharepoint.com/sites/dev/',
-            msal: {
-                config: config,
-                scopes: [ 'https://{my tenant}.sharepoint.com/.default' ]
-            }
-        }));
+    const sp = spfi().using(SPDefault({
+        baseUrl: 'https://{tenant}.sharepoint.com/sites/dev/',
+        msal: {
+            config: config,
+            scopes: ['https://{tenant}.sharepoint.com/.default']
+        }
+    }));
 
-        // make a call to SharePoint and log it in the console
-        const w = await sp.web.select("Title", "Description")();
-        console.log(JSON.stringify(w, null, 4));
-    }();
-    ```
+    // make a call to SharePoint and log it in the console
+    const w = await sp.web.select("Title", "Description")();
+    console.log(JSON.stringify(w, null, 4));
+}
+
+main();
+```
 
 ### Using @pnp/graph `graphfi` factory interface in NodeJS
 
 Similar to the above you can also make calls to the Microsoft Graph API from node using the libraries. Again we start with installing the required resources. You can see [./debug/launch/graph.ts](https://github.com/pnp/pnpjs/blob/main/debug/launch/graph.ts) for a live example.
 
-    ```cmd
-    npm i @pnp/graph @pnp/nodejs
-    ```
+```cmd
+npm i @pnp/graph @pnp/nodejs
+```
 
 Now we need to import what we'll need to call graph
 
-    ```TypeScript
-    import { graphfi } from "@pnp/graph";
-    import { GraphDefault } from "@pnp/nodejs";
-    import "@pnp/graph/users/index.js";
+```TypeScript
+import { graphfi } from "@pnp/graph";
+import { GraphDefault } from "@pnp/nodejs";
+import "@pnp/graph/users/index.js";
 
-    function() {
-        const graph = graphfi().using(GraphDefault({
+function main() {
+    const graph = graphfi().using(GraphDefault({
         baseUrl: 'https://graph.microsoft.com',
         msal: {
             config: config,
-            scopes: [ 'https://graph.microsoft.com/.default' ]
+            scopes: ['https://graph.microsoft.com/.default']
         }
-        }));
-        // make a call to Graph and get all the groups
-        const userInfo = await graph.users.top(1)();
-        console.log(JSON.stringify(userInfo, null, 4));
-    }();
-    ```
+    }));
+    // make a call to Graph and get all the groups
+    const userInfo = await graph.users.top(1)();
+    console.log(JSON.stringify(userInfo, null, 4));
+}
+
+main();
+```
 
 ### Node project using TypeScript producing commonjs modules
 
@@ -328,49 +352,49 @@ The tsconfig file for your project should have the `"module": "CommonJS"` and `"
 
 #### tsconfig.json
 
-    ```JSON
-    {
-        "compilerOptions": {
-            "module": "CommonJS",
-            "moduleResolution": "node12"
-    }
-    ```
+```JSON
+{
+    "compilerOptions": {
+        "module": "CommonJS",
+        "moduleResolution": "node12"
+}
+```
 
 You must then import the esm dependencies using the async import pattern. This works as expected with our selective imports, and vscode will pick up the intellisense as expected.
 
 #### index.ts
 
-    ```TypeScript
-    import { settings } from "./settings.js";
+```TypeScript
+import { settings } from "./settings.js";
 
-    // this is a simple example as async await is not supported with commonjs output
-    // at the root.
-    setTimeout(async () => {
+// this is a simple example as async await is not supported with commonjs output
+// at the root.
+setTimeout(async () => {
 
-        const { spfi } = await import("@pnp/sp");
-        const { SPDefault } = await import("@pnp/nodejs");
-        await import("@pnp/sp/webs/index.js");
+    const { spfi } = await import("@pnp/sp");
+    const { SPDefault } = await import("@pnp/nodejs");
+    await import("@pnp/sp/webs/index.js");
 
-        const sp = spfi().using(SPDefault({
-            baseUrl: settings.testing.sp.url,
-            msal: {
-                config: settings.testing.sp.msal.init,
-                scopes: settings.testing.sp.msal.scopes
-            }
-        }));
-        
-        // make a call to SharePoint and log it in the console
-        const w = await sp.web.select("Title", "Description")();
-        console.log(JSON.stringify(w, null, 4));
+    const sp = spfi().using(SPDefault({
+        baseUrl: settings.testing.sp.url,
+        msal: {
+            config: settings.testing.sp.msal.init,
+            scopes: settings.testing.sp.msal.scopes
+        }
+    }));
+    
+    // make a call to SharePoint and log it in the console
+    const w = await sp.web.select("Title", "Description")();
+    console.log(JSON.stringify(w, null, 4));
 
-    }, 0);
-    ```
+}, 0);
+```
 
-Finally, when launching node you need to include the `` flag with a setting of 'node'.
+Finally, when launching node you need to include the `--experimental-specifier-resolution` flag set to `node`:
 
 `node --experimental-specifier-resolution=node dist/index.js`
 
-> Read more in the releated [TypeScript Issue](https://github.com/microsoft/TypeScript/issues/43329), [TS pull request Adding the functionality](https://github.com/microsoft/TypeScript/pull/45884), and the [TS Docs](https://www.typescriptlang.org/tsconfig#moduleResolution).
+> Read more in the related [TypeScript Issue](https://github.com/microsoft/TypeScript/issues/43329), [TS pull request Adding the functionality](https://github.com/microsoft/TypeScript/pull/45884), and the [TS Docs](https://www.typescriptlang.org/tsconfig#moduleResolution).
 
 ## Single Page Application Context
 
@@ -394,26 +418,26 @@ Because of the way the fluent library is designed by definition it's extendible.
 
 The new factory function allows you to create a connection to a different web maintaining the same setup as your existing interface. You have two options, either to  'AssignFrom' or 'CopyFrom' the base timeline's observers. The below example utilizes 'AssignFrom' but the method would be the same regadless of which route you choose. For more information on these behaviors see [Core/Behaviors](./core/behaviors.md).
 
-    ```TypeScript
-    import { spfi, SPFx } from "@pnp/sp";
-    import { AssignFrom } from "@pnp/core";
-    import "@pnp/sp/webs";
+```TypeScript
+import { spfi, SPFx } from "@pnp/sp";
+import { AssignFrom } from "@pnp/core";
+import "@pnp/sp/webs";
 
-    //Connection to the current context's Web
-    const sp = spfi(...);
+//Connection to the current context's Web
+const sp = spfi(...);
 
-    // Option 1: Create a new instance of Queryable
-    const spWebB = spfi({Other Web URL}).using(SPFx(this.context));
+// Option 1: Create a new instance of Queryable
+const spWebB = spfi({Other Web URL}).using(SPFx(this.context));
 
-    // Option 2: Copy/Assign a new instance of Queryable using the existing
-    const spWebB = spfi({Other Web URL}).using(AssignFrom(sp.web));
+// Option 2: Copy/Assign a new instance of Queryable using the existing
+const spWebB = spfi({Other Web URL}).using(AssignFrom(sp.web));
 
-    // Option 3: Create a new instance of Queryable using other credentials?
-    const spWebB = spfi({Other Web URL}).using(SPFx(this.context));
+// Option 3: Create a new instance of Queryable using other credentials?
+const spWebB = spfi({Other Web URL}).using(SPFx(this.context));
 
-    // Option 4: Create new Web instance by using copying SPQuerable and new pointing to new web url (e.g. https://contoso.sharepoint.com/sites/Web2)
-    const web = Web([sp.web, {Other Web URL}]);
-    ```
+// Option 4: Create new Web instance by using copying SPQuerable and new pointing to new web url (e.g. https://contoso.sharepoint.com/sites/Web2)
+const web = Web([sp.web, {Other Web URL}]);
+```
 
 ## Multi-Geo / Cross tenant calls in SharePoint Framework (SPFx)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,31 @@
 
 PnPjs is a collection of fluent libraries for consuming SharePoint, Graph, and Office 365 REST APIs in a type-safe way. You can use it within SharePoint Framework, Nodejs, or any JavaScript project. This an open source initiative and we encourage contributions and constructive feedback from the community.
 
+## What can you do with PnPjs?
+
+- Read and write SharePoint list items, documents, site data and more with simple, chainable syntax
+- Query Microsoft Graph for Organizational Microsoft 365 Data
+- Handle authentication automatically in SPFx, Node.js, or browser apps
+- Batch multiple requests together to improve performance
+- and more...
+
+**Quick Example: Get items from a SharePoint list**
+
+```typescript
+import { spfi, SPFx } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/lists";
+import "@pnp/sp/items";
+
+const sp = spfi().using(SPFx(this.context));
+const items = await sp.web.lists.getByTitle("My List").items();
+```
+
 These articles provide general guidance for working with the libraries. If you are migrating from V2 please review the [transition guide](transition-guide.md).
 
 * **[Getting Started](getting-started.md)**
 * [Authentication](concepts/authentication.md)
+* [Troubleshooting](troubleshooting.md)
 * [Get Started Contributing](contributing/index.md)
 
 ![Fluent API in action](img/PnPjsFluentAPI.gif)

--- a/docs/transition-guide.md
+++ b/docs/transition-guide.md
@@ -1,54 +1,15 @@
-# Transition Guide V3 -> V4
+# Upgrading from PnPjs v4 to v5
 
-    **For more information about migrating from an earlier version of PnPjs please see the transition guides below**
+This guide covers migrating your code from PnPjs version 4.x to version 5.x.
 
-    - [V2 -> V3 Transition Guide](https://pnp.github.io/pnpjs/v3/transition-guide/)
-    - [V1 -> V2 Transition Guide](https://pnp.github.io/pnpjs/v2/transition-guide/)
+> ⚠️ **Before upgrading:** Create a new branch and thoroughly test your application after upgrading. Breaking changes in this version may require code modifications.
 
-It is our hope that the transition from version 3.\* to 4.\* will be as painless as possible as the changes we have made are not as extensive as with version 3. Below are some highlights of the most disruptive changes that were made. For a full, detailed list of what's been added, updated, and removed please see our [CHANGELOG](https://github.com/pnp/pnpjs/blob/main/CHANGELOG.md)
+**For more information about migrating from an earlier version of PnPjs please see the transition guides below**
 
-## SharePoint Taxonomy has moved to @pnp/graph from @pnp/sp
+- [V3 -> V4 Transition Guide](https://pnp.github.io/pnpjs/v4/transition-guide/)
+- [V2 -> V3 Transition Guide](https://pnp.github.io/pnpjs/v3/transition-guide/)
+- [V1 -> V2 Transition Guide](https://pnp.github.io/pnpjs/v2/transition-guide/)
 
-To better support Taxonomy authentication and control we've moved our Taxonomy implementation from the @pnp/sp module to the @pnp/graph module. We were utilizing the v2.x endpoints to continue to support taxonomy in the SharePoint bundle and we decided that this was not the best approach. You will need to update your taxonomy implementations to use the graph endpoints.
+It is our hope that the transition from version 4.\* to 5.\* will be as painless as possible as the changes we have made are not as extensive as with previous versions. Below are some highlights of the most disruptive changes that were made. For a full, detailed list of what's been added, updated, and removed please see our [CHANGELOG](https://github.com/pnp/pnpjs/blob/main/CHANGELOG.md)
 
-## Add/Update methods no longer returning data and a queryable instance
-
-The primary breaking change will be with add and update method return values. We are going to return what the calling endpoint returns in all cases instead of an object that includes data property and an "item" property. This means anywhere that you are referencing the return objects `data` property you will need to remove that reference. Many of the graph endpoints return the added or updated object so, other than changing the reference this will not impact your code.
-
-SharePoint returns the object for add events but many update events return 204, which would translate into a return type of void. In that case you will have to adjust your code to make a second call if you want to validate that the item has been updated:
-
-Ex:
-
-    ```TypeScript
-    // Version 3 
-    const update = await sp.web.lists.getByTitle("My List").items.getById(1).update({Title: "My New Title"});
-    const newTitle = update.data.Title;
-
-    // Version 4
-    await sp.web.lists.getByTitle("My List").items.getById(1).update({Title: "My New Title"});
-    const updatedItem = await sp.web.lists.getByTitle("My List").items.getById(1)();
-    ```
-
-As stated before, when adding items in both graph and SharePoint the call will return the object that was created. So you can get the newly created objects `id` by simply referencing it directly:
-
-Ex:
-
-    ```TypeScript
-    // Version 3 
-    const newItem = await sp.web.lists.getByTitle("My List").items.add({Title: "My New Title"});
-    const newItemId = newItem.data.Id;
-
-    // Version 4
-    const newItem = await sp.web.lists.getByTitle("My List").items.add({Title: "My New Title"});
-    const newItemId = newItem.Id;
-    ```
-
-## Async Iterator Pattern
-
-As an updated pattern we are recommending you move to an async iterator pattern to get more than 5000 items from a list.
-
-With that in mind we've removed the `/items/get-all` endpoint. In addition we've updated the @pnp/sp package's `IItems` and `_Items` collections as well as the @pnp/graph `IGraphQueryableCollection` to support the async iterator pattern.
-
-Check out this example for more information on this pattern: [Get Paged Items](./sp/items.md#get-paged-items).
-
-For advanced async patterns: [Async Paging](./concepts/async-paging.md).
+## TODO for V5

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,162 @@
+# Troubleshooting
+
+This guide covers common issues you may encounter when using PnPjs and how to resolve them.
+
+## Authentication Errors
+
+### 401 Unauthorized
+
+**Symptoms:** Requests fail with a 401 status code.
+
+**Common Causes:**
+- Missing or expired access token
+- Incorrect API permissions in Azure AD app registration
+- Using the wrong authentication method for your environment
+
+**Solutions:**
+1. Verify your Azure AD app registration has the correct API permissions (and admin consent if required)
+2. Check that your token scopes match the API you're calling:
+   - SharePoint: `https://{tenant}.sharepoint.com/.default`
+   - Graph: `https://graph.microsoft.com/.default`
+3. In SPFx, ensure you're passing `this.context` to the `SPFx` behavior
+
+### 403 Forbidden
+
+**Symptoms:** Requests fail with a 403 status code.
+
+**Common Causes:**
+- User lacks permissions to the resource
+- App-only permissions not configured correctly
+- Attempting to access a resource that requires elevated permissions
+
+**Solutions:**
+1. Verify the user/app has appropriate permissions on the SharePoint site or resource
+2. For app-only access, ensure the Azure AD app has the correct application permissions (not just delegated)
+3. Check if the site has unique permissions that might block access
+
+## Module/Import Errors
+
+### "Module not found" in Node.js
+
+**Symptoms:** Error like `Cannot find module '@pnp/sp/webs'`
+
+**Cause:** Node.js ESM resolution requires the full path including `index.js` for sub-module imports.
+
+**Solution:** Add `index.js` to your selective imports:
+
+```typescript
+// ❌ Incorrect
+import "@pnp/sp/webs";
+
+// ✅ Correct for Node.js
+import "@pnp/sp/webs/index.js";
+```
+
+> Note: Root imports like `import { spfi } from "@pnp/sp"` work without modification.
+
+### TypeScript Type Errors with Selective Imports
+
+**Symptoms:** TypeScript shows errors for missing properties on `sp.web` or similar.
+
+**Cause:** Selective imports only add functionality when the module is imported.
+
+**Solution:** Import both the module and its types:
+
+```typescript
+import { spfi } from "@pnp/sp";
+import "@pnp/sp/webs";
+import "@pnp/sp/lists";
+import { IList } from "@pnp/sp/lists";
+```
+
+## CORS Errors
+
+### CORS Error in Browser Applications
+
+**Symptoms:** Browser console shows "Access-Control-Allow-Origin" errors.
+
+**Common Causes:**
+- Running a standalone SPA trying to call SharePoint directly
+- Missing or incorrect CORS configuration
+
+**Solutions:**
+1. **For SPFx:** Use the `SPFx` behavior which handles authentication via the framework
+2. **For standalone SPAs:** Use `@pnp/msaljsclient` with proper Azure AD app registration configured for SPA redirect URIs
+3. **For local development:** Consider using a proxy or the SharePoint workbench
+
+## Common Runtime Errors
+
+### "sp.web is not a function" or "Cannot read property 'web' of undefined"
+
+**Cause:** The `spfi()` factory wasn't configured with behaviors, or selective imports are missing.
+
+**Solution:**
+
+```typescript
+import { spfi, SPFx } from "@pnp/sp";
+import "@pnp/sp/webs"; // Don't forget this!
+
+// Must configure with behaviors
+const sp = spfi().using(SPFx(this.context));
+
+// Now sp.web will work
+const web = await sp.web();
+```
+
+### "Cannot call spfi() multiple times" or stale context issues
+
+**Cause:** Creating new `spfi()` instances in event handlers or render methods.
+
+**Solution:** Initialize once in `onInit` or use a [project config file](./concepts/project-preset.md):
+
+```typescript
+// ❌ Wrong - creates new instance on every click
+async onClick() {
+    const sp = spfi().using(SPFx(this.context));
+    const items = await sp.web.lists.getByTitle("Tasks").items();
+}
+
+// ✅ Correct - initialize once, reuse
+private sp: SPFI;
+
+onInit() {
+    this.sp = spfi().using(SPFx(this.context));
+}
+
+async onClick() {
+    const items = await this.sp.web.lists.getByTitle("Tasks").items();
+}
+```
+
+## Batching Issues
+
+### Batch requests failing or returning unexpected results
+
+**Cause:** Mixing `await` with batched calls stops execution before the batch executes.
+
+**Solution:** Use `.then()` syntax for batched calls:
+
+```typescript
+const [batchedSP, execute] = sp.batched();
+
+// ❌ Wrong - this will hang
+const web = await batchedSP.web();
+
+// ✅ Correct - use .then()
+let webResult;
+batchedSP.web().then(r => webResult = r);
+
+await execute();
+console.log(webResult);
+```
+
+## Getting Help
+
+If you're still stuck:
+
+1. Search [existing issues](https://github.com/pnp/pnpjs/issues) on GitHub
+2. Open a [new issue](https://github.com/pnp/pnpjs/issues/new) with:
+   - PnPjs version
+   - Environment (SPFx version, Node.js version, browser)
+   - Minimal code to reproduce the issue
+   - Full error message and stack trace


### PR DESCRIPTION
**Started updates for V5 Docs.**
**Used Claude to analyze our existing docs for any issues and improvements.**
Found various errors to old patterns, helped with improved verbiage and clarity.

### Category
- [X] Documentation update?

### What's in this Pull Request?
Fixed grammar
Fixed Typos
Clarified SPFx version compatibility messaging
Fixed first code example to use @pnp/sp instead of @pnp/core
Improved Node.js ESM import explanation with clear examples
Fixed incomplete Node.js code samples (added missing imports, proper async patterns)
Fixed missing --experimental-specifier-resolution flag text
Improved title, added upgrade warning
Fixed outdated v2/v3 import pattern (import { sp } → spfi())
Updated examples to use spfi() pattern
Fixed inconsistent filename reference (pnpjs-presets.ts → pnpjs-config.ts)
Updated Node requirement (10.18.0 → 18), removed deprecated TSLint reference
Added "What can you do with PnPjs?" section with practical examples
troubleshooting.md: Created new troubleshooting guide for common issues