### PR TITLE
Updating Item Comments Add typings

### DIFF
--- a/docs/sp/comments-likes.md
+++ b/docs/sp/comments-likes.md
@@ -160,6 +160,29 @@ const sp = spfi(...);
 // you can add a comment as a string
 const comment = await item.comments.add("string comment");
 
+```
+### Add Comment with Mentions
+You can tag one or more users by supplying them in the mentions array and referencing each user in the comment text using the @mention{n} placeholder, where n is the zero-based index of the corresponding entry in the mentions array. For example, @mention{0} references the first user, while @mention{0} and @mention{1} reference the first and second users, respectively. The placeholder order must match the order of the entries in the mentions array.
+
+When comments are retrieved, the text value is returned HTML-encoded. For example, @mention{0} in the `text` is returned as @mention&#123;0&#125;.
+
+```TypeScript
+import { spfi } from "@pnp/sp";
+import { ICommentInfo } from "@pnp/sp/comments";
+
+const sp = spfi(...);
+
+// you can add a comment as a string and mention specific users
+const comment = await item.comments.add({
+    text: "This is a comment added from PnPjs. @mention{0}",
+    mentions: [
+        {
+            email: "pnpjs@tenant.onmicrosoft.com",
+            loginName:"i:0#.f|membership|pnpjs@tenant.onmicrosoft.com",
+            name:"PnPjs Developer"
+        }
+    ]
+});
 
 ```
 

--- a/packages/sp/comments/types.ts
+++ b/packages/sp/comments/types.ts
@@ -17,7 +17,7 @@ export class _Comments extends _SPCollection<ICommentInfo[]> {
      *
      * @param info Comment information to add
      */
-    public async add(info: string | ICommentInfo): Promise<IComment & ICommentInfo> {
+    public async add(info: string | Partial<ICommentInfo>): Promise<IComment & ICommentInfo> {
 
         if (typeof info === "string") {
             info = <ICommentInfo>{ text: info };
@@ -129,11 +129,11 @@ export interface ICommentInfo {
     itemId: number;
     likeCount: number;
     listId: string;
-    mentions: [{
+    mentions?: {
         loginName: string;
         email: string;
         name: string;
-    }] | null;
+    }[] | null;
     parentId: string;
     replyCount: number;
     text: string;


### PR DESCRIPTION
### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [X] Documentation update?

### Related Issues

fixes #3353 

### What's in this Pull Request?
This updates the types on Item Comments `add` method. This method should take a `Partial<ICommentInfo>`. In addition, I did make a change to the `mentions` where it was wrongly typed and wasn't allowing nullable. The API can return a null mentions when mentions aren't being used.

### Guidance
Please test adding comments and using atMentions.
