### PR TITLE
Microsoft Graph November deprecations

### DIFF
--- a/docs/graph/files.md
+++ b/docs/graph/files.md
@@ -92,6 +92,8 @@ const list = await graph.sites.getById("{site identifier}").getById({drive id}).
 
 ## Get the recent files
 
+> ⚠️ **Deprecated**: The `recent` API will operate in a degraded state until November 2026, after which it stops returning data.
+
 Using the recent() you get the recent files
 
 ```TypeScript
@@ -108,6 +110,8 @@ const files = await graph.me.drives.getById({drive id}).recent();
 ```
 
 ## Get the files shared with me
+
+> ⚠️ **Deprecated**: The `sharedWithMe` API will operate in a degraded state until November 2026, after which it stops returning data.
 
 Using the sharedWithMe() you get the files shared with the user
 

--- a/docs/graph/insights.md
+++ b/docs/graph/insights.md
@@ -61,6 +61,8 @@ const resource = await graph.users.getById("userId").insights.trending.getById('
 
 ### Get all Used documents
 
+> ⚠️ **Deprecated**: The `used` API will operate in a degraded state until November 2026, after which it stops returning data.
+
 Returns documents viewed and modified by a user. Includes documents the user used in OneDrive for Business, SharePoint, opened as email attachments, and as link attachments from sources like Box, DropBox and Google Drive.
 
 ```TypeScript
@@ -108,6 +110,8 @@ const resource = await graph.users.getById("userId").insights.used.getById('Id')
 ```
 
 ### Get all Shared documents
+
+> ⚠️ **Deprecated**: The `shared` API will operate in a degraded state until November 2026, after which it stops returning data.
 
 Returns documents shared with a user. Documents can be shared as email attachments or as OneDrive for Business links sent in emails.
 

--- a/packages/graph/files/types.ts
+++ b/packages/graph/files/types.ts
@@ -49,6 +49,7 @@ export class _Drive extends _GraphInstance<IDriveType> {
     /**
      * Method for retrieving recently accessed drive items by the user.
      * @returns IDriveItems
+     * @deprecated The recent API is deprecated and will operate in a degraded state until November, 2026, after which it stops returning data.
      */
     public get recent(): IDriveItems {
         return DriveItems(this, "recent");
@@ -58,6 +59,7 @@ export class _Drive extends _GraphInstance<IDriveType> {
      * Method for retrieving drive items shared with the user.
      * @param options - ISharingWithMeOptions (Optional)
      * @returns IDriveItems
+     * @deprecated The sharedWithMe API is deprecated and will operate in a degraded state until November, 2026, after which it stops returning data.
      */
     public async sharedWithMe(options: ISharingWithMeOptions = null): Promise<IDriveItems> {
         const q = DriveItems(this, "sharedWithMe");

--- a/packages/graph/insights/types.ts
+++ b/packages/graph/insights/types.ts
@@ -21,11 +21,15 @@ export class _Insights extends _GraphInstance<IOfficeGraphInsightsType> {
     public get trending(): ITrendingInsights {
         return TrendingInsights(this);
     }
-
+    /**
+     *  @deprecated The insights used API is deprecated and will operate in a degraded state until November, 2026, after which it stops returning data.
+     */
     public get used(): IUsedInsights {
         return UsedInsights(this);
     }
-
+    /**
+     * @deprecated The insights shared API is deprecated and will operate in a degraded state until November, 2026, after which it stops returning data.
+     */
     public get shared(): ISharedInsights {
         return SharedInsights(this);
     }


### PR DESCRIPTION
### Category

- [ ] Bug fix?
- [ ] New feature?
- [ ] New sample?
- [X] Documentation update?

### What's in this Pull Request?

Adds 4 deprecation warnings for the following Microsoft Graph deprecations, and updates the documentation to include the deprecation warnings

https://learn.microsoft.com/en-us/graph/api/drive-sharedwithme?view=graph-rest-1.0&tabs=http
https://learn.microsoft.com/en-us/graph/api/drive-recent?view=graph-rest-1.0&tabs=http
https://learn.microsoft.com/en-us/graph/api/insights-list-shared?view=graph-rest-1.0&tabs=http
https://learn.microsoft.com/en-us/graph/api/insights-list-used?view=graph-rest-1.0&tabs=http

