### PR TITLE
fix: ValidateUpdateListItem & AddValidateUpdateItemUsingPath Params

### DIFF
--- a/docs/sp/lists.md
+++ b/docs/sp/lists.md
@@ -384,7 +384,7 @@ const listItemId = await list.reserveListItemId();
 console.log(listItemId);
 ```
 
-### Add a list item using path (folder), validation and set field values
+### Add a item using path (folder), validation and set field values
 
 ```TypeScript
 import { spfi } from "@pnp/sp";
@@ -393,15 +393,22 @@ import "@pnp/sp/lists";
 
 const sp = spfi(...);
 
-const list = await sp.webs.lists.getByTitle("MyList").select("Title", "ParentWebUrl")();
+const list = await sp.web.lists.getByTitle("MyList").select("Title", "ParentWebUrl")();
 const formValues: IListItemFormUpdateValue[] = [
-                {
-                    FieldName: "Title",
-                    FieldValue: title,
-                },
-            ];
+    {
+        FieldName: "Title",
+        FieldValue: "Updated from PnPjs",
+    },
+];
 
-list.addValidateUpdateItemUsingPath(formValues,`${list.ParentWebUrl}/Lists/${list.Title}/MyFolder`)
+const decodedUrl = `${list.ParentWebUrl}/Lists/${list.Title}/MyFolder`;
+
+await sp.web.lists.getByTitle("Documents").addValidateUpdateItemUsingPath({
+        formValues,
+        decodedUrl,
+        leafName: "TestFolder",
+        underlyingObjectType: 1,
+    });
 
 ```
 

--- a/packages/sp/items/types.ts
+++ b/packages/sp/items/types.ts
@@ -229,11 +229,17 @@ export class _Item extends _SPInstance {
     /**
      * Validates and sets the values of the specified collection of fields for the list item.
      *
-     * @param formValues The fields to change and their new values.
-     * @param bNewDocumentUpdate true if the list item is a document being updated after upload; otherwise false.
+     * @param props The properties to validate and set on the list item. `bNewDocumentUpdate` defaults to false.
      */
-    public validateUpdateListItem(formValues: IListItemFormUpdateValue[], bNewDocumentUpdate = false): Promise<IListItemFormUpdateValue[]> {
-        return spPost(Item(this, "validateupdatelistitem"), body({ formValues, bNewDocumentUpdate }));
+    public validateUpdateListItem(props: IValidateUpdateListItem & { sharedLockId?: string }): Promise<IListItemFormUpdateValue[]> {
+        const postBody = {
+            bNewDocumentUpdate: false,
+            ...props,
+        };
+        return spPost(
+            Item(this, "validateupdatelistitem"),
+            body(postBody),
+        );
     }
 
     /**
@@ -303,10 +309,12 @@ export class _Item extends _SPInstance {
             "id": result.UniqueId,
         };
 
-        return this.validateUpdateListItem([{
-            FieldName: fieldName,
-            FieldValue: JSON.stringify(itemInfo),
-        }]);
+        return this.validateUpdateListItem({
+            formValues: [{
+                FieldName: fieldName,
+                FieldValue: JSON.stringify(itemInfo),
+            }],
+        });
     }
 
 }
@@ -351,6 +359,14 @@ function ItemUpdatedParser() {
     return parseBinderWithErrorCheck(async (r) => (<IItemUpdateResultData>{
         etag: r.headers.get("etag"),
     }));
+}
+
+export interface IValidateUpdateListItem {
+    formValues: IListItemFormUpdateValue[];
+    bNewDocumentUpdate?: boolean;
+    checkInComment?: string;
+    datesInUTC?: boolean;
+    numberInInvariantCulture?: boolean;
 }
 
 export interface IItemUpdateResultData {

--- a/packages/sp/lists/types.ts
+++ b/packages/sp/lists/types.ts
@@ -24,16 +24,7 @@ import { IViewInfo } from "../views/types.js";
 import { IUserCustomActionInfo } from "../user-custom-actions/types.js";
 import { IResourcePath, toResourcePath } from "../utils/to-resource-path.js";
 import { encodePath } from "../utils/encode-path-str.js";
-
-// type b2 = ExtractGeneric<_Lists>;
-
-// type ExtractGeneric<T extends _SPCollection> = _Lists extends _SPCollection<infer X> ? X : never;
-
-// // <T extends U, U extends number[]>
-// // ReturnType<Type>
-// // type T3 = ReturnType<<T extends U, U extends number[]>() => T>;
-
-// // _Lists extends _SPCollection<IListInfo[]>
+import { IValidateUpdateListItem } from "../items/types.js";
 
 @defaultPath("lists")
 export class _Lists extends _SPCollection<IListInfo[]> {
@@ -275,50 +266,39 @@ export class _List extends _SPInstance<IListInfo> {
     /**
      * Creates an item using path (in a folder), validates and sets its field values.
      *
-     * @param formValues The fields to change and their new values.
-     * @param decodedUrl Path decoded url; folder's server relative path.
-     * @param bNewDocumentUpdate true if the list item is a document being updated after upload; otherwise false.
-     * @param checkInComment Optional check in comment.
-     * @param additionalProps Optional set of additional properties LeafName new document file name,
+     * @param props The properties to validate and set on the list item. `bNewDocumentUpdate` defaults to false.
+     * `decodedUrl` is the path decoded url (folder's server relative path); `leafName` is an optional file name with
+     * extension; `underlyingObjectType` is an optional object type (0 for file, 1 for folder, 2 for Web).
      */
     public async addValidateUpdateItemUsingPath(
-        formValues: IListItemFormUpdateValue[],
-        decodedUrl: string,
-        bNewDocumentUpdate = false,
-        checkInComment?: string,
-        additionalProps?: {
-            /**
-             * If creating a document or folder, the name
-             */
+        props: IValidateUpdateListItem & {
+            decodedUrl: string;
             leafName?: string;
-            /**
-             * 0: File, 1: Folder, 2: Web
-             */
-            objectType?: 0 | 1 | 2;
-        },
+            underlyingObjectType?: 0 | 1 | 2;
+        }
     ): Promise<IListItemFormUpdateValue[]> {
+
+        const { decodedUrl, leafName, underlyingObjectType, ...validateProps } = props;
+        validateProps.bNewDocumentUpdate ??= false;
 
         const addProps: any = {
             FolderPath: toResourcePath(decodedUrl),
         };
 
-        if (objectDefinedNotNull(additionalProps)) {
-
-            if (additionalProps.leafName) {
-                addProps.LeafName = toResourcePath(additionalProps.leafName);
-            }
-
-            if (additionalProps.objectType) {
-                addProps.UnderlyingObjectType = additionalProps.objectType;
-            }
+        if (leafName) {
+            addProps.LeafName = toResourcePath(leafName);
         }
 
-        return spPost(List(this, "AddValidateUpdateItemUsingPath()"), body({
-            bNewDocumentUpdate,
-            checkInComment,
-            formValues,
+        if (underlyingObjectType) {
+            addProps.UnderlyingObjectType = underlyingObjectType;
+        }
+
+        const postBody = {
             listItemCreateInfo: addProps,
-        }));
+            ...validateProps,
+        };
+
+        return spPost(List(this, "AddValidateUpdateItemUsingPath()"), body(postBody));
     }
 
     /**

--- a/test/sp/items.ts
+++ b/test/sp/items.ts
@@ -152,4 +152,40 @@ describe("Items", function () {
         const item = await list.items.select("Id").top(1)().then(r => r[0]);
         return expect(list.items.getById(item.Id).getWopiFrameUrl()).to.eventually.be.fulfilled;
     }));
+
+    it("validateUpdateListItem", pnpTest("c8e5a1b7-9c3d-4f0e-9b1c-8a2e5c6d8f1e", async function () {
+        const item = await list.items.select("Id").top(1)().then(r => r[0]);
+        const { title } = await this.props({
+            title: `Validated ${getRandomString(4)}`,
+        });
+
+        const itemUpdated =  await list.items.getById(item.Id).validateUpdateListItem({
+            formValues: [{
+                FieldName: "Title",
+                FieldValue: title,
+            }],
+        });
+
+        return expect(itemUpdated[0].FieldValue).to.eq(title);
+
+    }));
+
+    it("validateUpdateListItem - with options", pnpTest("d1c8e5a1-9c3d-4f0e-9b1c-8a2e5c6d8f1e", async function () {
+        const item = await list.items.select("Id").top(1)().then(r => r[0]);
+        const { title } = await this.props({
+            title: `Item ${getRandomString(4)}`,
+        });
+
+        const itemUpdated = await list.items.getById(item.Id).validateUpdateListItem({
+            formValues: [{
+                FieldName: "Title",
+                FieldValue: title,
+            }],
+            bNewDocumentUpdate: true,
+            checkInComment: "Checked in by PnPjs",
+            datesInUTC: true,
+            numberInInvariantCulture: true,
+        });
+        return expect(itemUpdated[0].FieldValue).to.eq(title);
+    }));
 });

--- a/test/sp/lists.ts
+++ b/test/sp/lists.ts
@@ -334,4 +334,24 @@ describe("List", function () {
         const list = this.pnp.sp.web.lists.getById(result.Id);
         return expect(list.delete()).to.eventually.be.fulfilled;
     }));
+
+    it("addValidateUpdateItemUsingPath", pnpTest("a933ef36-2607-4cad-b867-b2fc31a341e6", async function () {
+        const { title, folderName } = await this.props({
+            title: `Item ${getRandomString(4)}`,
+            folderName: `test_${getRandomString(5)}`,
+        });
+
+        const itemUpdated = await list.addValidateUpdateItemUsingPath({
+            formValues:[{
+                FieldName: "Title",
+                FieldValue: title,
+            }],
+            bNewDocumentUpdate: true,
+            decodedUrl: this.pnp.settings.sp.testWebUrl + "/Shared Documents",
+            leafName: folderName,
+            underlyingObjectType: 1,
+        });
+
+        return expect(itemUpdated[0].FieldValue).to.be.eq(title);
+    }));
 });


### PR DESCRIPTION
ValidateUpdateListItem & AddValidateUpdateItemUsingPath were missing params that are available on the SharePoint endpoint. This is a breaking change and put into V5. The props are also now flattened. 

### Category

- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [X] Documentation update?

### Related Issues

fixes #3336 

### What's in this Pull Request?
Updates to docs for new samples
Updates to Tests for new/missing methods
Updating two methods to support new parameters.