### PR TITLE
Fixing Graph Channels return types

### DIFF
--- a/packages/graph/teams/types.ts
+++ b/packages/graph/teams/types.ts
@@ -8,6 +8,7 @@ import {
     TeamsTab as ITeamsTabType,
     TeamsAppInstallation as ITeamsAppInstallation,
     ChatMessage as IChatMessage,
+    Channel as IChannelType,
 } from "@microsoft/microsoft-graph-types";
 
 /**
@@ -129,7 +130,7 @@ export const Teams = graphInvokableFactory<ITeams>(_Teams);
 /**
  * Channel
  */
-export class _Channel extends _GraphInstance<IChannel> {
+export class _Channel extends _GraphInstance<IChannelType> {
     public get tabs(): ITabs {
         return Tabs(this);
     }
@@ -146,7 +147,7 @@ export const Channel = graphInvokableFactory<IChannel>(_Channel);
  */
 @defaultPath("channels")
 @getById(Channel)
-export class _Channels extends _GraphCollection<IChannel[]> {
+export class _Channels extends _GraphCollection<IChannelType[]> {
 
     /**
      * Creates a new Channel in the Team


### PR DESCRIPTION
Channels and Channel classes had improper definitions for return types.

### Category

- [X] Bug fix?

### Related Issues

fixes #3327 

### What's in this Pull Request?

Fix to return types for Channels and Channel classes to return the Graph Type, not the PnPjs Queryable class.
