### PR TITLE
docs: target PRs at version-4 branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
-## Contributing Guidance - v3
+## Contributing Guidance - v4
 
-* Target your pull requests to the **version-3** branch
+* Target your pull requests to the **version-4** branch
 * Add/Update any docs articles related to your changes
 * Include a test for any new functionality and ensure all existing tests are passing by running `npm test`
   * If you are fixing a bug, include a test that would have caught the bug you are fixing
-* Ensure tslint checks pass by typing `npm run lint`
+* Ensure lint checks pass by typing `npm run lint`
 * Keep your PRs as simple as possible and describe the changes to help the reviewer understand your work
 * If you have an idea for a larger change to the library please [open an issue](https://github.com/pnp/pnpjs/issues) and let's discuss before you invest many hours - these are very welcome but want to ensure it is something we can merge before you spend the time :)

--- a/docs/concepts/nightly-builds.md
+++ b/docs/concepts/nightly-builds.md
@@ -1,6 +1,6 @@
 # Nightly Builds
 
-Starting with version 3 we support nightly builds, which are built from the version-3 branch each evening and include all the changes merged ahead of a particular build. These are a great way to try out new features before a release, or get a fix or enhancement without waiting for the monthly builds.
+Starting with version 3 we support nightly builds, which are built from the current development branch (currently `version-4`) each evening and include all the changes merged ahead of a particular build. These are a great way to try out new features before a release, or get a fix or enhancement without waiting for the monthly builds.
 
 You can install the nightly builds using the below examples. While we only show examples for `sp` and `graph` nightly builds are available for all packages.
 

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -2,7 +2,7 @@
 
 Pull requests may be large or small - adding whole new features or fixing some misspellings. Regardless, they are all appreciated and help improve the library for everyone! By following the below guidelines we'll have an easier time merging your work and getting it into the next release.
 
-* Target your pull requests to the **version-3** branch
+* Target your pull requests to the **version-4** branch
 * Add/Update any relevant docs articles in the relevant package's docs folder related to your changes
 * Include a test for any new functionality and ensure all existing tests are passing by running `npm test`
 * Ensure linting checks pass by typing `npm run lint`


### PR DESCRIPTION
## Summary
Contributing docs on the default `version-4` branch still tell contributors to target `version-3` and mention `tslint`. This updates CONTRIBUTING and related docs pages so the PR target matches the active development branch.

## Changes
- `CONTRIBUTING.md`: v3 → v4 guidance; `npm run lint`
- `docs/contributing/pull-requests.md`: same PR target correction
- `docs/concepts/nightly-builds.md`: clarify nightly builds come from the current development branch (`version-4`)

## Test plan
- [ ] Skim CONTRIBUTING + linked docs pages for consistency
- [ ] Confirm default branch remains `version-4`

Docs-only; no runtime/M365 tenant required.
