### PR TITLE
fix: hardening spfx behavior context lifecycle

### DIFF
--- a/packages/sp/behaviors/spfx.ts
+++ b/packages/sp/behaviors/spfx.ts
@@ -60,6 +60,21 @@ export function SPFx(context: ISPFXContext): TimelinePipe<Queryable> {
 
     SPFxTokenNullOrUndefinedError.check("SPFx", context);
 
+    // Snapshot the context at the time the behavior is applied. During client-side (non-refresh)
+    // navigation SPFx can dispose the pageContext while our closures are still active in memory,
+    context = {
+        pageContext: {
+            web: {
+                absoluteUrl: context.pageContext.web.absoluteUrl,
+            },
+            legacyPageContext: {
+                formDigestValue: context.pageContext.legacyPageContext?.formDigestValue,
+                formDigestTimeoutSeconds: context.pageContext.legacyPageContext?.formDigestTimeoutSeconds,
+            },
+        },
+        aadTokenProviderFactory: context.aadTokenProviderFactory,
+    };
+
     return (instance: Queryable) => {
 
         instance.using(


### PR DESCRIPTION
This is a ***potential*** fix for the pageContext issues that have been reported when using PnPJs and navigation events in SharePoint. I'd like to discuss this further before merging in, but I think we should implement a fix as I don't believe Microsoft will be making any updates (given it's been months since my original ticket was created).

We could potentially push this into V4 as well if we think it makes sense.

Context of the issue is all provided in that SP-Dev-Docs ticket linked below, but essentially, when Microsoft is disposing of objects, they are disposing of pageContext objects before the SPFx Web Parts have been disposed. The SPFx stays in memory and starts throwing errors because the pageContext is no longer there. 

This change creates a copy of the pageContext, so even if the pageContext is destroyed, if the SPFx Behavior is still in memory, it won't surface an error. 

I have implemented a workaround (on ticket #3334) and have been used in Production in our products for about 6 months and the issue hasn't occurred since. 

### Category
- [X] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [ ] Documentation update?

### Related Issues

Fixes #3334 
SP-Dev-Docs https://github.com/SharePoint/sp-dev-docs/issues/10730

### What's in this Pull Request?
Adds some code inside the SPFx behavior to copy the context being passed in to survive SharePoint destroying the pageContext on navigation events.
