### PR TITLE
feat(sp): add ThemeManager support for tenant theming REST API

### DIFF
--- a/docs/sp/thememanager.md
+++ b/docs/sp/thememanager.md
@@ -1,0 +1,191 @@
+# @pnp/sp/thememanager
+
+The ThemeManager API allows you to manage tenant themes in SharePoint Online. You can add, update, delete, and apply custom themes to your SharePoint sites.
+Check out [SharePoint site theming: REST API](https://learn.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-theming/sharepoint-site-theming-rest-api) for more information.
+
+## Theme Manager
+
+[![Selective Imports Banner](https://img.shields.io/badge/Selective%20Imports-informational.svg)](../concepts/selective-imports.md)
+
+## Get tenant theming options
+
+Retrieves the current tenant theming configuration, including the list of available custom themes.
+
+```TypeScript
+import { spfi } from "@pnp/sp";
+import "@pnp/sp/thememanager";
+
+const sp = spfi(...);
+
+const options = await sp.themeManager.getTenantThemingOptions();
+
+console.log(`Hide default themes: ${options.hideDefaultThemes}`);
+console.log(`Custom themes: ${options.themePreviews.length}`);
+```
+
+## Add a new tenant theme
+
+Creates a new custom theme available across the tenant.
+
+```TypeScript
+import { spfi } from "@pnp/sp";
+import "@pnp/sp/thememanager";
+
+const sp = spfi(...);
+
+// Using hex color strings (simple format)
+const result = await sp.themeManager.addTenantTheme("My Custom Theme", {
+    palette: {
+        themePrimary: "#0078d4",
+        themeLighterAlt: "#eff6fc",
+        themeLighter: "#deecf9",
+        themeLight: "#c7e0f4",
+        themeTertiary: "#71afe5",
+        themeSecondary: "#2b88d8",
+        themeDarkAlt: "#106ebe",
+        themeDark: "#005a9e",
+        themeDarker: "#004578",
+        neutralLighterAlt: "#faf9f8",
+        neutralLighter: "#f3f2f1",
+        neutralLight: "#edebe9",
+        neutralQuaternaryAlt: "#e1dfdd",
+        neutralQuaternary: "#d0d0d0",
+        neutralTertiaryAlt: "#c8c6c4",
+        neutralTertiary: "#a19f9d",
+        neutralSecondary: "#605e5c",
+        neutralPrimaryAlt: "#3b3a39",
+        neutralPrimary: "#323130",
+        neutralDark: "#201f1e",
+        black: "#000000",
+        white: "#ffffff",
+    }
+});
+
+console.log(`Theme added: ${result}`);
+```
+
+## Update an existing tenant theme
+
+Updates the palette of an existing custom theme.
+
+```TypeScript
+import { spfi } from "@pnp/sp";
+import "@pnp/sp/thememanager";
+
+const sp = spfi(...);
+
+const result = await sp.themeManager.updateTenantTheme("My Custom Theme", {
+    palette: {
+        themePrimary: "#107c10",  // Changed to green
+        themeLighterAlt: "#f0fff0",
+        // ... rest of palette colors
+    }
+});
+
+console.log(`Theme updated: ${result}`);
+```
+
+## Delete a tenant theme
+
+Removes a custom theme from the tenant.
+
+```TypeScript
+import { spfi } from "@pnp/sp";
+import "@pnp/sp/thememanager";
+
+const sp = spfi(...);
+
+await sp.themeManager.deleteTenantTheme("My Custom Theme");
+```
+
+## Apply a theme to the current web
+
+Applies a theme to the site where the request is made.
+
+```TypeScript
+import { spfi } from "@pnp/sp";
+import "@pnp/sp/thememanager";
+
+const sp = spfi(...);
+
+await sp.themeManager.applyTheme("My Custom Theme", {
+    palette: {
+        themePrimary: "#0078d4",
+        themeLighterAlt: "#eff6fc",
+        themeLighter: "#deecf9",
+        themeLight: "#c7e0f4",
+        themeTertiary: "#71afe5",
+        themeSecondary: "#2b88d8",
+        themeDarkAlt: "#106ebe",
+        themeDark: "#005a9e",
+        themeDarker: "#004578",
+        neutralLighterAlt: "#faf9f8",
+        neutralLighter: "#f3f2f1",
+        neutralLight: "#edebe9",
+        neutralQuaternaryAlt: "#e1dfdd",
+        neutralQuaternary: "#d0d0d0",
+        neutralTertiaryAlt: "#c8c6c4",
+        neutralTertiary: "#a19f9d",
+        neutralSecondary: "#605e5c",
+        neutralPrimaryAlt: "#3b3a39",
+        neutralPrimary: "#323130",
+        neutralDark: "#201f1e",
+        black: "#000000",
+        white: "#ffffff",
+    }
+});
+```
+
+## Using RGBA color format
+
+SharePoint also supports colors in RGBA object format for full fidelity with advanced theme properties.
+
+```TypeScript
+import { spfi } from "@pnp/sp";
+import "@pnp/sp/thememanager";
+import { IRGBAColor } from "@pnp/sp/thememanager";
+
+const sp = spfi(...);
+
+// Using RGBA color objects
+await sp.themeManager.addTenantTheme("Dark Theme", {
+    palette: {
+        themePrimary: { R: 82, G: 159, B: 241, A: 255 },
+        themeLighterAlt: { R: 3, G: 6, B: 10, A: 255 },
+        // ... other colors in RGBA format
+    },
+    isInverted: true,
+    displayMode: "dark"
+});
+```
+
+## Theme Palette Properties
+
+The theme palette supports the following color slots:
+
+| Property | Description |
+|----------|-------------|
+| themePrimary | Primary theme color |
+| themeLighterAlt | Lightest shade of the theme color |
+| themeLighter | Lighter shade of the theme color |
+| themeLight | Light shade of the theme color |
+| themeTertiary | Tertiary theme color |
+| themeSecondary | Secondary theme color |
+| themeDarkAlt | Darker alternate theme color |
+| themeDark | Dark theme color |
+| themeDarker | Darkest theme color |
+| neutralLighterAlt | Lightest neutral color |
+| neutralLighter | Lighter neutral color |
+| neutralLight | Light neutral color |
+| neutralQuaternaryAlt | Quaternary alternate neutral |
+| neutralQuaternary | Quaternary neutral |
+| neutralTertiaryAlt | Tertiary alternate neutral |
+| neutralTertiary | Tertiary neutral color |
+| neutralSecondary | Secondary neutral color |
+| neutralPrimaryAlt | Primary alternate neutral |
+| neutralPrimary | Primary neutral color |
+| neutralDark | Dark neutral color |
+| black | Black color |
+| white | White/background color |
+
+For generating theme palettes, use the [Fluent UI Theme Designer](https://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/theming-designer/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
       - 'SP.Utilities.Utility': 'sp/sp-utilities-utility.md'
       - Subscriptions: 'sp/subscriptions.md'
       - 'Tenant Properties': 'sp/tenant-properties.md'
+      - 'Theme Manager': 'sp/thememanager.md'
       - 'User custom actions': 'sp/user-custom-actions.md'      
       - 'Utils': 'sp/utils.md'
       - Views: 'sp/views.md'

--- a/packages/sp/thememanager/index.ts
+++ b/packages/sp/thememanager/index.ts
@@ -1,0 +1,28 @@
+import { SPFI } from "../fi.js";
+import { IThemeManager, ThemeManager } from "./types.js";
+
+export {
+    IThemeManager,
+    ThemeManager,
+    IRGBAColor,
+    ThemeColor,
+    IThemePalette,
+    IThemeColorPair,
+    IThemeJson,
+    IThemeInfo,
+    ITenantThemingOptions,
+} from "./types.js";
+
+declare module "../fi" {
+    interface SPFI {
+        readonly themeManager: IThemeManager;
+    }
+}
+
+Reflect.defineProperty(SPFI.prototype, "themeManager", {
+    configurable: true,
+    enumerable: true,
+    get: function (this: SPFI) {
+        return this.create(ThemeManager);
+    },
+});

--- a/packages/sp/thememanager/types.ts
+++ b/packages/sp/thememanager/types.ts
@@ -1,0 +1,213 @@
+import { ISPQueryable, _SPQueryable, spPost } from "../spqueryable.js";
+import { extractWebUrl } from "../utils/extract-web-url.js";
+import { headers, body } from "@pnp/queryable";
+import { combine } from "@pnp/core";
+
+export class _ThemeManager extends _SPQueryable {
+
+    constructor(base: string | ISPQueryable, methodName = "") {
+        super(base);
+        this._url = combine(extractWebUrl(this._url), `_api/thememanager/${methodName}`);
+    }
+
+    public run<T>(props: any): Promise<T> {
+        return spPost<T>(this, body(props, headers({ "Content-Type": "application/json;charset=utf-8" })));
+    }
+
+    /**
+     * Gets the current tenant theming options including available themes
+     *
+     * @returns Tenant theming options
+     */
+    public getTenantThemingOptions(): Promise<ITenantThemingOptions> {
+        return ThemeManagerCloneFactory(this, "GetTenantThemingOptions").run<ITenantThemingOptions>({});
+    }
+
+    /**
+     * Adds a new tenant theme
+     *
+     * @param name The name of the theme
+     * @param themeJson The theme definition as a JSON object containing the palette
+     * @returns True if the theme was added successfully
+     */
+    public addTenantTheme(name: string, themeJson: IThemeJson | string): Promise<boolean> {
+        const themeJsonString = typeof themeJson === "string" ? themeJson : JSON.stringify(themeJson);
+        return ThemeManagerCloneFactory(this, "AddTenantTheme").run<boolean>({ name, themeJson: themeJsonString });
+    }
+
+    /**
+     * Deletes a tenant theme by name
+     *
+     * @param name The name of the theme to delete
+     */
+    public deleteTenantTheme(name: string): Promise<void> {
+        return ThemeManagerCloneFactory(this, "DeleteTenantTheme").run<void>({ name });
+    }
+
+    /**
+     * Updates an existing tenant theme
+     *
+     * @param name The name of the theme to update
+     * @param themeJson The updated theme definition as a JSON object containing the palette
+     * @returns True if the theme was updated successfully
+     */
+    public updateTenantTheme(name: string, themeJson: IThemeJson | string): Promise<boolean> {
+        const themeJsonString = typeof themeJson === "string" ? themeJson : JSON.stringify(themeJson);
+        return ThemeManagerCloneFactory(this, "UpdateTenantTheme").run<boolean>({ name, themeJson: themeJsonString });
+    }
+
+    /**
+     * Applies a theme to the current web
+     *
+     * @param name The name of the theme
+     * @param themeJson The theme definition as a JSON object containing the palette
+     */
+    public applyTheme(name: string, themeJson: IThemeJson | string): Promise<void> {
+        const themeJsonString = typeof themeJson === "string" ? themeJson : JSON.stringify(themeJson);
+        return ThemeManagerCloneFactory(this, "ApplyTheme").run<void>({ name, themeJson: themeJsonString });
+    }
+}
+export interface IThemeManager extends _ThemeManager { }
+export const ThemeManager = (base: ISPQueryable | string, methodName?: string): IThemeManager => new _ThemeManager(base, methodName);
+
+type ThemeManagerCloneType = IThemeManager & ISPQueryable & { run<T>(props: any): Promise<T> };
+const ThemeManagerCloneFactory = (baseUrl: string | ISPQueryable, methodName = ""): ThemeManagerCloneType => <any>ThemeManager(baseUrl, methodName);
+
+/**
+ * RGBA color format used by SharePoint theming
+ */
+export interface IRGBAColor {
+    R: number;
+    G: number;
+    B: number;
+    A: number;
+}
+
+/**
+ * Theme color - can be hex string (e.g. "#0078d4") or RGBA object
+ */
+export type ThemeColor = string | IRGBAColor;
+
+/**
+ * Theme palette containing all color slots
+ */
+export interface IThemePalette {
+    themePrimary: ThemeColor;
+    themeLighterAlt: ThemeColor;
+    themeLighter: ThemeColor;
+    themeLight: ThemeColor;
+    themeTertiary: ThemeColor;
+    themeSecondary: ThemeColor;
+    themeDarkAlt: ThemeColor;
+    themeDark: ThemeColor;
+    themeDarker: ThemeColor;
+    neutralLighterAlt: ThemeColor;
+    neutralLighter: ThemeColor;
+    neutralLight: ThemeColor;
+    neutralQuaternaryAlt: ThemeColor;
+    neutralQuaternary: ThemeColor;
+    neutralTertiaryAlt: ThemeColor;
+    neutralTertiary: ThemeColor;
+    neutralSecondaryAlt?: ThemeColor;
+    neutralSecondary: ThemeColor;
+    neutralPrimaryAlt: ThemeColor;
+    neutralPrimary: ThemeColor;
+    neutralDark: ThemeColor;
+    black: ThemeColor;
+    white: ThemeColor;
+    primaryBackground?: ThemeColor;
+    primaryText?: ThemeColor;
+    backgroundColor?: ThemeColor;
+    error?: ThemeColor;
+    disabledBackground?: ThemeColor;
+    disabledText?: ThemeColor;
+}
+
+/**
+ * Color pair used in secondary colors configuration
+ */
+export interface IThemeColorPair {
+    themePrimary: IRGBAColor;
+    backgroundColor: IRGBAColor;
+}
+
+/**
+ * Theme JSON structure for the themeJson parameter
+ */
+export interface IThemeJson {
+    /**
+     * The palette containing all theme colors
+     */
+    palette: IThemePalette;
+    /**
+     * Optional background image URI
+     */
+    backgroundImageUri?: string;
+    /**
+     * Cache token for the theme
+     */
+    cacheToken?: string;
+    /**
+     * Whether this is the default theme
+     */
+    isDefault?: boolean;
+    /**
+     * Whether the theme is inverted (dark theme)
+     */
+    isInverted?: boolean;
+    /**
+     * Theme version
+     */
+    version?: string;
+    /**
+     * Display mode - "light" or "dark"
+     */
+    displayMode?: "light" | "dark";
+    /**
+     * Secondary color configurations for light and dark modes
+     */
+    secondaryColors?: {
+        light: IThemeColorPair[];
+        dark: IThemeColorPair[];
+    };
+    /**
+     * Alternate mode palette configuration
+     */
+    otherMode?: {
+        palette: IThemePalette;
+        isInverted: boolean;
+        displayMode: string;
+    };
+    /**
+     * Theme schema version
+     */
+    themeSchemaVersion?: string;
+}
+
+/**
+ * Theme information returned from GetTenantThemingOptions
+ */
+export interface IThemeInfo {
+    /**
+     * The name of the theme
+     */
+    name: string;
+    /**
+     * The theme JSON definition
+     */
+    themeJson: string;
+}
+
+/**
+ * Tenant theming options returned from GetTenantThemingOptions
+ */
+export interface ITenantThemingOptions {
+    /**
+     * Whether default themes are hidden
+     */
+    hideDefaultThemes: boolean;
+    /**
+     * List of custom themes available in the tenant
+     */
+    themePreviews: IThemeInfo[];
+}

--- a/test/sp/thememanager.ts
+++ b/test/sp/thememanager.ts
@@ -1,0 +1,101 @@
+import { expect } from "chai";
+import { getRandomString } from "@pnp/core";
+import "@pnp/sp/webs";
+import "@pnp/sp/thememanager";
+import { IThemePalette } from "@pnp/sp/thememanager";
+import { pnpTest } from "../pnp-test.js";
+
+describe("ThemeManager", function () {
+
+    const createdThemeNames: string[] = [];
+
+    // Sample theme palette for testing (hex string format)
+    const testPalette: IThemePalette = {
+        themePrimary: "#0078d4",
+        themeLighterAlt: "#eff6fc",
+        themeLighter: "#deecf9",
+        themeLight: "#c7e0f4",
+        themeTertiary: "#71afe5",
+        themeSecondary: "#2b88d8",
+        themeDarkAlt: "#106ebe",
+        themeDark: "#005a9e",
+        themeDarker: "#004578",
+        neutralLighterAlt: "#faf9f8",
+        neutralLighter: "#f3f2f1",
+        neutralLight: "#edebe9",
+        neutralQuaternaryAlt: "#e1dfdd",
+        neutralQuaternary: "#d0d0d0",
+        neutralTertiaryAlt: "#c8c6c4",
+        neutralTertiary: "#a19f9d",
+        neutralSecondary: "#605e5c",
+        neutralPrimaryAlt: "#3b3a39",
+        neutralPrimary: "#323130",
+        neutralDark: "#201f1e",
+        black: "#000000",
+        white: "#ffffff",
+    };
+
+    after(async function () {
+        // Clean up created themes
+        for (const themeName of createdThemeNames) {
+            try {
+                await this.pnp.sp.themeManager.deleteTenantTheme(themeName);
+            } catch (e) {
+                // Ignore errors during cleanup
+            }
+        }
+    });
+
+    it("getTenantThemingOptions", pnpTest("f8a1b2c3-d4e5-6789-abcd-ef0123456789", async function () {
+        const options = await this.pnp.sp.themeManager.getTenantThemingOptions();
+        return expect(options).to.have.property("themePreviews");
+    }));
+
+    it("addTenantTheme", pnpTest("a1b2c3d4-e5f6-7890-abcd-ef1234567890", async function () {
+        const { themeName } = await this.props({
+            themeName: `TestTheme_${getRandomString(8)}`,
+        });
+
+        const result = await this.pnp.sp.themeManager.addTenantTheme(themeName, { palette: testPalette });
+        createdThemeNames.push(themeName);
+
+        return expect(result).to.be.true;
+    }));
+
+    it("updateTenantTheme", pnpTest("b2c3d4e5-f6a7-8901-bcde-f23456789012", async function () {
+        const { themeName } = await this.props({
+            themeName: `TestTheme_Update_${getRandomString(8)}`,
+        });
+
+        // First create a theme
+        await this.pnp.sp.themeManager.addTenantTheme(themeName, { palette: testPalette });
+        createdThemeNames.push(themeName);
+
+        // Then update it with a modified palette
+        const updatedPalette = { ...testPalette, themePrimary: "#107c10" };
+        const result = await this.pnp.sp.themeManager.updateTenantTheme(themeName, { palette: updatedPalette });
+
+        return expect(result).to.be.true;
+    }));
+
+    it("deleteTenantTheme", pnpTest("c3d4e5f6-a7b8-9012-cdef-345678901234", async function () {
+        const { themeName } = await this.props({
+            themeName: `TestTheme_Delete_${getRandomString(8)}`,
+        });
+
+        // Create a theme to delete
+        await this.pnp.sp.themeManager.addTenantTheme(themeName, { palette: testPalette });
+
+        // Delete it
+        return expect(this.pnp.sp.themeManager.deleteTenantTheme(themeName)).to.eventually.be.fulfilled;
+    }));
+
+    it("applyTheme", pnpTest("d4e5f6a7-b8c9-0123-defa-456789012345", async function () {
+        const { themeName } = await this.props({
+            themeName: `TestTheme_Apply_${getRandomString(8)}`,
+        });
+
+        // Apply a theme to the current web
+        return expect(this.pnp.sp.themeManager.applyTheme(themeName, { palette: testPalette })).to.eventually.be.fulfilled;
+    }));
+});


### PR DESCRIPTION
- Add ThemeManager class with methods: getTenantThemingOptions, addTenantTheme, updateTenantTheme, deleteTenantTheme, applyTheme
- Support both hex string and RGBA color formats
- Add unit tests
- Add documentation

### Category

- [ ] Bug fix?
- [x] New feature?
- [ ] New sample?
- [ ] Documentation update?